### PR TITLE
Allow Errors to be thrown from a stub

### DIFF
--- a/src/main/kotlin/org/amshove/kluent/Mocking.kt
+++ b/src/main/kotlin/org/amshove/kluent/Mocking.kt
@@ -33,6 +33,9 @@ infix fun <T> OngoingStubbing<T>.itReturns(value: T): OngoingStubbing<T> = this 
 infix fun <T> OngoingStubbing<T>.`it throws`(value: RuntimeException): OngoingStubbing<T> = this.thenThrow(value)
 infix fun <T> OngoingStubbing<T>.itThrows(value: RuntimeException): OngoingStubbing<T> = this `it throws` value
 
+infix fun <T> OngoingStubbing<T>.`it throws`(value: Error): OngoingStubbing<T> = this.thenThrow(value)
+infix fun <T> OngoingStubbing<T>.itThrows(value: Error): OngoingStubbing<T> = this `it throws` value
+
 infix fun <T> OngoingStubbing<T>.`it answers`(value: (InvocationOnMock) -> T): OngoingStubbing<T> = this.thenAnswer(value)
 infix fun <T> OngoingStubbing<T>.itAnswers(value: (InvocationOnMock) -> T): OngoingStubbing<T> = this `it answers` value
 

--- a/src/test/kotlin/org/amshove/kluent/tests/mocking/StubTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/mocking/StubTests.kt
@@ -34,6 +34,13 @@ class StubTests : Spek({
                 assertFailsWith(RuntimeException::class, { mock.getPerson() })
             }
         }
+        on("telling it to throw an error") {
+            it("should throw an error") {
+                val mock = mock(Database::class)
+                When calling mock.getPerson() itThrows Error("An exception")
+                assertFailsWith(Error::class, { mock.getPerson() })
+            }
+        }
         on("telling it to answer") {
             it("should answer when called") {
                 val mock = mock(Database::class)


### PR DESCRIPTION
Sadly, some libraries still using errors for exception handling. Those must be handled and to test them, Error-Classes should also be allowed to be thrown by the subbed mocks.