### PR TITLE
Add shouldEqualTo and shouldNotEqualTo assertions with compile check on basic types

### DIFF
--- a/src/main/kotlin/org/amshove/kluent/Assertions.kt
+++ b/src/main/kotlin/org/amshove/kluent/Assertions.kt
@@ -1,3 +1,5 @@
+@file:Suppress("FINAL_UPPER_BOUND")
+
 package org.amshove.kluent
 
 import kotlin.reflect.KClass
@@ -5,6 +7,15 @@ import kotlin.reflect.KClass
 
 infix fun Any?.shouldEqual(theOther: Any?) = this `should equal` theOther
 infix fun Any?.shouldNotEqual(theOther: Any?) = this `should not equal` theOther
+
+infix fun <T : Boolean> T?.shouldEqualTo(theOther: T?) = this `should equal to` theOther
+infix fun <T : Byte> T?.shouldEqualTo(theOther: T?) = this `should equal to` theOther
+infix fun <T : Short> T?.shouldEqualTo(theOther: T?) = this `should equal to` theOther
+infix fun <T : Int> T?.shouldEqualTo(theOther: T?) = this `should equal to` theOther
+infix fun <T : Long> T?.shouldEqualTo(theOther: T?) = this `should equal to` theOther
+infix fun <T : Float> T?.shouldEqualTo(theOther: T?) = this `should equal to` theOther
+infix fun <T : Double> T?.shouldEqualTo(theOther: T?) = this `should equal to` theOther
+infix fun <T : String> T?.shouldEqualTo(theOther: T?) = this `should equal to` theOther
 
 infix fun <T> Array<T>?.shouldEqual(theOther: Array<T>?) = this `should equal` theOther
 infix fun <T> Iterable<T>?.shouldEqual(theOther: Iterable<T>?) = this `should equal` theOther

--- a/src/main/kotlin/org/amshove/kluent/Assertions.kt
+++ b/src/main/kotlin/org/amshove/kluent/Assertions.kt
@@ -17,6 +17,15 @@ infix fun <T : Float> T?.shouldEqualTo(theOther: T?) = this `should equal to` th
 infix fun <T : Double> T?.shouldEqualTo(theOther: T?) = this `should equal to` theOther
 infix fun <T : String> T?.shouldEqualTo(theOther: T?) = this `should equal to` theOther
 
+infix fun <T : Boolean> T?.shouldNotEqualTo(theOther: T?) = this `should not equal to` theOther
+infix fun <T : Byte> T?.shouldNotEqualTo(theOther: T?) = this `should not equal to` theOther
+infix fun <T : Short> T?.shouldNotEqualTo(theOther: T?) = this `should not equal to` theOther
+infix fun <T : Int> T?.shouldNotEqualTo(theOther: T?) = this `should not equal to` theOther
+infix fun <T : Long> T?.shouldNotEqualTo(theOther: T?) = this `should not equal to` theOther
+infix fun <T : Float> T?.shouldNotEqualTo(theOther: T?) = this `should not equal to` theOther
+infix fun <T : Double> T?.shouldNotEqualTo(theOther: T?) = this `should not equal to` theOther
+infix fun <T : String> T?.shouldNotEqualTo(theOther: T?) = this `should not equal to` theOther
+
 infix fun <T> Array<T>?.shouldEqual(theOther: Array<T>?) = this `should equal` theOther
 infix fun <T> Iterable<T>?.shouldEqual(theOther: Iterable<T>?) = this `should equal` theOther
 

--- a/src/main/kotlin/org/amshove/kluent/BacktickAssertions.kt
+++ b/src/main/kotlin/org/amshove/kluent/BacktickAssertions.kt
@@ -1,3 +1,5 @@
+@file:Suppress("FINAL_UPPER_BOUND")
+
 package org.amshove.kluent
 
 import org.junit.Assert.*
@@ -6,6 +8,15 @@ import kotlin.reflect.KClass
 
 infix fun Any?.`should equal`(theOther: Any?) = assertEquals(theOther, this)
 infix fun Any?.`should not equal`(theOther: Any?) = assertNotEquals(theOther, this)
+
+infix fun <T : Boolean> T?.`should equal to`(theOther: T?) = assertEquals(theOther, this)
+infix fun <T : Byte> T?.`should equal to`(theOther: T?) = assertEquals(theOther, this)
+infix fun <T : Short> T?.`should equal to`(theOther: T?) = assertEquals(theOther, this)
+infix fun <T : Int> T?.`should equal to`(theOther: T?) = assertEquals(theOther, this)
+infix fun <T : Long> T?.`should equal to`(theOther: T?) = assertEquals(theOther, this)
+infix fun <T : Float> T?.`should equal to`(theOther: T?) = assertEquals(theOther, this)
+infix fun <T : Double> T?.`should equal to`(theOther: T?) = assertEquals(theOther, this)
+infix fun <T : String> T?.`should equal to`(theOther: T?) = assertEquals(theOther, this)
 
 infix fun <T> Array<T>?.`should equal`(theOther: Array<T>?) = assertArrayEquals(theOther, this)
 infix fun <T> Iterable<T>?.`should equal`(theOther: Iterable<T>?) = assertEquals(theOther, this)

--- a/src/main/kotlin/org/amshove/kluent/BacktickAssertions.kt
+++ b/src/main/kotlin/org/amshove/kluent/BacktickAssertions.kt
@@ -18,6 +18,15 @@ infix fun <T : Float> T?.`should equal to`(theOther: T?) = assertEquals(theOther
 infix fun <T : Double> T?.`should equal to`(theOther: T?) = assertEquals(theOther, this)
 infix fun <T : String> T?.`should equal to`(theOther: T?) = assertEquals(theOther, this)
 
+infix fun <T : Boolean> T?.`should not equal to`(theOther: T?) = assertNotEquals(theOther, this)
+infix fun <T : Byte> T?.`should not equal to`(theOther: T?) = assertNotEquals(theOther, this)
+infix fun <T : Short> T?.`should not equal to`(theOther: T?) = assertNotEquals(theOther, this)
+infix fun <T : Int> T?.`should not equal to`(theOther: T?) = assertNotEquals(theOther, this)
+infix fun <T : Long> T?.`should not equal to`(theOther: T?) = assertNotEquals(theOther, this)
+infix fun <T : Float> T?.`should not equal to`(theOther: T?) = assertNotEquals(theOther, this)
+infix fun <T : Double> T?.`should not equal to`(theOther: T?) = assertNotEquals(theOther, this)
+infix fun <T : String> T?.`should not equal to`(theOther: T?) = assertNotEquals(theOther, this)
+
 infix fun <T> Array<T>?.`should equal`(theOther: Array<T>?) = assertArrayEquals(theOther, this)
 infix fun <T> Iterable<T>?.`should equal`(theOther: Iterable<T>?) = assertEquals(theOther, this)
 

--- a/src/test/kotlin/org/amshove/kluent/tests/backtickassertions/ShouldEqualToTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/backtickassertions/ShouldEqualToTests.kt
@@ -1,0 +1,94 @@
+package org.amshove.kluent.tests.backtickassertions
+
+import org.amshove.kluent.`should equal to`
+import org.jetbrains.spek.api.Spek
+import kotlin.test.assertFails
+
+class ShouldEqualToTests : Spek() {
+    init {
+        given("the should equal to method") {
+            on("checking two equal boolean") {
+                it("should pass") {
+                    true `should equal to` true
+                }
+            }
+            on("checking two different boolean") {
+                it("should fail") {
+                    assertFails { true `should equal to` false }
+                }
+            }
+            on("checking two equal byte") {
+                it("should pass") {
+                    5.toByte() `should equal to` 5.toByte()
+                }
+            }
+            on("checking two different byte") {
+                it("should fail") {
+                    assertFails {
+                        5.toByte() `should equal to` 20.toByte()
+                    }
+                }
+            }
+            on("checking two equal short") {
+                it("should pass") {
+                    5.toShort() `should equal to` 5.toShort()
+                }
+            }
+            on("checking two different short") {
+                it("should fail") {
+                    assertFails { 5.toShort() `should equal to` 20.toShort() }
+                }
+            }
+            on("checking two equal int") {
+                it("should pass") {
+                    5 `should equal to` 5
+                }
+            }
+            on("checking two different int") {
+                it("should fail") {
+                    assertFails { 5 `should equal to` 20 }
+                }
+            }
+            on("checking two equal long") {
+                it("should pass") {
+                    5L `should equal to` 5L
+                }
+            }
+            on("checking two different long") {
+                it("should fail") {
+                    assertFails { 5L `should equal to` 20L }
+                }
+            }
+            on("checking two equal float") {
+                it("should pass") {
+                    5F `should equal to` 5F
+                }
+            }
+            on("checking two different float") {
+                it("should fail") {
+                    assertFails { 5F `should equal to` 20F }
+                }
+            }
+            on("checking two equal double") {
+                it("should pass") {
+                    5.0 `should equal to` 5.0
+                }
+            }
+            on("checking two different double") {
+                it("should fail") {
+                    assertFails { 5.0 `should equal to` 20.0 }
+                }
+            }
+            on("checking two equal string") {
+                it("should pass") {
+                    "hello world" `should equal to` "hello world"
+                }
+            }
+            on("checking two different string") {
+                it("should fail") {
+                    assertFails { "hello world" `should equal to` "hello" }
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/org/amshove/kluent/tests/backtickassertions/ShouldNotEqualToTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/backtickassertions/ShouldNotEqualToTests.kt
@@ -1,0 +1,92 @@
+package org.amshove.kluent.tests.backtickassertions
+
+import org.amshove.kluent.`should not equal to`
+import org.jetbrains.spek.api.Spek
+import kotlin.test.assertFails
+
+class ShouldNotEqualToTests : Spek() {
+    init {
+        given("the should not equal to method") {
+            on("checking two equal boolean") {
+                it("should pass") {
+                    true `should not equal to` false
+                }
+            }
+            on("checking two different boolean") {
+                it("should fail") {
+                    assertFails { true `should not equal to` true }
+                }
+            }
+            on("checking two equal byte") {
+                it("should pass") {
+                    5.toByte() `should not equal to` 20.toByte()
+                }
+            }
+            on("checking two different byte") {
+                it("should fail") {
+                    assertFails { 5.toByte() `should not equal to` 5.toByte() }
+                }
+            }
+            on("checking two equal short") {
+                it("should pass") {
+                    5.toShort() `should not equal to` 20.toShort()
+                }
+            }
+            on("checking two different short") {
+                it("should fail") {
+                    assertFails { 5.toShort() `should not equal to` 5.toShort() }
+                }
+            }
+            on("checking two equal int") {
+                it("should pass") {
+                    5 `should not equal to` 20
+                }
+            }
+            on("checking two different int") {
+                it("should fail") {
+                    assertFails { 5 `should not equal to` 5 }
+                }
+            }
+            on("checking two equal long") {
+                it("should pass") {
+                    5L `should not equal to` 20L
+                }
+            }
+            on("checking two different long") {
+                it("should fail") {
+                    assertFails { 5L `should not equal to` 5L }
+                }
+            }
+            on("checking two equal float") {
+                it("should pass") {
+                    5F `should not equal to` 20F
+                }
+            }
+            on("checking two different float") {
+                it("should fail") {
+                    assertFails { 5F `should not equal to` 5F }
+                }
+            }
+            on("checking two equal double") {
+                it("should pass") {
+                    5.0 `should not equal to` 20.0
+                }
+            }
+            on("checking two different double") {
+                it("should fail") {
+                    assertFails { 5.0 `should not equal to` 5.0 }
+                }
+            }
+            on("checking two equal string") {
+                it("should pass") {
+                    "hello world" `should not equal to` "hello"
+                }
+            }
+            on("checking two different string") {
+                it("should fail") {
+                    assertFails { "hello world" `should not equal to` "hello world" }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add `shouldEqualTo` and `shouldNotEqualTo` assertions with compile time checks on :
- `Boolean`
- `Byte`
- `Short`
- `Int`
- `Long`
- `Float`
- `Double`
- `String`

```kotlin
"hello world" `should equal to` "hello world"  // OK
"hello world" `should equal to` 5              // Compile error
```