### PR TITLE
Added ShouldBeInstanceOf and ShouldNotBeInstanceOf

### DIFF
--- a/src/main/kotlin/org/amshove/kluent/Assertions.kt
+++ b/src/main/kotlin/org/amshove/kluent/Assertions.kt
@@ -48,6 +48,9 @@ infix fun <T> Array<T>.shouldNotContain(theThing: T) = this `should not contain`
 infix fun <T> Iterable<T>.shouldContain(theThing: T) = this `should contain` theThing
 infix fun <T> Iterable<T>.shouldNotContain(theThing: T) = this `should not contain` theThing
 
+infix fun Any?.shouldBeInstanceOf(className: Class<*>) = this `should be instance of` className
+infix fun Any?.shouldNotBeInstanceOf(className: Class<*>) = this `should not be instance of` className
+
 /*
 Map
  */

--- a/src/main/kotlin/org/amshove/kluent/BacktickAssertions.kt
+++ b/src/main/kotlin/org/amshove/kluent/BacktickAssertions.kt
@@ -43,6 +43,9 @@ infix fun <T> Iterable<T>?.`should equal`(theOther: Iterable<T>?) = assertEquals
 infix fun Any?.`should be`(theOther: Any?) = assertSame(theOther, this)
 infix fun Any?.`should not be`(theOther: Any?) = assertNotSame(theOther, this)
 
+infix fun Any?.`should be instance of`(className: Class<*>) = assertTrue(className.isInstance(this))
+infix fun Any?.`should not be instance of`(className: Class<*>) = assertFalse(className.isInstance(this))
+
 infix fun <T> Array<T>.`should contain`(theThing: T) = if (this.contains(theThing)) Unit else fail("$this should contain $theThing", "$theThing", join(this))
 infix fun <T> Array<T>.`should not contain`(theThing: T) = if (!this.contains(theThing)) Unit else fail("$this should not contain $theThing", "$theThing", join(this))
 

--- a/src/test/kotlin/org/amshove/kluent/tests/assertions/ShouldBeInstanceOfTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/assertions/ShouldBeInstanceOfTests.kt
@@ -1,0 +1,25 @@
+package org.amshove.kluent.tests.assertions
+
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.tests.helpclasses.Circle
+import org.amshove.kluent.tests.helpclasses.Shape
+import org.amshove.kluent.tests.helpclasses.Square
+import org.jetbrains.spek.api.Spek
+import kotlin.test.assertFails
+
+class ShouldBeInstanceOfTests : Spek({
+    given("the should be instance of method") {
+        on("checking objects of the correct class") {
+            val firstObject: Shape = Circle(10.0)
+            it("should pass") {
+                firstObject shouldBeInstanceOf Circle::class.java
+            }
+        }
+        on("checking objects of the wrong class") {
+            val firstObject: Shape = Square(10.0)
+            it("should fail") {
+                assertFails({ firstObject shouldBeInstanceOf Circle::class.java })
+            }
+        }
+    }
+})

--- a/src/test/kotlin/org/amshove/kluent/tests/assertions/ShouldNotBeInstanceOfTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/assertions/ShouldNotBeInstanceOfTests.kt
@@ -1,0 +1,25 @@
+package org.amshove.kluent.tests.assertions
+
+import org.amshove.kluent.shouldNotBeInstanceOf
+import org.amshove.kluent.tests.helpclasses.Circle
+import org.amshove.kluent.tests.helpclasses.Shape
+import org.amshove.kluent.tests.helpclasses.Square
+import org.jetbrains.spek.api.Spek
+import kotlin.test.assertFails
+
+class ShouldNotBeInstanceOfTests : Spek({
+    given("the should be instance of method") {
+        on("checking objects of the correct class") {
+            val firstObject: Shape = Circle(10.0)
+            it("should fail") {
+                assertFails({ firstObject shouldNotBeInstanceOf Circle::class.java })
+            }
+        }
+        on("checking objects of the wrong class") {
+            val firstObject: Shape = Square(10.0)
+            it("should pass") {
+                firstObject shouldNotBeInstanceOf Circle::class.java
+            }
+        }
+    }
+})

--- a/src/test/kotlin/org/amshove/kluent/tests/backtickassertions/ShouldBeInstanceOfTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/backtickassertions/ShouldBeInstanceOfTests.kt
@@ -1,0 +1,25 @@
+package org.amshove.kluent.tests.backtickassertions
+
+import org.amshove.kluent.`should be instance of`
+import org.amshove.kluent.tests.helpclasses.Circle
+import org.amshove.kluent.tests.helpclasses.Shape
+import org.amshove.kluent.tests.helpclasses.Square
+import org.jetbrains.spek.api.Spek
+import kotlin.test.assertFails
+
+class ShouldBeInstanceOfTests : Spek({
+    given("the should be instance of method") {
+        on("checking objects of the correct class") {
+            val firstObject: Shape = Circle(10.0)
+            it("should pass") {
+                firstObject `should be instance of` Circle::class.java
+            }
+        }
+        on("checking objects of the wrong class") {
+            val firstObject: Shape = Square(10.0)
+            it("should fail") {
+                assertFails({ firstObject `should be instance of` Circle::class.java })
+            }
+        }
+    }
+})

--- a/src/test/kotlin/org/amshove/kluent/tests/backtickassertions/ShouldNotBeInstanceOfTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/backtickassertions/ShouldNotBeInstanceOfTests.kt
@@ -1,0 +1,25 @@
+package org.amshove.kluent.tests.backtickassertions
+
+import org.amshove.kluent.`should not be instance of`
+import org.amshove.kluent.tests.helpclasses.Circle
+import org.amshove.kluent.tests.helpclasses.Shape
+import org.amshove.kluent.tests.helpclasses.Square
+import org.jetbrains.spek.api.Spek
+import kotlin.test.assertFails
+
+class ShouldNotBeInstanceOfTests : Spek({
+    given("the should be instance of method") {
+        on("checking objects of the correct class") {
+            val firstObject: Shape = Circle(10.0)
+            it("should fail") {
+                assertFails({ firstObject `should not be instance of` Circle::class.java })
+            }
+        }
+        on("checking objects of the wrong class") {
+            val firstObject: Shape = Square(10.0)
+            it("should pass") {
+                firstObject `should not be instance of` Circle::class.java
+            }
+        }
+    }
+})

--- a/src/test/kotlin/org/amshove/kluent/tests/helpclasses/DataClasses.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/helpclasses/DataClasses.kt
@@ -1,3 +1,11 @@
 package org.amshove.kluent.tests.helpclasses
 
 data class Person(val name: String, val surname: String)
+
+class Circle(val radius: Double) : Shape{
+    override fun getArea() = radius * Math.PI * Math.PI
+}
+
+class Square(val side: Double) : Shape{
+    override fun getArea() = side * side
+}

--- a/src/test/kotlin/org/amshove/kluent/tests/helpclasses/Interfaces.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/helpclasses/Interfaces.kt
@@ -6,3 +6,7 @@ interface Database {
     fun getPerson(id: Int): Person
 }
 
+interface Shape {
+    fun getArea(): Double
+}
+


### PR DESCRIPTION
`shouldBeInstanceOf` and `shouldNotBeInstanceOf` can be used to check if an object can be cast to a certain class. I find this useful for when I have a function that returns an object whose type is an interface with a few implementations, and I want to make sure that it returns the correct implementation.

Currently the only way of doing this with  Kluent AFAIK is:

```kotlin
val testObject: MyInterface = foo()
(testObject is SomeImplentation) `should equal` true
```
And with this PR it becomes:

```kotlin
val testObject: MyInterface = foo()
testObject  `should be instance of` SomeImplementation
```

I find the later easier to read. :)