### PR TITLE
merge shouldThrowTheException into shouldThrow

### DIFF
--- a/src/main/kotlin/org/amshove/kluent/Exceptions.kt
+++ b/src/main/kotlin/org/amshove/kluent/Exceptions.kt
@@ -32,6 +32,13 @@ infix fun <T : Throwable> (() -> Any).`should not throw`(expectedException: KCla
 
 infix fun <T : Throwable> (() -> Any).shouldNotThrow(expectedException: KClass<T>) = this `should not throw` expectedException
 
+@Deprecated("Use `should throw` instead", ReplaceWith("x `should throw` expectedException"))
+infix fun <T : Throwable> (() -> Any).`should throw the Exception`(expectedException: KClass<T>): ExceptionResult<T>
+        = this `should throw` expectedException
+
+@Deprecated("User shouldThrow instead", ReplaceWith("x shouldThrow expectedException"))
+infix fun <T : Throwable> (() -> Any).shouldThrowTheException(expectedException: KClass<T>): ExceptionResult<T> = this shouldThrow expectedException
+
 infix fun <T : Throwable> (() -> Any).`should not throw the Exception`(expectedException: KClass<T>): NotThrowExceptionResult {
     try {
         this.invoke()

--- a/src/main/kotlin/org/amshove/kluent/Exceptions.kt
+++ b/src/main/kotlin/org/amshove/kluent/Exceptions.kt
@@ -3,16 +3,15 @@ package org.amshove.kluent
 import org.junit.ComparisonFailure
 import kotlin.reflect.KClass
 
-infix fun <T : Throwable> (() -> Any).`should throw`(expectedException: KClass<T>) {
+infix fun <T : Throwable> (() -> Any).`should throw`(expectedException: KClass<T>): ExceptionResult<T> {
     try {
         this.invoke()
         fail("There was an Exception expected to be thrown, but nothing was thrown", "$expectedException", "None")
     } catch (e: Throwable) {
-        if(e.isA(ComparisonFailure::class)) {
-            throw e
-        }
-        if (!e.isA(expectedException))
-            throw ComparisonFailure("Expected ${expectedException.javaObjectType} to be thrown", "${expectedException.javaObjectType}", "${e.javaClass}")
+        @Suppress("UNCHECKED_CAST")
+        if (e.isA(ComparisonFailure::class)) throw e
+        else if (e.isA(expectedException)) return ExceptionResult(e as T)
+        else throw ComparisonFailure("Expected ${expectedException.javaObjectType} to be thrown", "${expectedException.javaObjectType}", "${e.javaClass}")
     }
 }
 
@@ -33,21 +32,6 @@ infix fun <T : Throwable> (() -> Any).`should not throw`(expectedException: KCla
 
 infix fun <T : Throwable> (() -> Any).shouldNotThrow(expectedException: KClass<T>) = this `should not throw` expectedException
 
-
-infix fun <T : Throwable> (() -> Any).`should throw the Exception`(expectedException: KClass<T>): ExceptionResult<T> {
-    try {
-        this.invoke()
-        fail("There was an Exception expected to be thrown, but nothing was thrown", "$expectedException", "None")
-    } catch (e: Throwable) {
-        @Suppress("UNCHECKED_CAST")
-        if (e.isA(expectedException)) return ExceptionResult(e as T)
-        else throw ComparisonFailure("Expected ${expectedException.javaObjectType} to be thrown", "${expectedException.javaObjectType}", "${e.javaClass}")
-    }
-}
-
-infix fun <T : Throwable> (() -> Any).shouldThrowTheException(expectedException: KClass<T>): ExceptionResult<T> = this `should throw the Exception` expectedException
-
-
 infix fun <T : Throwable> (() -> Any).`should not throw the Exception`(expectedException: KClass<T>): NotThrowExceptionResult {
     try {
         this.invoke()
@@ -63,12 +47,12 @@ infix fun <T : Throwable> (() -> Any).`should not throw the Exception`(expectedE
 infix fun <T : Throwable> (() -> Any).shouldNotThrowTheException(expectedException: KClass<T>): NotThrowExceptionResult = this `should not throw the Exception` expectedException
 
 
-infix fun <T: Throwable> ExceptionResult<T>.`with message`(theMessage: String): ExceptionResult<T> {
+infix fun <T : Throwable> ExceptionResult<T>.`with message`(theMessage: String): ExceptionResult<T> {
     this.exceptionMessage `should equal` theMessage
     return this
 }
 
-infix fun <T: Throwable> ExceptionResult<T>.withMessage(theMessage: String) = this `with message` theMessage
+infix fun <T : Throwable> ExceptionResult<T>.withMessage(theMessage: String) = this `with message` theMessage
 
 
 infix fun NotThrowExceptionResult.`with message`(theMessage: String): NotThrowExceptionResult {
@@ -79,12 +63,12 @@ infix fun NotThrowExceptionResult.`with message`(theMessage: String): NotThrowEx
 infix fun NotThrowExceptionResult.withMessage(theMessage: String) = this `with message` theMessage
 
 
-infix fun <T: Throwable> ExceptionResult<T>.`with cause`(expectedCause: KClass<out Throwable>): ExceptionResult<T> {
+infix fun <T : Throwable> ExceptionResult<T>.`with cause`(expectedCause: KClass<out Throwable>): ExceptionResult<T> {
     this.exceptionCause `should be instance of` expectedCause.java
     return this
 }
 
-infix fun <T: Throwable> ExceptionResult<T>.withCause(expectedCause: KClass<out Throwable>) = this `with cause` expectedCause
+infix fun <T : Throwable> ExceptionResult<T>.withCause(expectedCause: KClass<out Throwable>) = this `with cause` expectedCause
 
 
 infix fun NotThrowExceptionResult.`with cause`(expectedCause: KClass<out Throwable>): NotThrowExceptionResult {

--- a/src/test/kotlin/org/amshove/kluent/tests/assertions/ShouldThrowTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/assertions/ShouldThrowTests.kt
@@ -1,7 +1,8 @@
 package org.amshove.kluent.tests.assertions
 
-import org.amshove.kluent.shouldThrow
+import org.amshove.kluent.*
 import org.jetbrains.spek.api.Spek
+import java.io.IOException
 import java.util.*
 import kotlin.test.assertFails
 
@@ -30,6 +31,82 @@ class ShouldThrowTests : Spek({
             val func = { throw IllegalStateException() }
             it("should pass a shouldThrow with expected super type") {
                 func shouldThrow RuntimeException::class
+            }
+        }
+        on("throwing an exception with a message") {
+            it("should pass") {
+                val func = { throw Exception("Hello World!") }
+                func shouldThrow Exception::class withMessage "Hello World!"
+            }
+        }
+        on("throwing an exception with a wrong message") {
+            it("should fail") {
+                val func = { throw Exception("Hello World!") }
+                assertFails({ func shouldThrow Exception::class withMessage "Hello" })
+            }
+        }
+        on("throwing an exception with a cause") {
+            it("should pass") {
+                val func = { throw Exception(RuntimeException()) }
+                func shouldThrow Exception::class withCause RuntimeException::class
+            }
+        }
+        on("throwing an exception with a wrong cause") {
+            it("should fail") {
+                val func = { throw Exception(RuntimeException()) }
+                assertFails({ func shouldThrow Exception::class withCause IOException::class })
+            }
+        }
+        on("throwing another exception") {
+            it("should fail") {
+                val func = { throw IllegalArgumentException() }
+                assertFails({ func shouldThrow IndexOutOfBoundsException::class })
+            }
+        }
+        on("expecting any exception when any exception is thrown") {
+            it("should pass") {
+                val func = { throw Exception() }
+                func shouldThrow AnyException
+            }
+        }
+        on("expecting any exception when no exception is thrown") {
+            it("should fail") {
+                val func = { Unit }
+                assertFails({ func shouldThrow AnyException })
+            }
+        }
+        on("being fluent asserting both a cause and a message") {
+            on("both the message and cause being right") {
+                it("should pass") {
+                    val func = { throw IllegalArgumentException("hello", IOException()) }
+                    func shouldThrow IllegalArgumentException::class withCause IOException::class withMessage "hello"
+                }
+            }
+
+            on("on the message being wrong") {
+                it("should fail") {
+                    val func = { throw IllegalArgumentException("not hello", IOException()) }
+                    assertFails { func shouldThrow IllegalArgumentException::class withCause IOException::class withMessage "hello" }
+                }
+            }
+        }
+
+        given("a custom exception") {
+            class CustomException(val code: Int) : Exception("code is $code")
+
+            on("throwing an exception of the right type") {
+                it("should return the exception result with the given type") {
+
+                    val func = { throw CustomException(10) }
+
+                    func.shouldThrow(CustomException::class).exception.code.shouldEqualTo(10)
+                }
+            }
+            on("throwing an exception of the wrong type") {
+                it("should fail") {
+                    val func = { throw IllegalArgumentException() }
+                    assertFails { func.shouldThrow(CustomException::class).exception.code.shouldEqualTo(10) }
+                }
             }
         }
     }

--- a/src/test/kotlin/org/amshove/kluent/tests/assertions/ShouldThrowTheExceptionTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/assertions/ShouldThrowTheExceptionTests.kt
@@ -6,29 +6,29 @@ import java.io.IOException
 import kotlin.test.assertFails
 
 class ShouldThrowTheExceptionTests : Spek({
-    given("the shouldThrowTheException method") {
+    given("the shouldThrow method") {
         on("throwing an exception with a message") {
             it("should pass") {
                 val func = { throw Exception("Hello World!") }
-                func shouldThrowTheException Exception::class withMessage "Hello World!"
+                func shouldThrow Exception::class withMessage "Hello World!"
             }
         }
         on("throwing an exception with a wrong message") {
             it("should fail") {
                 val func = { throw Exception("Hello World!") }
-                assertFails({ func shouldThrowTheException Exception::class withMessage "Hello" })
+                assertFails({ func shouldThrow Exception::class withMessage "Hello" })
             }
         }
         on("throwing an exception with a cause") {
             it("should pass") {
                 val func = { throw Exception(RuntimeException()) }
-                func shouldThrowTheException Exception::class withCause RuntimeException::class
+                func shouldThrow Exception::class withCause RuntimeException::class
             }
         }
         on("throwing an exception with a wrong cause") {
             it("should fail") {
                 val func = { throw Exception(RuntimeException()) }
-                assertFails({ func shouldThrowTheException Exception::class withCause IOException::class })
+                assertFails({ func shouldThrow Exception::class withCause IOException::class })
             }
         }
         on("throwing another exception") {
@@ -53,14 +53,14 @@ class ShouldThrowTheExceptionTests : Spek({
             on("both the message and cause being right") {
                 it("should pass") {
                     val func = { throw IllegalArgumentException("hello", IOException()) }
-                    func shouldThrowTheException IllegalArgumentException::class withCause IOException::class withMessage "hello"
+                    func shouldThrow IllegalArgumentException::class withCause IOException::class withMessage "hello"
                 }
             }
 
             on("on the message being wrong") {
                 it("should fail") {
                     val func = { throw IllegalArgumentException("not hello", IOException()) }
-                    assertFails { func shouldThrowTheException IllegalArgumentException::class withCause IOException::class withMessage "hello" }
+                    assertFails { func shouldThrow IllegalArgumentException::class withCause IOException::class withMessage "hello" }
                 }
             }
         }
@@ -73,13 +73,13 @@ class ShouldThrowTheExceptionTests : Spek({
 
                     val func = { throw CustomException(10) }
 
-                    func.shouldThrowTheException(CustomException::class).exception.code.shouldEqualTo(10)
+                    func.shouldThrow(CustomException::class).exception.code.shouldEqualTo(10)
                 }
             }
             on("throwing an exception of the wrong type") {
                 it("should fail") {
                     val func = { throw IllegalArgumentException() }
-                    assertFails { func.shouldThrowTheException(CustomException::class).exception.code.shouldEqualTo(10) }
+                    assertFails { func.shouldThrow(CustomException::class).exception.code.shouldEqualTo(10) }
                 }
             }
         }

--- a/src/test/kotlin/org/amshove/kluent/tests/assertions/ShouldThrowTheExceptionTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/assertions/ShouldThrowTheExceptionTests.kt
@@ -10,57 +10,57 @@ class ShouldThrowTheExceptionTests : Spek({
         on("throwing an exception with a message") {
             it("should pass") {
                 val func = { throw Exception("Hello World!") }
-                func shouldThrow Exception::class withMessage "Hello World!"
+                func shouldThrowTheException Exception::class withMessage "Hello World!"
             }
         }
         on("throwing an exception with a wrong message") {
             it("should fail") {
                 val func = { throw Exception("Hello World!") }
-                assertFails({ func shouldThrow Exception::class withMessage "Hello" })
+                assertFails({ func shouldThrowTheException Exception::class withMessage "Hello" })
             }
         }
         on("throwing an exception with a cause") {
             it("should pass") {
                 val func = { throw Exception(RuntimeException()) }
-                func shouldThrow Exception::class withCause RuntimeException::class
+                func shouldThrowTheException Exception::class withCause RuntimeException::class
             }
         }
         on("throwing an exception with a wrong cause") {
             it("should fail") {
                 val func = { throw Exception(RuntimeException()) }
-                assertFails({ func shouldThrow Exception::class withCause IOException::class })
+                assertFails({ func shouldThrowTheException Exception::class withCause IOException::class })
             }
         }
         on("throwing another exception") {
             it("should fail") {
                 val func = { throw IllegalArgumentException() }
-                assertFails({ func shouldThrow IndexOutOfBoundsException::class })
+                assertFails({ func shouldThrowTheException IndexOutOfBoundsException::class })
             }
         }
         on("expecting any exception when any exception is thrown") {
             it("should pass") {
                 val func = { throw Exception() }
-                func shouldThrow AnyException
+                func shouldThrowTheException AnyException
             }
         }
         on("expecting any exception when no exception is thrown") {
             it("should fail") {
                 val func = { Unit }
-                assertFails({ func shouldThrow AnyException })
+                assertFails({ func shouldThrowTheException AnyException })
             }
         }
         on("being fluent asserting both a cause and a message") {
             on("both the message and cause being right") {
                 it("should pass") {
                     val func = { throw IllegalArgumentException("hello", IOException()) }
-                    func shouldThrow IllegalArgumentException::class withCause IOException::class withMessage "hello"
+                    func shouldThrowTheException IllegalArgumentException::class withCause IOException::class withMessage "hello"
                 }
             }
 
             on("on the message being wrong") {
                 it("should fail") {
                     val func = { throw IllegalArgumentException("not hello", IOException()) }
-                    assertFails { func shouldThrow IllegalArgumentException::class withCause IOException::class withMessage "hello" }
+                    assertFails { func shouldThrowTheException IllegalArgumentException::class withCause IOException::class withMessage "hello" }
                 }
             }
         }
@@ -73,17 +73,16 @@ class ShouldThrowTheExceptionTests : Spek({
 
                     val func = { throw CustomException(10) }
 
-                    func.shouldThrow(CustomException::class).exception.code.shouldEqualTo(10)
+                    func.shouldThrowTheException(CustomException::class).exception.code.shouldEqualTo(10)
                 }
             }
             on("throwing an exception of the wrong type") {
                 it("should fail") {
                     val func = { throw IllegalArgumentException() }
-                    assertFails { func.shouldThrow(CustomException::class).exception.code.shouldEqualTo(10) }
+                    assertFails { func.shouldThrowTheException(CustomException::class).exception.code.shouldEqualTo(10) }
                 }
             }
         }
-
     }
 })
 

--- a/src/test/kotlin/org/amshove/kluent/tests/backtickassertions/ShouldThrowTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/backtickassertions/ShouldThrowTests.kt
@@ -1,7 +1,8 @@
 package org.amshove.kluent.tests.backtickassertions
 
-import org.amshove.kluent.`should throw`
+import org.amshove.kluent.*
 import org.jetbrains.spek.api.Spek
+import java.io.IOException
 import java.util.*
 import kotlin.test.assertFails
 
@@ -29,6 +30,82 @@ class ShouldThrowTests : Spek({
             val func = { throw IllegalStateException() }
             it("should pass a shouldThrow with expected super type") {
                 func `should throw` RuntimeException::class
+            }
+        }
+        on("throwing an exception with a message") {
+            it("should pass") {
+                val func = { throw Exception("Hello World!") }
+                func `should throw` Exception::class `with message` "Hello World!"
+            }
+        }
+        on("throwing an exception with a wrong message") {
+            it("should fail") {
+                val func = { throw Exception("Hello World!") }
+                assertFails({ func `should throw` Exception::class `with message` "Hello" })
+            }
+        }
+        on("throwing an exception with a cause") {
+            it("should pass") {
+                val func = { throw Exception(RuntimeException()) }
+                func `should throw` Exception::class `with cause` RuntimeException::class
+            }
+        }
+        on("throwing an exception with a wrong cause") {
+            it("should fail") {
+                val func = { throw Exception(RuntimeException()) }
+                assertFails({ func `should throw` Exception::class `with cause` IOException::class })
+            }
+        }
+        on("throwing another exception") {
+            it("should fail") {
+                val func = { throw IllegalArgumentException() }
+                assertFails({ func `should throw` IndexOutOfBoundsException::class })
+            }
+        }
+        on("expecting any exception when any exception is thrown") {
+            it("should pass") {
+                val func = { throw Exception() }
+                func `should throw` AnyException
+            }
+        }
+        on("expecting any exception when no exception is thrown") {
+            it("should fail") {
+                val func = { Unit }
+                assertFails({ func `should throw` AnyException })
+            }
+        }
+        on("being fluent asserting both a cause and a message") {
+            on("both the message and cause being right") {
+                it("should pass") {
+                    val func = { throw IllegalArgumentException("hello", IOException()) }
+                    func `should throw` IllegalArgumentException::class `with cause` IOException::class `with message` "hello"
+                }
+            }
+
+            on("on the message being wrong") {
+                it("should fail") {
+                    val func = { throw IllegalArgumentException("not hello", IOException()) }
+                    assertFails { func `should throw` IllegalArgumentException::class `with cause` IOException::class `with message` "hello" }
+                }
+            }
+        }
+
+        given("a custom exception") {
+            class CustomException(val code: Int) : Exception("code is $code")
+
+            on("throwing an exception of the right type") {
+                it("should return the exception result with the given type") {
+
+                    val func = { throw CustomException(10) }
+
+                    func.`should throw`(CustomException::class).exception.code.shouldEqualTo(10)
+                }
+            }
+            on("throwing an exception of the wrong type") {
+                it("should fail") {
+                    val func = { throw IllegalArgumentException() }
+                    assertFails { func.`should throw`(CustomException::class).exception.code.shouldEqualTo(10) }
+                }
             }
         }
     }

--- a/src/test/kotlin/org/amshove/kluent/tests/backtickassertions/ShouldThrowTheExceptionTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/backtickassertions/ShouldThrowTheExceptionTests.kt
@@ -10,25 +10,25 @@ class ShouldThrowTheExceptionTests : Spek({
         on("throwing an exception with a message") {
             it("should pass") {
                 val func = { throw Exception("Hello World!") }
-                func `should throw the Exception` Exception::class `with message` "Hello World!"
+                func `should throw`  Exception::class `with message` "Hello World!"
             }
         }
         on("throwing an exception with a wrong message") {
             it("should fail") {
                 val func = { throw Exception("Hello World!") }
-                assertFails({ func `should throw the Exception` Exception::class `with message` "Hello" })
+                assertFails({ func `should throw` Exception::class `with message` "Hello" })
             }
         }
         on("throwing an exception with a cause") {
             it("should pass") {
                 val func = { throw Exception(RuntimeException()) }
-                func `should throw the Exception` Exception::class `with cause` RuntimeException::class
+                func `should throw` Exception::class `with cause` RuntimeException::class
             }
         }
         on("throwing an exception with a wrong cause") {
             it("should fail") {
                 val func = { throw Exception(RuntimeException()) }
-                assertFails({ func `should throw the Exception` Exception::class `with cause` IOException::class })
+                assertFails({ func `should throw` Exception::class `with cause` IOException::class })
             }
         }
         on("throwing another exception") {
@@ -53,14 +53,14 @@ class ShouldThrowTheExceptionTests : Spek({
             on("both the message and cause being right") {
                 it("should pass") {
                     val func = { throw IllegalArgumentException("hello", IOException()) }
-                    func `should throw the Exception` IllegalArgumentException::class `with cause` IOException::class `with message`  "hello"
+                    func `should throw` IllegalArgumentException::class `with cause` IOException::class `with message`  "hello"
                 }
             }
 
             on("on the message being wrong") {
                 it("should fail") {
                     val func = { throw IllegalArgumentException("not hello", IOException()) }
-                    assertFails { func `should throw the Exception`  IllegalArgumentException::class `with cause`  IOException::class `with message`  "hello" }
+                    assertFails { func `should throw`  IllegalArgumentException::class `with cause`  IOException::class `with message`  "hello" }
                 }
             }
         }
@@ -73,13 +73,13 @@ class ShouldThrowTheExceptionTests : Spek({
 
                     val func = { throw CustomException(10) }
 
-                    func.`should throw the Exception`(CustomException::class).exception.code.shouldEqualTo(10)
+                    func.`should throw`(CustomException::class).exception.code.shouldEqualTo(10)
                 }
             }
             on("throwing an exception of the wrong type") {
                 it("should fail") {
                     val func = { throw IllegalArgumentException() }
-                    assertFails { func.`should throw the Exception`(CustomException::class).exception.code.shouldEqualTo(10) }
+                    assertFails { func.`should throw`(CustomException::class).exception.code.shouldEqualTo(10) }
                 }
             }
         }

--- a/src/test/kotlin/org/amshove/kluent/tests/backtickassertions/ShouldThrowTheExceptionTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/backtickassertions/ShouldThrowTheExceptionTests.kt
@@ -10,57 +10,57 @@ class ShouldThrowTheExceptionTests : Spek({
         on("throwing an exception with a message") {
             it("should pass") {
                 val func = { throw Exception("Hello World!") }
-                func `should throw`  Exception::class `with message` "Hello World!"
+                func `should throw the Exception` Exception::class `with message` "Hello World!"
             }
         }
         on("throwing an exception with a wrong message") {
             it("should fail") {
                 val func = { throw Exception("Hello World!") }
-                assertFails({ func `should throw` Exception::class `with message` "Hello" })
+                assertFails({ func `should throw the Exception` Exception::class `with message` "Hello" })
             }
         }
         on("throwing an exception with a cause") {
             it("should pass") {
                 val func = { throw Exception(RuntimeException()) }
-                func `should throw` Exception::class `with cause` RuntimeException::class
+                func `should throw the Exception` Exception::class `with cause` RuntimeException::class
             }
         }
         on("throwing an exception with a wrong cause") {
             it("should fail") {
                 val func = { throw Exception(RuntimeException()) }
-                assertFails({ func `should throw` Exception::class `with cause` IOException::class })
+                assertFails({ func `should throw the Exception` Exception::class `with cause` IOException::class })
             }
         }
         on("throwing another exception") {
             it("should fail") {
                 val func = { throw IllegalArgumentException() }
-                assertFails({ func `should throw` IndexOutOfBoundsException::class })
+                assertFails({ func `should throw the Exception` IndexOutOfBoundsException::class })
             }
         }
         on("expecting any exception when any exception is thrown") {
             it("should pass") {
                 val func = { throw Exception() }
-                func `should throw` AnyException
+                func `should throw the Exception` AnyException
             }
         }
         on("expecting any exception when no exception is thrown") {
             it("should fail") {
                 val func = { Unit }
-                assertFails({ func `should throw` AnyException })
+                assertFails({ func `should throw the Exception` AnyException })
             }
         }
         on("being fluent asserting both a cause and a message") {
             on("both the message and cause being right") {
                 it("should pass") {
                     val func = { throw IllegalArgumentException("hello", IOException()) }
-                    func `should throw` IllegalArgumentException::class `with cause` IOException::class `with message`  "hello"
+                    func `should throw the Exception` IllegalArgumentException::class `with cause` IOException::class `with message` "hello"
                 }
             }
 
             on("on the message being wrong") {
                 it("should fail") {
                     val func = { throw IllegalArgumentException("not hello", IOException()) }
-                    assertFails { func `should throw`  IllegalArgumentException::class `with cause`  IOException::class `with message`  "hello" }
+                    assertFails { func `should throw the Exception` IllegalArgumentException::class `with cause` IOException::class `with message` "hello" }
                 }
             }
         }
@@ -73,13 +73,13 @@ class ShouldThrowTheExceptionTests : Spek({
 
                     val func = { throw CustomException(10) }
 
-                    func.`should throw`(CustomException::class).exception.code.shouldEqualTo(10)
+                    func.`should throw the Exception`(CustomException::class).exception.code.shouldEqualTo(10)
                 }
             }
             on("throwing an exception of the wrong type") {
                 it("should fail") {
                     val func = { throw IllegalArgumentException() }
-                    assertFails { func.`should throw`(CustomException::class).exception.code.shouldEqualTo(10) }
+                    assertFails { func.`should throw the Exception`(CustomException::class).exception.code.shouldEqualTo(10) }
                 }
             }
         }


### PR DESCRIPTION
I noticed the `shouldThrowTheException()` method is kind of obsolete. 

We can just make the `shouldThrow` return an ExceptionResult, which can be evaluated (`withMessage`) if needed, or disregarded. 

Now the `shouldThrow()` covers both use cases, but is much shorter and easier to read. 

Example:
`func shouldThrow Exception::class withCause IOException::class`

What do you think?