### PR TITLE
Generalize functions

### DIFF
--- a/src/main/kotlin/org/amshove/kluent/Assertions.kt
+++ b/src/main/kotlin/org/amshove/kluent/Assertions.kt
@@ -44,11 +44,11 @@ infix fun <T> Any?.shouldNotBeIn(array: Array<T>) = this `should not be in` arra
 infix fun <T> Any?.shouldBeIn(iterable: Iterable<T>) = this `should be in` iterable
 infix fun <T> Any?.shouldNotBeIn(iterable: Iterable<T>) = this `should not be in` iterable
 
-infix fun <T: Exception> (() -> Unit).shouldThrow(expectedException: KClass<T>) = this `should throw` expectedException
-infix fun <T: Exception> (() -> Unit).shouldNotThrow(expectedException: KClass<T>) = this `should not throw` expectedException
+infix fun <T: Exception> (() -> Any).shouldThrow(expectedException: KClass<T>) = this `should throw` expectedException
+infix fun <T: Exception> (() -> Any).shouldNotThrow(expectedException: KClass<T>) = this `should not throw` expectedException
 
-infix fun <T: Exception> (() -> Unit).shouldThrowTheException(expectedException: KClass<T>) : ExceptionResult = this `should throw the Exception` expectedException
-infix fun <T: Exception> (() -> Unit).shouldNotThrowTheException(expectedException: KClass<T>) : NotThrowExceptionResult = this `should not throw the Exception` expectedException
+infix fun <T: Exception> (() -> Any).shouldThrowTheException(expectedException: KClass<T>) : ExceptionResult = this `should throw the Exception` expectedException
+infix fun <T: Exception> (() -> Any).shouldNotThrowTheException(expectedException: KClass<T>) : NotThrowExceptionResult = this `should not throw the Exception` expectedException
 
 infix fun ExceptionResult.withMessage(theMessage: String) = this `with message` theMessage
 infix fun NotThrowExceptionResult.withMessage(theMessage: String) = this `with message` theMessage

--- a/src/main/kotlin/org/amshove/kluent/BacktickAssertions.kt
+++ b/src/main/kotlin/org/amshove/kluent/BacktickAssertions.kt
@@ -45,7 +45,7 @@ infix fun <T> Any?.`should not be in`(array: Array<T>) = if (!array.contains(thi
 infix fun <T> Any?.`should be in`(iterable: Iterable<T>) = if (iterable.contains(this)) Unit else fail("$this should be in $iterable", "$this", "${join(iterable)}")
 infix fun <T> Any?.`should not be in`(iterable: Iterable<T>) = if (!iterable.contains(this)) Unit else fail("$this should not be in $iterable", "$this", "${join(iterable)}")
 
-infix fun <T : Exception> (() -> Unit).`should throw`(expectedException: KClass<T>) {
+infix fun <T : Exception> (() -> Any).`should throw`(expectedException: KClass<T>) {
     try {
         this.invoke()
         fail("There was an Exception expected to be thrown, but nothing was thrown", "$expectedException", "None")
@@ -59,7 +59,7 @@ infix fun <T : Exception> (() -> Unit).`should throw`(expectedException: KClass<
     }
 }
 
-infix fun <T : Exception> (() -> Unit).`should throw the Exception`(expectedException: KClass<T>): ExceptionResult {
+infix fun <T : Exception> (() -> Any).`should throw the Exception`(expectedException: KClass<T>): ExceptionResult {
     try {
         this.invoke()
         fail("There was an Exception expected to be thrown, but nothing was thrown", "$expectedException", "None")
@@ -70,7 +70,7 @@ infix fun <T : Exception> (() -> Unit).`should throw the Exception`(expectedExce
     }
 }
 
-infix fun <T : Exception> (() -> Unit).`should not throw`(expectedException: KClass<T>) {
+infix fun <T : Exception> (() -> Any).`should not throw`(expectedException: KClass<T>) {
     try {
         this.invoke()
     } catch (e: Exception) {
@@ -83,7 +83,7 @@ infix fun <T : Exception> (() -> Unit).`should not throw`(expectedException: KCl
     }
 }
 
-infix fun <T : Exception> (() -> Unit).`should not throw the Exception`(expectedException: KClass<T>): NotThrowExceptionResult {
+infix fun <T : Exception> (() -> Any).`should not throw the Exception`(expectedException: KClass<T>): NotThrowExceptionResult {
     try {
         this.invoke()
         return NotThrowExceptionResult(noException)

--- a/src/test/kotlin/org/amshove/kluent/tests/assertions/ShouldThrowTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/assertions/ShouldThrowTests.kt
@@ -2,6 +2,7 @@ package org.amshove.kluent.tests.assertions
 
 import org.amshove.kluent.shouldThrow
 import org.jetbrains.spek.api.Spek
+import java.util.*
 import kotlin.test.assertFails
 
 class ShouldThrowTests: Spek({
@@ -16,6 +17,13 @@ class ShouldThrowTests: Spek({
             it("should fail") {
                 val func = { throw IndexOutOfBoundsException() }
                 assertFails({ func shouldThrow IllegalArgumentException::class })
+            }
+        }
+
+        on("trying to get an out of indexed item in an empty list") {
+            val funcWithReturn = { ArrayList<String>().get(-1) }
+            it("should pass a failing test") {
+                funcWithReturn shouldThrow ArrayIndexOutOfBoundsException::class
             }
         }
     }


### PR DESCRIPTION
calling
`{ ArrayList<String>().get(-1) } shouldThrow ArrayIndexOutOfBoundsException::class`
actually using
`{ ArrayList<String>().get(-1) } as () -> Unit shouldThrow ArrayIndexOutOfBoundsException::class`
this evolution allow to write this code :
`{ ArrayList<String>().get(-1) } shouldThrow ArrayIndexOutOfBoundsException::class`