### PR TITLE
Added Map. shouldHaveKey  and shouldNotHaveKey functions 

### DIFF
--- a/src/main/kotlin/org/amshove/kluent/Assertions.kt
+++ b/src/main/kotlin/org/amshove/kluent/Assertions.kt
@@ -38,17 +38,20 @@ infix fun <T> Array<T>.shouldNotContain(theThing: T) = this `should not contain`
 infix fun <T> Iterable<T>.shouldContain(theThing: T) = this `should contain` theThing
 infix fun <T> Iterable<T>.shouldNotContain(theThing: T) = this `should not contain` theThing
 
+infix fun <R, T> Map<R, T>.shouldHaveKey(theKey: R) = this `should have key` theKey
+infix fun <R, T> Map<R, T>.shouldNotHaveKey(theKey: R) = this `should not have key` theKey
+
 infix fun <T> Any?.shouldBeIn(array: Array<T>) = this `should be in` array
 infix fun <T> Any?.shouldNotBeIn(array: Array<T>) = this `should not be in` array
 
 infix fun <T> Any?.shouldBeIn(iterable: Iterable<T>) = this `should be in` iterable
 infix fun <T> Any?.shouldNotBeIn(iterable: Iterable<T>) = this `should not be in` iterable
 
-infix fun <T: Exception> (() -> Any).shouldThrow(expectedException: KClass<T>) = this `should throw` expectedException
-infix fun <T: Exception> (() -> Any).shouldNotThrow(expectedException: KClass<T>) = this `should not throw` expectedException
+infix fun <T : Exception> (() -> Any).shouldThrow(expectedException: KClass<T>) = this `should throw` expectedException
+infix fun <T : Exception> (() -> Any).shouldNotThrow(expectedException: KClass<T>) = this `should not throw` expectedException
 
-infix fun <T: Exception> (() -> Any).shouldThrowTheException(expectedException: KClass<T>) : ExceptionResult = this `should throw the Exception` expectedException
-infix fun <T: Exception> (() -> Any).shouldNotThrowTheException(expectedException: KClass<T>) : NotThrowExceptionResult = this `should not throw the Exception` expectedException
+infix fun <T : Exception> (() -> Any).shouldThrowTheException(expectedException: KClass<T>): ExceptionResult = this `should throw the Exception` expectedException
+infix fun <T : Exception> (() -> Any).shouldNotThrowTheException(expectedException: KClass<T>): NotThrowExceptionResult = this `should not throw the Exception` expectedException
 
 infix fun ExceptionResult.withMessage(theMessage: String) = this `with message` theMessage
 infix fun NotThrowExceptionResult.withMessage(theMessage: String) = this `with message` theMessage

--- a/src/main/kotlin/org/amshove/kluent/BacktickAssertions.kt
+++ b/src/main/kotlin/org/amshove/kluent/BacktickAssertions.kt
@@ -39,6 +39,9 @@ infix fun <T> Array<T>.`should not contain`(theThing: T) = if (!this.contains(th
 infix fun <T> Iterable<T>.`should contain`(theThing: T) = if (this.contains(theThing)) Unit else fail("$this should contain $theThing", "$theThing", "${join(this)}")
 infix fun <T> Iterable<T>.`should not contain`(theThing: T) = if (!this.contains(theThing)) Unit else fail("$this should not contain $theThing", "$theThing", "${join(this)}")
 
+infix fun <R, T> Map<R, T>.`should have key`(theKey: R) = if (this.containsKey(theKey)) Unit else fail("$this should contain $theKey", "$theKey", join(this.keys))
+infix fun <R, T> Map<R, T>.`should not have key`(theKey: R) = if (!this.containsKey(theKey)) Unit else fail("$this should not contain $theKey", "$theKey", join(this.keys))
+
 infix fun <T> Any?.`should be in`(array: Array<T>) = if (array.contains(this)) Unit else fail("$this should be in $array", "$this", "${join(array)}")
 infix fun <T> Any?.`should not be in`(array: Array<T>) = if (!array.contains(this)) Unit else fail("$this should not be in $array", "$this", "${join(array)}")
 

--- a/src/test/kotlin/org/amshove/kluent/tests/assertions/ShouldHaveKeyTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/assertions/ShouldHaveKeyTests.kt
@@ -1,0 +1,54 @@
+package org.amshove.kluent.tests.assertions
+
+import org.amshove.kluent.shouldHaveKey
+import org.amshove.kluent.tests.getFailure
+import org.amshove.kluent.tests.helpclasses.Person
+import org.jetbrains.spek.api.Spek
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+
+/**
+ * Created by Av on 11/15/2016.
+ */
+class ShouldHaveKeyTests : Spek({
+    given("the should have key method") {
+        on("checking a Map with the key") {
+            val map = mapOf("First" to "valueIchi", "Second" to "valueNi")
+            it("should pass") {
+                map shouldHaveKey "First"
+            }
+        }
+        on("checking a Map without the key") {
+            val map = mapOf(1 to "first", 2 to "second")
+            it("should fail") {
+                assertFails { map shouldHaveKey 3 }
+            }
+            it("should format the keys") {
+                val theFailure = getFailure { map shouldHaveKey 3 }
+                assertEquals("1, 2", theFailure.actual)
+            }
+        }
+        on("checking any Map for an object as key") {
+            val alice = Person("Alice", "Green")
+            val bob = Person("Bob", "Blue")
+            val jon = Person("Jon", "Grey")
+            val map = mapOf(alice to bob, bob to jon)
+            it("should pass") {
+                map shouldHaveKey alice
+            }
+        }
+        on("checking any Map for an object which isn't contained") {
+            val alice = Person("Alice", "Green")
+            val bob = Person("Bob", "Blue")
+            val jon = Person("Jon", "Grey")
+            val map = mapOf(alice to bob)
+            it("should fail") {
+                assertFails { map shouldHaveKey jon }
+            }
+            it("should format the output") {
+                val failure = getFailure { map shouldHaveKey jon }
+                assertEquals("Person(name=Alice, surname=Green)", failure.actual)
+            }
+        }
+    }
+})

--- a/src/test/kotlin/org/amshove/kluent/tests/assertions/ShouldNotHaveKeyTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/assertions/ShouldNotHaveKeyTests.kt
@@ -1,0 +1,54 @@
+package org.amshove.kluent.tests.assertions
+
+import org.amshove.kluent.shouldNotHaveKey
+import org.amshove.kluent.tests.getFailure
+import org.amshove.kluent.tests.helpclasses.Person
+import org.jetbrains.spek.api.Spek
+import org.junit.Assert.assertEquals
+import kotlin.test.assertFails
+
+/**
+ * Created by Av on 11/15/2016.
+ */
+class ShouldNotHaveKeyTests : Spek({
+    given("the should not have key method") {
+        on("checking a Map with the key") {
+            val map = mapOf("First" to "valueIchi", "Second" to "valueNi")
+            it("should fail") {
+                assertFails { map shouldNotHaveKey "First" }
+            }
+        }
+        on("checking a Map without the key") {
+            val map = mapOf(1 to "first", 2 to "second")
+            it("should pass") {
+                map shouldNotHaveKey 3
+            }
+            it("should format the keys") {
+                val theFailure = getFailure { map shouldNotHaveKey 2 }
+                assertEquals("1, 2", theFailure.actual)
+            }
+        }
+        on("checking any Map for an object as key") {
+            val alice = Person("Alice", "Green")
+            val bob = Person("Bob", "Blue")
+            val jon = Person("Jon", "Grey")
+            val map = mapOf(alice to bob, bob to jon)
+            it("should fail") {
+                assertFails { map shouldNotHaveKey alice }
+            }
+        }
+        on("checking any Map for an object which isn't contained") {
+            val alice = Person("Alice", "Green")
+            val bob = Person("Bob", "Blue")
+            val jon = Person("Jon", "Grey")
+            val map = mapOf(alice to bob)
+            it("should pass") {
+                map shouldNotHaveKey jon
+            }
+            it("should format the output") {
+                val failure = getFailure { map shouldNotHaveKey alice }
+                assertEquals("Person(name=Alice, surname=Green)", failure.actual)
+            }
+        }
+    }
+})

--- a/src/test/kotlin/org/amshove/kluent/tests/backtickassertions/ShouldHaveKeyTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/backtickassertions/ShouldHaveKeyTests.kt
@@ -1,0 +1,54 @@
+package org.amshove.kluent.tests.backtickassertions
+
+import org.amshove.kluent.`should have key`
+import org.amshove.kluent.tests.getFailure
+import org.amshove.kluent.tests.helpclasses.Person
+import org.jetbrains.spek.api.Spek
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+
+/**
+ * Created by Av on 11/15/2016.
+ */
+class ShouldHaveKeyTests : Spek({
+    given("the should have key method") {
+        on("checking a Map with the key") {
+            val map = mapOf("First" to "valueIchi", "Second" to "valueNi")
+            it("should pass") {
+                map `should have key` "First"
+            }
+        }
+        on("checking a Map without the key") {
+            val map = mapOf(1 to "first", 2 to "second")
+            it("should fail") {
+                assertFails { map `should have key` 3 }
+            }
+            it("should format the keys") {
+                val theFailure = getFailure { map `should have key` 3 }
+                assertEquals("1, 2", theFailure.actual)
+            }
+        }
+        on("checking any Map for an object as key") {
+            val alice = Person("Alice", "Green")
+            val bob = Person("Bob", "Blue")
+            val jon = Person("Jon", "Grey")
+            val map = mapOf(alice to bob, bob to jon)
+            it("should pass") {
+                map `should have key` alice
+            }
+        }
+        on("checking any Map for an object which isn't contained") {
+            val alice = Person("Alice", "Green")
+            val bob = Person("Bob", "Blue")
+            val jon = Person("Jon", "Grey")
+            val map = mapOf(alice to bob)
+            it("should fail") {
+                assertFails { map `should have key` jon }
+            }
+            it("should format the output") {
+                val failure = getFailure { map `should have key` jon }
+                assertEquals("Person(name=Alice, surname=Green)", failure.actual)
+            }
+        }
+    }
+})

--- a/src/test/kotlin/org/amshove/kluent/tests/backtickassertions/ShouldNotHaveKeyTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/backtickassertions/ShouldNotHaveKeyTests.kt
@@ -1,0 +1,56 @@
+package org.amshove.kluent.tests.backtickassertions
+
+import junit.framework.Assert.assertEquals
+import org.amshove.kluent.`should not have key`
+import org.amshove.kluent.tests.getFailure
+import org.amshove.kluent.tests.helpclasses.Person
+import org.jetbrains.spek.api.Spek
+import kotlin.test.assertFails
+
+/**
+ * Created by Av on 11/15/2016.
+ */
+class ShouldNotHaveKeyTests : Spek({
+    given("the should not have key method") {
+        on("checking a Map with the key") {
+            val map = mapOf("First" to "valueIchi", "Second" to "valueNi")
+            it("should fail") {
+                assertFails { map `should not have key` "First" }
+            }
+        }
+        on("checking a Map without the key") {
+            val map = mapOf(1 to "first", 2 to "second")
+            it("should pass") {
+                map `should not have key` 3
+            }
+            it("should format the keys") {
+                val theFailure = getFailure { map `should not have key` 2 }
+                assertEquals("1, 2", theFailure.actual)
+            }
+        }
+        on("checking any Map for an object as key") {
+            val alice = Person("Alice", "Green")
+            val bob = Person("Bob", "Blue")
+            val jon = Person("Jon", "Grey")
+            val map = mapOf(alice to bob, bob to jon)
+            it("should fail") {
+                assertFails { map `should not have key` alice }
+            }
+        }
+        on("checking any Map for an object which isn't contained") {
+            val alice = Person("Alice", "Green")
+            val bob = Person("Bob", "Blue")
+            val jon = Person("Jon", "Grey")
+            val map = mapOf(alice to bob)
+            it("should pass") {
+                map `should not have key` jon
+            }
+            it("should format the output") {
+                val failure = getFailure { map `should not have key` alice }
+                assertEquals("Person(name=Alice, surname=Green)", failure.actual)
+            }
+        }
+    }
+
+
+})


### PR DESCRIPTION
To check whether a Map contains a key

for example one might use it like this:

`val map = mapOf("First" to "valueIchi", "Second" to "valueNi")`
                `map shouldHaveKey "First"`

I think your project is great!

I just miss some extensions for Maps. 

I also frequently use an extension that checks whether a Map contains a value. If you think this makes sense, I could also add that. 