### PR TITLE
ExceptionResult is now Typed and withCause and withMessage are now fluent

### DIFF
--- a/src/main/kotlin/org/amshove/kluent/ExceptionResult.kt
+++ b/src/main/kotlin/org/amshove/kluent/ExceptionResult.kt
@@ -1,6 +1,6 @@
 package org.amshove.kluent
 
-class ExceptionResult(val exception: Exception) {
+class ExceptionResult<out T : Exception>(val exception: T) {
     val exceptionMessage = exception.message ?: ""
     val exceptionCause = exception.cause
 }

--- a/src/main/kotlin/org/amshove/kluent/Exceptions.kt
+++ b/src/main/kotlin/org/amshove/kluent/Exceptions.kt
@@ -31,17 +31,18 @@ infix fun <T : Exception> (() -> Any).`should not throw`(expectedException: KCla
 infix fun <T : Exception> (() -> Any).shouldNotThrow(expectedException: KClass<T>) = this `should not throw` expectedException
 
 
-infix fun <T : Exception> (() -> Any).`should throw the Exception`(expectedException: KClass<T>): ExceptionResult {
+infix fun <T : Exception> (() -> Any).`should throw the Exception`(expectedException: KClass<T>): ExceptionResult<T> {
     try {
         this.invoke()
         fail("There was an Exception expected to be thrown, but nothing was thrown", "$expectedException", "None")
     } catch (e: Exception) {
-        if (e.isA(expectedException)) return ExceptionResult(e)
+        @Suppress("UNCHECKED_CAST")
+        if (e.isA(expectedException)) return ExceptionResult(e as T)
         else throw ComparisonFailure("Expected ${expectedException.javaObjectType} to be thrown", "${expectedException.javaObjectType}", "${e.javaClass}")
     }
 }
 
-infix fun <T : Exception> (() -> Any).shouldThrowTheException(expectedException: KClass<T>): ExceptionResult = this `should throw the Exception` expectedException
+infix fun <T : Exception> (() -> Any).shouldThrowTheException(expectedException: KClass<T>): ExceptionResult<T> = this `should throw the Exception` expectedException
 
 
 infix fun <T : Exception> (() -> Any).`should not throw the Exception`(expectedException: KClass<T>): NotThrowExceptionResult {
@@ -59,29 +60,33 @@ infix fun <T : Exception> (() -> Any).`should not throw the Exception`(expectedE
 infix fun <T : Exception> (() -> Any).shouldNotThrowTheException(expectedException: KClass<T>): NotThrowExceptionResult = this `should not throw the Exception` expectedException
 
 
-infix fun ExceptionResult.`with message`(theMessage: String) {
+infix fun <T: Exception> ExceptionResult<T>.`with message`(theMessage: String): ExceptionResult<T> {
     this.exceptionMessage `should equal` theMessage
+    return this
 }
 
-infix fun ExceptionResult.withMessage(theMessage: String) = this `with message` theMessage
+infix fun <T: Exception> ExceptionResult<T>.withMessage(theMessage: String) = this `with message` theMessage
 
 
-infix fun NotThrowExceptionResult.`with message`(theMessage: String) {
+infix fun NotThrowExceptionResult.`with message`(theMessage: String): NotThrowExceptionResult {
     this.exceptionMessage `should not equal` theMessage
+    return this;
 }
 
 infix fun NotThrowExceptionResult.withMessage(theMessage: String) = this `with message` theMessage
 
 
-infix fun ExceptionResult.`with cause`(expectedCause: KClass<out Exception>) {
+infix fun <T: Exception> ExceptionResult<T>.`with cause`(expectedCause: KClass<out Exception>): ExceptionResult<T> {
     this.exceptionCause `should be instance of` expectedCause.java
+    return this
 }
 
-infix fun ExceptionResult.withCause(expectedCause: KClass<out Exception>) = this `with cause` expectedCause
+infix fun <T: Exception> ExceptionResult<T>.withCause(expectedCause: KClass<out Exception>) = this `with cause` expectedCause
 
 
-infix fun NotThrowExceptionResult.`with cause`(expectedCause: KClass<out Exception>) {
+infix fun NotThrowExceptionResult.`with cause`(expectedCause: KClass<out Exception>): NotThrowExceptionResult {
     this.exceptionCause `should not be instance of` expectedCause.java
+    return this
 }
 
 infix fun NotThrowExceptionResult.withCause(expectedCause: KClass<out Exception>) = this `with cause` expectedCause

--- a/src/test/kotlin/org/amshove/kluent/tests/assertions/ShouldThrowTheExceptionTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/assertions/ShouldThrowTheExceptionTests.kt
@@ -1,10 +1,6 @@
 package org.amshove.kluent.tests.assertions
 
-import org.amshove.kluent.AnyException
-import org.amshove.kluent.shouldThrow
-import org.amshove.kluent.shouldThrowTheException
-import org.amshove.kluent.withCause
-import org.amshove.kluent.withMessage
+import org.amshove.kluent.*
 import org.jetbrains.spek.api.Spek
 import java.io.IOException
 import kotlin.test.assertFails
@@ -53,6 +49,43 @@ class ShouldThrowTheExceptionTests : Spek({
                 assertFails({ func shouldThrow AnyException })
             }
         }
+        on("being fluent asserting both a cause and a message") {
+            on("both the message and cause being right") {
+                it("should pass") {
+                    val func = { throw IllegalArgumentException("hello", IOException()) }
+                    func shouldThrowTheException IllegalArgumentException::class withCause IOException::class withMessage "hello"
+                }
+            }
+
+            on("on the message being wrong") {
+                it("should fail") {
+                    val func = { throw IllegalArgumentException("not hello", IOException()) }
+                    assertFails { func shouldThrowTheException IllegalArgumentException::class withCause IOException::class withMessage "hello" }
+                }
+            }
+        }
+
+        given("a custom exception") {
+            class CustomException(val code: Int) : Exception("code is $code")
+
+            on("throwing an exception of the right type") {
+                it("should return the exception result with the given type") {
+
+                    val func = { throw CustomException(10) }
+
+                    func.shouldThrowTheException(CustomException::class).exception.code.shouldEqualTo(10)
+                }
+            }
+            on("throwing an exception of the wrong type") {
+                it("should fail") {
+                    val func = { throw IllegalArgumentException() }
+                    assertFails { func.shouldThrowTheException(CustomException::class).exception.code.shouldEqualTo(10) }
+                }
+            }
+        }
+
     }
 })
+
+
 

--- a/src/test/kotlin/org/amshove/kluent/tests/backtickassertions/ShouldThrowTheExceptionTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/backtickassertions/ShouldThrowTheExceptionTests.kt
@@ -1,10 +1,6 @@
 package org.amshove.kluent.tests.backtickassertions
 
-import org.amshove.kluent.AnyException
-import org.amshove.kluent.`should throw the Exception`
-import org.amshove.kluent.`should throw`
-import org.amshove.kluent.`with cause`
-import org.amshove.kluent.`with message`
+import org.amshove.kluent.*
 import org.jetbrains.spek.api.Spek
 import java.io.IOException
 import kotlin.test.assertFails
@@ -51,6 +47,40 @@ class ShouldThrowTheExceptionTests : Spek({
             it("should fail") {
                 val func = { Unit }
                 assertFails({ func `should throw` AnyException })
+            }
+        }
+        on("being fluent asserting both a cause and a message") {
+            on("both the message and cause being right") {
+                it("should pass") {
+                    val func = { throw IllegalArgumentException("hello", IOException()) }
+                    func `should throw the Exception` IllegalArgumentException::class `with cause` IOException::class `with message`  "hello"
+                }
+            }
+
+            on("on the message being wrong") {
+                it("should fail") {
+                    val func = { throw IllegalArgumentException("not hello", IOException()) }
+                    assertFails { func `should throw the Exception`  IllegalArgumentException::class `with cause`  IOException::class `with message`  "hello" }
+                }
+            }
+        }
+
+        given("a custom exception") {
+            class CustomException(val code: Int) : Exception("code is $code")
+
+            on("throwing an exception of the right type") {
+                it("should return the exception result with the given type") {
+
+                    val func = { throw CustomException(10) }
+
+                    func.`should throw the Exception`(CustomException::class).exception.code.shouldEqualTo(10)
+                }
+            }
+            on("throwing an exception of the wrong type") {
+                it("should fail") {
+                    val func = { throw IllegalArgumentException() }
+                    assertFails { func.`should throw the Exception`(CustomException::class).exception.code.shouldEqualTo(10) }
+                }
             }
         }
     }


### PR DESCRIPTION
## Typed ExceptionResult
Currently I'm working with Custom Exceptions that have properties like status codes and I have the need to further validate those properties

```kotlin
            class CustomException(val code: Int) : Exception("code is $code")

            on("throwing an exception of the right type") {
                it("should return the exception result with the given type") {

                    val func = { throw CustomException(10) }

                    func.shouldThrowTheException(CustomException::class).exception.code.shouldEqualTo(10)
                }
            }
```

## Fluent withCause and withMessage
The change now allows you to do:
```kotlin
val func = { throw IllegalArgumentException("hello", IOException()) }
func shouldThrowTheException IllegalArgumentException::class withCause IOException::class withMessage "hello"
```

Let me know if there is anything else I need to add.