### PR TITLE
Add support for Android-compliant builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ out/
 .project
 bin/
 .settings/
+local.properties

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,8 @@ apply plugin: 'maven'
 apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.bintray'
 
+def isAndroid = project.rootProject.hasProperty("ANDROID")
+
 repositories {
     jcenter()
     maven {
@@ -39,8 +41,24 @@ dependencies {
 }
 
 sourceSets {
-    main.kotlin.srcDirs += 'src/main/kotlin'
-    test.kotlin.srcDirs += 'src/test/kotlin'
+    main {
+        kotlin {
+            srcDirs += 'src/main/kotlin'
+
+            if(isAndroid) {
+                exclude '**/*Backtick.kt'
+            }
+        }
+    }
+    test {
+        kotlin {
+            srcDirs += 'src/test/kotlin'
+
+            if(isAndroid) {
+                exclude '**/backtick*/**'
+            }
+        }
+    }
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {
@@ -71,7 +89,7 @@ publishing {
         PublishKluent(MavenPublication) {
             from components.java
             groupId 'org.amshove.kluent'
-            artifactId 'kluent'
+            artifactId isAndroid ? 'kluent-android' : 'kluent'
             version project.version
 
             // http://stackoverflow.com/a/32353697/6556970

--- a/src/main/kotlin/org/amshove/kluent/Basic.kt
+++ b/src/main/kotlin/org/amshove/kluent/Basic.kt
@@ -3,44 +3,30 @@ package org.amshove.kluent
 import org.junit.Assert.*
 import kotlin.reflect.KClass
 
-infix fun Any?.`should equal`(theOther: Any?) = assertEquals(theOther, this)
-infix fun Any?.shouldEqual(theOther: Any?) = this `should equal` theOther
+infix fun Any?.shouldEqual(theOther: Any?) = assertEquals(theOther, this)
 
-infix fun Any?.`should not equal`(theOther: Any?) = assertNotEquals(theOther, this)
-infix fun Any?.shouldNotEqual(theOther: Any?) = this `should not equal` theOther
+infix fun Any?.shouldNotEqual(theOther: Any?) =  assertNotEquals(theOther, this)
 
-infix fun Any?.`should be`(theOther: Any?) = assertSame(theOther, this)
-infix fun Any?.shouldBe(theOther: Any?) = this `should be` theOther
+infix fun Any?.shouldBe(theOther: Any?) = assertSame(theOther, this)
 
-infix fun Any?.`should not be`(theOther: Any?) = assertNotSame(theOther, this)
-infix fun Any?.shouldNotBe(theOther: Any?) = this `should not be` theOther
+infix fun Any?.shouldNotBe(theOther: Any?) = assertNotSame(theOther, this)
 
-infix fun Any?.`should be instance of`(className: Class<*>) = assertTrue("Expected $this to be an instance of $className", className.isInstance(this))
-infix fun Any?.shouldBeInstanceOf(className: Class<*>) = this `should be instance of` className
+infix fun Any?.shouldBeInstanceOf(className: Class<*>) = assertTrue("Expected $this to be an instance of $className", className.isInstance(this))
 
-infix fun Any?.`should be instance of`(className: KClass<*>) = assertTrue("Expected $this to be an instance of $className", className.isInstance(this))
-infix fun Any?.shouldBeInstanceOf(className: KClass<*>) = this `should be instance of` className
+infix fun Any?.shouldBeInstanceOf(className: KClass<*>) = assertTrue("Expected $this to be an instance of $className", className.isInstance(this))
 
-infix fun Any?.`should not be instance of`(className: Class<*>) = assertFalse("Expected $this to not be an instance of $className", className.isInstance(this))
-infix fun Any?.shouldNotBeInstanceOf(className: Class<*>) = this `should not be instance of` className
+infix fun Any?.shouldNotBeInstanceOf(className: Class<*>) = assertFalse("Expected $this to not be an instance of $className", className.isInstance(this))
 
-infix fun Any?.`should not be instance of`(className: KClass<*>) = assertFalse("Expected $this to not be an instance of $className", className.isInstance(this))
-infix fun Any?.shouldNotBeInstanceOf(className: KClass<*>) = this `should not be instance of` className
+infix fun Any?.shouldNotBeInstanceOf(className: KClass<*>) = assertFalse("Expected $this to not be an instance of $className", className.isInstance(this))
 
-fun Any?.`should be null`() = assertNull(this)
-fun Any?.shouldBeNull() = this.`should be null`()
+fun Any?.shouldBeNull() = assertNull(this)
 
-fun Any?.`should not be null`() = assertNotNull(this)
-fun Any?.shouldNotBeNull() = this.`should not be null`()
+fun Any?.shouldNotBeNull() = assertNotNull(this)
 
-fun Boolean.`should be true`() = assertTrue(this)
-fun Boolean.shouldBeTrue() = this.`should be true`()
+fun Boolean.shouldBeTrue() = assertTrue(this)
 
-fun Boolean.`should be false`() = assertFalse(this)
-fun Boolean.shouldBeFalse() = this.`should be false`()
+fun Boolean.shouldBeFalse() =  assertFalse(this)
 
-fun Boolean.`should not be true`() = this.`should be false`()
-fun Boolean.shouldNotBeTrue() = this.`should not be true`()
+fun Boolean.shouldNotBeTrue() = this.shouldBeFalse()
 
-fun Boolean.`should not be false`() = this.`should be true`()
-fun Boolean.shouldNotBeFalse() = this.`should not be false`()
+fun Boolean.shouldNotBeFalse() = this.shouldBeTrue()

--- a/src/main/kotlin/org/amshove/kluent/BasicBacktick.kt
+++ b/src/main/kotlin/org/amshove/kluent/BasicBacktick.kt
@@ -1,0 +1,31 @@
+package org.amshove.kluent
+
+import kotlin.reflect.KClass
+
+infix fun Any?.`should equal`(theOther: Any?) = this.shouldEqual(theOther)
+
+infix fun Any?.`should not equal`(theOther: Any?) = this.shouldNotEqual(theOther)
+
+infix fun Any?.`should be`(theOther: Any?) = this.shouldBe(theOther)
+
+infix fun Any?.`should not be`(theOther: Any?) = this.shouldNotBe(theOther)
+
+infix fun Any?.`should be instance of`(className: Class<*>) = this.shouldBeInstanceOf(className)
+
+infix fun Any?.`should be instance of`(className: KClass<*>) = this.shouldBeInstanceOf(className)
+
+infix fun Any?.`should not be instance of`(className: Class<*>) = this.shouldNotBeInstanceOf(className)
+
+infix fun Any?.`should not be instance of`(className: KClass<*>) = this.shouldNotBeInstanceOf(className)
+
+fun Any?.`should be null`() = this.shouldBeNull()
+
+fun Any?.`should not be null`() = this.shouldNotBeNull()
+
+fun Boolean.`should be true`() = this.shouldBeTrue()
+
+fun Boolean.`should be false`() = this.shouldBeFalse()
+
+fun Boolean.`should not be true`() = this.shouldBeFalse()
+
+fun Boolean.`should not be false`() = this.shouldBeTrue()

--- a/src/main/kotlin/org/amshove/kluent/CharSequence.kt
+++ b/src/main/kotlin/org/amshove/kluent/CharSequence.kt
@@ -2,68 +2,48 @@ package org.amshove.kluent
 
 import org.junit.Assert.*
 
-infix fun CharSequence.`should start with`(theOther: CharSequence) = assertTrue("Expected the CharSequence $this to start with $theOther", this.startsWith(theOther))
-infix fun CharSequence.shouldStartWith(theOther: CharSequence) = this `should start with` theOther
+infix fun CharSequence.shouldStartWith(theOther: CharSequence) = assertTrue("Expected the CharSequence $this to start with $theOther", this.startsWith(theOther))
 
-infix fun CharSequence.`should end with`(theOther: CharSequence) = assertTrue("Expected the CharSequence $this to end with $theOther", this.endsWith(theOther))
-infix fun CharSequence.shouldEndWith(theOther: CharSequence) = this `should end with` theOther
+infix fun CharSequence.shouldEndWith(theOther: CharSequence) = assertTrue("Expected the CharSequence $this to end with $theOther", this.endsWith(theOther))
 
-infix fun CharSequence.`should contain`(theOther: CharSequence) = assertTrue("Expected the CharSequence $this to contain $theOther", this.contains(theOther))
-infix fun CharSequence.shouldContain(theOther: CharSequence) = this `should contain` theOther
+infix fun CharSequence.shouldContain(theOther: CharSequence) = assertTrue("Expected the CharSequence $this to contain $theOther", this.contains(theOther))
 
-infix fun CharSequence.`should match`(regex: String) = assertTrue("Expected $this to match $regex", this.matches(Regex(regex)))
-infix fun CharSequence.shouldMatch(regex: String) = this `should match` regex
+infix fun CharSequence.shouldMatch(regex: String) = assertTrue("Expected $this to match $regex", this.matches(Regex(regex)))
 
-infix fun CharSequence.`should match`(regex: Regex) = assertTrue("Expected $this to match ${regex.pattern}", this.matches(regex))
-infix fun CharSequence.shouldMatch(regex: Regex) = this `should match` regex
+infix fun CharSequence.shouldMatch(regex: Regex) = assertTrue("Expected $this to match ${regex.pattern}", this.matches(regex))
 
-fun CharSequence.`should be empty`() = assertTrue("Expected the CharSequence to be empty, but was $this", this.isEmpty())
-fun CharSequence.shouldBeEmpty() = this.`should be empty`()
+fun CharSequence.shouldBeEmpty() = assertTrue("Expected the CharSequence to be empty, but was $this", this.isEmpty())
 
-fun CharSequence?.`should be null or empty`() = assertTrue("Expected $this to be null or empty", this == null || this.isEmpty())
-fun CharSequence?.shouldBeNullOrEmpty() = this.`should be null or empty`()
+fun CharSequence?.shouldBeNullOrEmpty() = assertTrue("Expected $this to be null or empty", this == null || this.isEmpty())
 
-fun CharSequence.`should be blank`() = assertTrue("Expected the CharSequence to be blank, but was $this", this.isBlank())
-fun CharSequence.shouldBeBlank() = this.`should be blank`()
+fun CharSequence.shouldBeBlank() = assertTrue("Expected the CharSequence to be blank, but was $this", this.isBlank())
 
-fun CharSequence?.`should be null or blank`() = assertTrue("Expected $this to be null or blank", this == null || this.isBlank())
-fun CharSequence?.shouldBeNullOrBlank() = this.`should be null or blank`()
+fun CharSequence?.shouldBeNullOrBlank() = assertTrue("Expected $this to be null or blank", this == null || this.isBlank())
 
-infix fun String.`should equal to`(theOther: String) = assertEquals(theOther, this)
-infix fun String.shouldEqualTo(theOther: String) = this `should equal to` theOther
+infix fun String.shouldEqualTo(theOther: String) = assertEquals(theOther, this)
 
-infix fun String.`should not equal to`(theOther: String) = assertNotEquals(theOther, this)
-infix fun String.shouldNotEqualTo(theOther: String) = this `should not equal to` theOther
+infix fun String.shouldNotEqualTo(theOther: String) = assertNotEquals(theOther, this)
 
-infix fun CharSequence.`should not start with`(theOther: CharSequence) = assertFalse("Expected the CharSequence $this to not start with $theOther", this.startsWith(theOther))
-infix fun CharSequence.shouldNotStartWith(theOther: CharSequence) = this `should not start with` theOther
+infix fun CharSequence.shouldNotStartWith(theOther: CharSequence) =assertFalse("Expected the CharSequence $this to not start with $theOther", this.startsWith(theOther))
 
-infix fun CharSequence.`should not end with`(theOther: CharSequence) = assertFalse("Expected the CharSequence $this to not end with $theOther", this.endsWith(theOther))
-infix fun CharSequence.shouldNotEndWith(theOther: CharSequence) = this `should not end with` theOther
+infix fun CharSequence.shouldNotEndWith(theOther: CharSequence) = assertFalse("Expected the CharSequence $this to not end with $theOther", this.endsWith(theOther))
 
-infix fun CharSequence.`should not contain`(theOther: CharSequence) = assertFalse("Expected the CharSequence $this to not contain $theOther", this.contains(theOther))
-infix fun CharSequence.shouldNotContain(theOther: CharSequence) = this `should not contain` theOther
+infix fun CharSequence.shouldNotContain(theOther: CharSequence) = assertFalse("Expected the CharSequence $this to not contain $theOther", this.contains(theOther))
 
-infix fun CharSequence.`should not match`(regex: String) = assertFalse("Expected $this to not match $regex", this.matches(Regex(regex)))
-infix fun CharSequence.shouldNotMatch(regex: String) = this `should not match` regex
+infix fun CharSequence.shouldNotMatch(regex: String) = assertFalse("Expected $this to not match $regex", this.matches(Regex(regex)))
 
-infix fun CharSequence.`should not match`(regex: Regex) = assertFalse("Expected $this to not match ${regex.pattern}", this.matches(regex))
-infix fun CharSequence.shouldNotMatch(regex: Regex) = this `should not match` regex
+infix fun CharSequence.shouldNotMatch(regex: Regex) = assertFalse("Expected $this to not match ${regex.pattern}", this.matches(regex))
 
-fun CharSequence.`should not be empty`() = assertTrue("Expected the CharSequence to not be empty", this.isNotEmpty())
-fun CharSequence.shouldNotBeEmpty() = this.`should not be empty`()
+fun CharSequence.shouldNotBeEmpty() = assertTrue("Expected the CharSequence to not be empty", this.isNotEmpty())
 
-fun CharSequence?.`should not be null or empty`() {
-    this.`should not be null`()
-    this!!.`should not be empty`()
+fun CharSequence?.shouldNotBeNullOrEmpty() {
+    this.shouldNotBeNull()
+    this!!.shouldNotBeEmpty()
 }
-fun CharSequence?.shouldNotBeNullOrEmpty() = this.`should not be null or empty`()
 
-fun CharSequence.`should not be blank`() = assertTrue("Expected the CharSequence to not be blank", this.isNotBlank())
-fun CharSequence.shouldNotBeBlank() = this.`should not be blank`()
+fun CharSequence.shouldNotBeBlank() = assertTrue("Expected the CharSequence to not be blank", this.isNotBlank())
 
-fun CharSequence?.`should not be null or blank`() {
-    this.`should not be null`()
-    this!!.`should not be blank`()
+fun CharSequence?.shouldNotBeNullOrBlank() {
+    this.shouldNotBeNull()
+    this!!.shouldNotBeBlank()
 }
-fun CharSequence?.shouldNotBeNullOrBlank() = this.`should not be null or blank`()

--- a/src/main/kotlin/org/amshove/kluent/CharSequenceBacktick.kt
+++ b/src/main/kotlin/org/amshove/kluent/CharSequenceBacktick.kt
@@ -1,0 +1,41 @@
+package org.amshove.kluent
+
+infix fun CharSequence.`should start with`(theOther: CharSequence) = this.shouldStartWith(theOther)
+
+infix fun CharSequence.`should end with`(theOther: CharSequence) = this.shouldEndWith(theOther)
+
+infix fun CharSequence.`should contain`(theOther: CharSequence) = this.shouldContain(theOther)
+
+infix fun CharSequence.`should match`(regex: String) = this.shouldMatch(regex)
+
+infix fun CharSequence.`should match`(regex: Regex) = this.shouldMatch(regex)
+
+fun CharSequence.`should be empty`() = this.shouldBeEmpty()
+
+fun CharSequence?.`should be null or empty`() = this.shouldBeNullOrEmpty()
+
+fun CharSequence.`should be blank`() = this.shouldBeBlank()
+
+fun CharSequence?.`should be null or blank`() = this.shouldBeNullOrBlank()
+
+infix fun String.`should equal to`(theOther: String) = this.shouldEqualTo(theOther)
+
+infix fun String.`should not equal to`(theOther: String) = this.shouldNotEqualTo(theOther)
+
+infix fun CharSequence.`should not start with`(theOther: CharSequence) = this.shouldNotStartWith(theOther)
+
+infix fun CharSequence.`should not end with`(theOther: CharSequence) = this.shouldNotEndWith(theOther)
+
+infix fun CharSequence.`should not contain`(theOther: CharSequence) = this.shouldNotContain(theOther)
+
+infix fun CharSequence.`should not match`(regex: String) = this.shouldNotMatch(regex)
+
+infix fun CharSequence.`should not match`(regex: Regex) = this.shouldNotMatch(regex)
+
+fun CharSequence.`should not be empty`() = this.shouldNotBeEmpty()
+
+fun CharSequence?.`should not be null or empty`() = this.shouldNotBeNullOrEmpty()
+
+fun CharSequence.`should not be blank`() = this.shouldNotBeBlank()
+
+fun CharSequence?.`should not be null or blank`() = this.shouldNotBeNullOrBlank()

--- a/src/main/kotlin/org/amshove/kluent/Collections.kt
+++ b/src/main/kotlin/org/amshove/kluent/Collections.kt
@@ -2,309 +2,207 @@ package org.amshove.kluent
 
 import org.junit.Assert.*
 
-infix fun <T> Array<T>.shouldContain(theThing: T) = this `should contain` theThing
-infix fun <T> Array<T>.`should contain`(theThing: T) = if (this.contains(theThing)) Unit else fail("$this should contain $theThing", "$theThing", join(this))
+infix fun <T> Array<T>.shouldContain(theThing: T) = if (this.contains(theThing)) Unit else fail("$this should contain $theThing", "$theThing", join(this))
 
 infix fun <T> Array<T>.shouldContainAll(things: Array<T>) = things.forEach { shouldContain(it) }
-infix fun <T> Array<T>.`should contain all`(things: Array<T>) = this.shouldContainAll(things)
 
-infix fun <T> Array<T>.`should not contain`(theThing: T) = if (!this.contains(theThing)) Unit else fail("$this should not contain $theThing", "the Array to not contain $theThing", join(this))
-infix fun <T> Array<T>.shouldNotContain(theThing: T) = this `should not contain` theThing
+infix fun <T> Array<T>.shouldNotContain(theThing: T) = if (!this.contains(theThing)) Unit else fail("$this should not contain $theThing", "the Array to not contain $theThing", join(this))
 
 infix fun <T> Array<T>.shouldNotContainAny(things: Array<T>) = things.forEach { shouldNotContain(it) }
-infix fun <T> Array<T>.`should not contain any`(things: Array<T>) = this.shouldNotContainAny(things)
 
-infix fun <T> Array<T>?.`should equal`(theOther: Array<T>?) = assertArrayEquals(theOther, this)
-infix fun <T> Array<T>?.shouldEqual(theOther: Array<T>?) = this `should equal` theOther
+infix fun <T> Array<T>?.shouldEqual(theOther: Array<T>?) = assertArrayEquals(theOther, this)
 
-fun <T> Array<T>.`should be empty`() = assertEmpty(this.toList(), "Array")
-fun <T> Array<T>.shouldBeEmpty() = this.`should be empty`()
+fun <T> Array<T>.shouldBeEmpty() = assertEmpty(this.toList(), "Array")
 
-fun <T> Array<T>.`should not be empty`() = assertNotEmpty(this.toList(), "Array")
-fun <T> Array<T>.shouldNotBeEmpty() = this.`should not be empty`()
+fun <T> Array<T>.shouldNotBeEmpty() = assertNotEmpty(this.toList(), "Array")
 
-infix fun IntArray.`should equal`(theOther: IntArray) = assertArrayEquals(theOther, this)
-infix fun IntArray.shouldEqual(theOther: IntArray) = this `should equal` theOther
+infix fun IntArray.shouldEqual(theOther: IntArray) = assertArrayEquals(this, theOther)
 
-fun IntArray.`should be empty`() = this.toTypedArray().`should be empty`()
-fun IntArray.shouldBeEmpty() = this.`should be empty`()
+fun IntArray.shouldBeEmpty() = this.toTypedArray().shouldBeEmpty()
 
-fun IntArray.`should not be empty`() = this.toTypedArray().`should not be empty`()
-fun IntArray.shouldNotBeEmpty() = this.`should not be empty`()
+fun IntArray.shouldNotBeEmpty() = this.toTypedArray().shouldNotBeEmpty()
 
-infix fun IntArray.`should contain`(theThing: Int) = this.toTypedArray() `should contain` theThing
-infix fun IntArray.shouldContain(theThing: Int) = this `should contain` theThing
+infix fun IntArray.shouldContain(theThing: Int) = this.toTypedArray() shouldContain theThing
 
 infix fun IntArray.shouldContainAll(things: IntArray) = things.forEach { shouldContain(it) }
-infix fun IntArray.`should contain all`(things: IntArray) = this.shouldContainAll(things)
 
-infix fun IntArray.`should not contain`(theThing: Int) = this.toTypedArray() `should not contain` theThing
-infix fun IntArray.shouldNotContain(theThing: Int) = this `should not contain` theThing
+infix fun IntArray.shouldNotContain(theThing: Int) = this.toTypedArray() shouldNotContain theThing
 
 infix fun IntArray.shouldNotContainAny(things: IntArray) = things.forEach { shouldNotContain(it) }
-infix fun IntArray.`should not contain any`(things: IntArray) = this.shouldNotContainAny(things)
 
-infix fun Int.`should be in`(theArray: IntArray) = this `should be in` theArray.toTypedArray()
-infix fun Int.shouldBeIn(theArray: IntArray) = this `should be in` theArray
+infix fun Int.shouldBeIn(theArray: IntArray) = this shouldBeIn theArray.toTypedArray()
 
-infix fun Int.`should not be in`(theArray: IntArray) = this `should not be in` theArray.toTypedArray()
-infix fun Int.shouldNotBeIn(theArray: IntArray) = this `should not be in` theArray
+infix fun Int.shouldNotBeIn(theArray: IntArray) = this shouldNotBeIn theArray.toTypedArray()
 
-infix fun BooleanArray.`should equal`(theOther: BooleanArray) = assertArrayEquals(theOther, this)
-infix fun BooleanArray.shouldEqual(theOther: BooleanArray) = this `should equal` theOther
+infix fun BooleanArray.shouldEqual(theOther: BooleanArray) = assertArrayEquals(this, theOther)
 
-fun BooleanArray.`should be empty`() = this.toTypedArray().`should be empty`()
-fun BooleanArray.shouldBeEmpty() = this.`should be empty`()
+fun BooleanArray.shouldBeEmpty() = this.toTypedArray().shouldBeEmpty()
 
-fun BooleanArray.`should not be empty`() = this.toTypedArray().`should not be empty`()
-fun BooleanArray.shouldNotBeEmpty() = this.`should not be empty`()
+fun BooleanArray.shouldNotBeEmpty() = this.toTypedArray().shouldNotBeEmpty()
 
-infix fun BooleanArray.`should contain`(theThing: Boolean) = this.toTypedArray() `should contain` theThing
-infix fun BooleanArray.shouldContain(theThing: Boolean) = this `should contain` theThing
+infix fun BooleanArray.shouldContain(theThing: Boolean) = this.toTypedArray() shouldContain theThing
 
 infix fun BooleanArray.shouldContainAll(things: BooleanArray) = things.forEach { shouldContain(it) }
-infix fun BooleanArray.`should contain all`(things: BooleanArray) = this.shouldContainAll(things)
 
-infix fun BooleanArray.`should not contain`(theThing: Boolean) = this.toTypedArray() `should not contain` theThing
-infix fun BooleanArray.shouldNotContain(theThing: Boolean) = this `should not contain` theThing
+infix fun BooleanArray.shouldNotContain(theThing: Boolean) = this.toTypedArray() shouldNotContain theThing
 
 infix fun BooleanArray.shouldNotContainAny(things: BooleanArray) = things.forEach { shouldNotContain(it) }
-infix fun BooleanArray.`should not contain any`(things: BooleanArray) = this.shouldNotContainAny(things)
 
-infix fun Boolean.`should be in`(theArray: BooleanArray) = this `should be in` theArray.toTypedArray()
-infix fun Boolean.shouldBeIn(theArray: BooleanArray) = this `should be in` theArray
+infix fun Boolean.shouldBeIn(theArray: BooleanArray) = this shouldBeIn theArray.toTypedArray()
 
-infix fun Boolean.`should not be in`(theArray: BooleanArray) = this `should not be in` theArray.toTypedArray()
-infix fun Boolean.shouldNotBeIn(theArray: BooleanArray) = this `should not be in` theArray
+infix fun Boolean.shouldNotBeIn(theArray: BooleanArray) = this shouldNotBeIn theArray.toTypedArray()
 
-infix fun ByteArray.`should equal`(theOther: ByteArray) = assertArrayEquals(theOther, this)
-infix fun ByteArray.shouldEqual(theOther: ByteArray) = this `should equal` theOther
+infix fun ByteArray.shouldEqual(theOther: ByteArray) = assertArrayEquals(this, theOther)
 
-fun ByteArray.`should be empty`() = this.toTypedArray().`should be empty`()
-fun ByteArray.shouldBeEmpty() = this.`should be empty`()
+fun ByteArray.shouldBeEmpty() = this.toTypedArray().shouldBeEmpty()
 
-fun ByteArray.`should not be empty`() = this.toTypedArray().`should not be empty`()
-fun ByteArray.shouldNotBeEmpty() = this.`should not be empty`()
+fun ByteArray.shouldNotBeEmpty() = this.toTypedArray().shouldNotBeEmpty()
 
-infix fun ByteArray.`should contain`(theThing: Byte) = this.toTypedArray() `should contain` theThing
-infix fun ByteArray.shouldContain(theThing: Byte) = this `should contain` theThing
+infix fun ByteArray.shouldContain(theThing: Byte) = this.toTypedArray() shouldContain theThing
 
 infix fun ByteArray.shouldContainAll(things: ByteArray) = things.forEach { shouldContain(it) }
-infix fun ByteArray.`should contain all`(things: ByteArray) = this.shouldContainAll(things)
 
-infix fun ByteArray.`should not contain`(theThing: Byte) = this.toTypedArray() `should not contain` theThing
-infix fun ByteArray.shouldNotContain(theThing: Byte) = this `should not contain` theThing
+infix fun ByteArray.shouldNotContain(theThing: Byte) = this.toTypedArray() shouldNotContain theThing
 
 infix fun ByteArray.shouldNotContainAny(things: ByteArray) = things.forEach { shouldNotContain(it) }
-infix fun ByteArray.`should not contain any`(things: ByteArray) = this.shouldNotContainAny(things)
 
-infix fun Byte.`should be in`(theArray: ByteArray) = this `should be in` theArray.toTypedArray()
-infix fun Byte.shouldBeIn(theArray: ByteArray) = this `should be in` theArray
+infix fun Byte.shouldBeIn(theArray: ByteArray) = this shouldBeIn theArray.toTypedArray()
 
-infix fun Byte.`should not be in`(theArray: ByteArray) = this `should not be in` theArray.toTypedArray()
-infix fun Byte.shouldNotBeIn(theArray: ByteArray) = this `should not be in` theArray
+infix fun Byte.shouldNotBeIn(theArray: ByteArray) = this shouldNotBeIn theArray.toTypedArray()
 
-infix fun CharArray.`should equal`(theOther: CharArray) = assertArrayEquals(theOther, this)
-infix fun CharArray.shouldEqual(theOther: CharArray) = this `should equal` theOther
+infix fun CharArray.shouldEqual(theOther: CharArray) = assertArrayEquals(this, theOther)
 
-infix fun CharArray.`should not equal`(theOther: CharArray) = this.toTypedArray() `should not equal` theOther.toTypedArray()
-infix fun CharArray.shouldNotEqual(theOther: CharArray) = this `should not equal` theOther
+infix fun CharArray.shouldNotEqual(theOther: CharArray) = this.toTypedArray() shouldNotEqual theOther.toTypedArray()
 
-fun CharArray.`should be empty`() = this.toTypedArray().`should be empty`()
-fun CharArray.shouldBeEmpty() = this.`should be empty`()
+fun CharArray.shouldBeEmpty() = this.toTypedArray().shouldBeEmpty()
 
-fun CharArray.`should not be empty`() = this.toTypedArray().`should not be empty`()
-fun CharArray.shouldNotBeEmpty() = this.`should not be empty`()
+fun CharArray.shouldNotBeEmpty() = this.toTypedArray().shouldNotBeEmpty()
 
-infix fun CharArray.`should contain`(theThing: Char) = this.toTypedArray() `should contain` theThing
-infix fun CharArray.shouldContain(theThing: Char) = this `should contain` theThing
+infix fun CharArray.shouldContain(theThing: Char) = this.toTypedArray() shouldContain theThing
 
 infix fun CharArray.shouldContainAll(things: CharArray) = things.forEach { shouldContain(it) }
-infix fun CharArray.`should contain all`(things: CharArray) = this.shouldContainAll(things)
 
-infix fun CharArray.`should not contain`(theThing: Char) = this.toTypedArray() `should not contain` theThing
-infix fun CharArray.shouldNotContain(theThing: Char) = this `should not contain` theThing
+infix fun CharArray.shouldNotContain(theThing: Char) = this.toTypedArray() shouldNotContain theThing
 
 infix fun CharArray.shouldNotContainAny(things: CharArray) = things.forEach { shouldNotContain(it) }
-infix fun CharArray.`should not contain any`(things: CharArray) = this.shouldNotContainAny(things)
 
-infix fun Char.`should be in`(theArray: CharArray) = this `should be in` theArray.toTypedArray()
-infix fun Char.shouldBeIn(theArray: CharArray) = this `should be in` theArray
+infix fun Char.shouldBeIn(theArray: CharArray) = this shouldBeIn theArray.toTypedArray()
 
-infix fun Char.`should not be in`(theArray: CharArray) = this `should not be in` theArray.toTypedArray()
-infix fun Char.shouldNotBeIn(theArray: CharArray) = this `should not be in` theArray
+infix fun Char.shouldNotBeIn(theArray: CharArray) = this shouldNotBeIn theArray.toTypedArray()
 
-infix fun DoubleArray.`should equal`(theOther: DoubleArray) = assertArrayEquals(theOther.toTypedArray(), this.toTypedArray())
-infix fun DoubleArray.shouldEqual(theOther: DoubleArray) = this `should equal` theOther
+infix fun DoubleArray.shouldEqual(theOther: DoubleArray) = assertArrayEquals(this.toTypedArray(), theOther.toTypedArray())
 
-fun DoubleArray.`should be empty`() = this.toTypedArray().`should be empty`()
-fun DoubleArray.shouldBeEmpty() = this.`should be empty`()
+fun DoubleArray.shouldBeEmpty() = this.toTypedArray().shouldBeEmpty()
 
-fun DoubleArray.`should not be empty`() = this.toTypedArray().`should not be empty`()
-fun DoubleArray.shouldNotBeEmpty() = this.`should not be empty`()
+fun DoubleArray.shouldNotBeEmpty() = this.toTypedArray().shouldNotBeEmpty()
 
-infix fun DoubleArray.`should contain`(theThing: Double) = this.toTypedArray() `should contain` theThing
-infix fun DoubleArray.shouldContain(theThing: Double) = this `should contain` theThing
+infix fun DoubleArray.shouldContain(theThing: Double) = this.toTypedArray() shouldContain theThing
 
 infix fun DoubleArray.shouldContainAll(things: DoubleArray) = things.forEach { shouldContain(it) }
-infix fun DoubleArray.`should contain all`(things: DoubleArray) = this.shouldContainAll(things)
 
-infix fun DoubleArray.`should not contain`(theThing: Double) = this.toTypedArray() `should not contain` theThing
-infix fun DoubleArray.shouldNotContain(theThing: Double) = this `should not contain` theThing
+infix fun DoubleArray.shouldNotContain(theThing: Double) = this.toTypedArray() shouldNotContain theThing
 
 infix fun DoubleArray.shouldNotContainAny(things: DoubleArray) = things.forEach { shouldNotContain(it) }
-infix fun DoubleArray.`should not contain any`(things: DoubleArray) = this.shouldNotContainAny(things)
 
-infix fun Double.`should be in`(theArray: DoubleArray) = this `should be in` theArray.toTypedArray()
-infix fun Double.shouldBeIn(theArray: DoubleArray) = this `should be in` theArray
+infix fun Double.shouldBeIn(theArray: DoubleArray) = this shouldBeIn theArray.toTypedArray()
 
-infix fun Double.`should not be in`(theArray: DoubleArray) = this `should not be in` theArray.toTypedArray()
-infix fun Double.shouldNotBeIn(theArray: DoubleArray) = this `should not be in` theArray
+infix fun Double.shouldNotBeIn(theArray: DoubleArray) = this shouldNotBeIn theArray.toTypedArray()
 
-infix fun FloatArray.`should equal`(theOther: FloatArray) = assertArrayEquals(theOther.toTypedArray(), this.toTypedArray())
-infix fun FloatArray.shouldEqual(theOther: FloatArray) = this `should equal` theOther
+infix fun FloatArray.shouldEqual(theOther: FloatArray) = assertArrayEquals(this.toTypedArray(), theOther.toTypedArray())
 
-fun FloatArray.`should be empty`() = this.toTypedArray().`should be empty`()
-fun FloatArray.shouldBeEmpty() = this.`should be empty`()
+fun FloatArray.shouldBeEmpty() = this.toTypedArray().shouldBeEmpty()
 
-fun FloatArray.`should not be empty`() = this.toTypedArray().`should not be empty`()
-fun FloatArray.shouldNotBeEmpty() = this.`should not be empty`()
+fun FloatArray.shouldNotBeEmpty() = this.toTypedArray().shouldNotBeEmpty()
 
-infix fun FloatArray.`should contain`(theThing: Float) = this.toTypedArray() `should contain` theThing
-infix fun FloatArray.shouldContain(theThing: Float) = this `should contain` theThing
+infix fun FloatArray.shouldContain(theThing: Float) = this.toTypedArray() shouldContain theThing
 
 infix fun FloatArray.shouldContainAll(things: FloatArray) = things.forEach { shouldContain(it) }
-infix fun FloatArray.`should contain all`(things: FloatArray) = this.shouldContainAll(things)
 
-infix fun FloatArray.`should not contain`(theThing: Float) = this.toTypedArray() `should not contain` theThing
-infix fun FloatArray.shouldNotContain(theThing: Float) = this `should not contain` theThing
+infix fun FloatArray.shouldNotContain(theThing: Float) = this.toTypedArray() shouldNotContain theThing
 
 infix fun FloatArray.shouldNotContainAny(things: FloatArray) = things.forEach { shouldNotContain(it) }
-infix fun FloatArray.`should not contain any`(things: FloatArray) = this.shouldNotContainAny(things)
 
-infix fun Float.`should be in`(theArray: FloatArray) = this `should be in` theArray.toTypedArray()
-infix fun Float.shouldBeIn(theArray: FloatArray) = this `should be in` theArray
+infix fun Float.shouldBeIn(theArray: FloatArray) = this shouldBeIn theArray.toTypedArray()
 
-infix fun Float.`should not be in`(theArray: FloatArray) = this `should not be in` theArray.toTypedArray()
-infix fun Float.shouldNotBeIn(theArray: FloatArray) = this `should not be in` theArray
+infix fun Float.shouldNotBeIn(theArray: FloatArray) = this shouldNotBeIn theArray.toTypedArray()
 
-infix fun LongArray.`should equal`(theOther: LongArray) = assertArrayEquals(theOther, this)
-infix fun LongArray.shouldEqual(theOther: LongArray) = this `should equal` theOther
+infix fun LongArray.shouldEqual(theOther: LongArray) = assertArrayEquals(this, theOther)
 
-fun LongArray.`should be empty`() = this.toTypedArray().`should be empty`()
-fun LongArray.shouldBeEmpty() = this.`should be empty`()
+fun LongArray.shouldBeEmpty() = this.toTypedArray().shouldBeEmpty()
 
-fun LongArray.`should not be empty`() = this.toTypedArray().`should not be empty`()
-fun LongArray.shouldNotBeEmpty() = this.`should not be empty`()
+fun LongArray.shouldNotBeEmpty() = this.toTypedArray().shouldNotBeEmpty()
 
-infix fun LongArray.`should contain`(theThing: Long) = this.toTypedArray() `should contain` theThing
-infix fun LongArray.shouldContain(theThing: Long) = this `should contain` theThing
+infix fun LongArray.shouldContain(theThing: Long) = this.toTypedArray() shouldContain theThing
 
 infix fun LongArray.shouldContainAll(things: LongArray) = things.forEach { shouldContain(it) }
-infix fun LongArray.`should contain all`(things: LongArray) = this.shouldContainAll(things)
 
-infix fun LongArray.`should not contain`(theThing: Long) = this.toTypedArray() `should not contain` theThing
-infix fun LongArray.shouldNotContain(theThing: Long) = this `should not contain` theThing
+infix fun LongArray.shouldNotContain(theThing: Long) = this.toTypedArray() shouldNotContain theThing
 
 infix fun LongArray.shouldNotContainAny(things: LongArray) = things.forEach { shouldNotContain(it) }
-infix fun LongArray.`should not contain any`(things: LongArray) = this.shouldNotContainAny(things)
 
-infix fun Long.`should be in`(theArray: LongArray) = this `should be in` theArray.toTypedArray()
-infix fun Long.shouldBeIn(theArray: LongArray) = this `should be in` theArray
+infix fun Long.shouldBeIn(theArray: LongArray) = this shouldBeIn theArray.toTypedArray()
 
-infix fun Long.`should not be in`(theArray: LongArray) = this `should not be in` theArray.toTypedArray()
-infix fun Long.shouldNotBeIn(theArray: LongArray) = this `should not be in` theArray
+infix fun Long.shouldNotBeIn(theArray: LongArray) = this shouldNotBeIn theArray.toTypedArray()
 
-infix fun ShortArray.`should equal`(theOther: ShortArray) = assertArrayEquals(theOther, this)
-infix fun ShortArray.shouldEqual(theOther: ShortArray) = this `should equal` theOther
+infix fun ShortArray.shouldEqual(theOther: ShortArray) = assertArrayEquals(this, theOther)
 
-fun ShortArray.`should be empty`() = this.toTypedArray().`should be empty`()
-fun ShortArray.shouldBeEmpty() = this.`should be empty`()
+fun ShortArray.shouldBeEmpty() = this.toTypedArray().shouldBeEmpty()
 
-fun ShortArray.`should not be empty`() = this.toTypedArray().`should not be empty`()
-fun ShortArray.shouldNotBeEmpty() = this.`should not be empty`()
+fun ShortArray.shouldNotBeEmpty() = this.toTypedArray().shouldNotBeEmpty()
 
-infix fun ShortArray.`should contain`(theThing: Short) = this.toTypedArray() `should contain` theThing
-infix fun ShortArray.shouldContain(theThing: Short) = this `should contain` theThing
+infix fun ShortArray.shouldContain(theThing: Short) = this.toTypedArray() shouldContain theThing
 
 infix fun ShortArray.shouldContainAll(things: ShortArray) = things.forEach { shouldContain(it) }
-infix fun ShortArray.`should contain all`(things: ShortArray) = this.shouldContainAll(things)
 
-infix fun ShortArray.`should not contain`(theThing: Short) = this.toTypedArray() `should not contain` theThing
-infix fun ShortArray.shouldNotContain(theThing: Short) = this `should not contain` theThing
+infix fun ShortArray.shouldNotContain(theThing: Short) = this.toTypedArray() shouldNotContain theThing
 
 infix fun ShortArray.shouldNotContainAny(things: ShortArray) = things.forEach { shouldNotContain(it) }
-infix fun ShortArray.`should not contain any`(things: ShortArray) = this.shouldNotContainAny(things)
 
-infix fun Short.`should be in`(theArray: ShortArray) = this `should be in` theArray.toTypedArray()
-infix fun Short.shouldBeIn(theArray: ShortArray) = this `should be in` theArray
+infix fun Short.shouldBeIn(theArray: ShortArray) = this shouldBeIn theArray.toTypedArray()
 
-infix fun Short.`should not be in`(theArray: ShortArray) = this `should not be in` theArray.toTypedArray()
-infix fun Short.shouldNotBeIn(theArray: ShortArray) = this `should not be in` theArray
+infix fun Short.shouldNotBeIn(theArray: ShortArray) = this shouldNotBeIn theArray.toTypedArray()
 
-
-infix fun <T> Iterable<T>.`should contain`(theThing: T) = if (this.contains(theThing)) Unit else fail("$this should contain $theThing", "$theThing", join(this))
-infix fun <T> Iterable<T>.shouldContain(theThing: T) = this `should contain` theThing
+infix fun <T> Iterable<T>.shouldContain(theThing: T) = if (this.contains(theThing)) Unit else fail("$this should contain $theThing", "$theThing", join(this))
 
 infix fun <T> Iterable<T>.shouldContainAll(things: Iterable<T>) = things.forEach { shouldContain(it) }
-infix fun <T> Iterable<T>.`should contain all`(things: Iterable<T>) = this.shouldContainAll(things)
 
-infix fun <T> Iterable<T>.`should not contain`(theThing: T) = if (!this.contains(theThing)) Unit else fail("$this should not contain $theThing", "the Iterable to not contain $theThing", join(this))
-infix fun <T> Iterable<T>.shouldNotContain(theThing: T) = this `should not contain` theThing
+infix fun <T> Iterable<T>.shouldNotContain(theThing: T) = if (!this.contains(theThing)) Unit else fail("$this should not contain $theThing", "the Iterable to not contain $theThing", join(this))
 
 infix fun <T> Iterable<T>.shouldNotContainAny(things: Iterable<T>) = things.forEach { shouldNotContain(it) }
-infix fun <T> Iterable<T>.`should not contain any`(things: Iterable<T>) = this.shouldNotContainAny(things)
 
-infix fun <T> Iterable<T>?.`should equal`(theOther: Iterable<T>?) = assertEquals(theOther, this)
-infix fun <T> Iterable<T>?.shouldEqual(theOther: Iterable<T>?) = this `should equal` theOther
+infix fun <T> Iterable<T>?.shouldEqual(theOther: Iterable<T>?) = assertEquals(theOther, this)
 
-fun <T> Iterable<T>.`should be empty`() = assertEmpty(this, "Iterable")
-fun <T> Iterable<T>.shouldBeEmpty() = this.`should be empty`()
+fun <T> Iterable<T>.shouldBeEmpty() = assertEmpty(this, "Iterable")
 
-fun <T> Iterable<T>.`should not be empty`() = assertNotEmpty(this, "Iterable")
-fun <T> Iterable<T>.shouldNotBeEmpty() = this.`should not be empty`()
+fun <T> Iterable<T>.shouldNotBeEmpty() = assertNotEmpty(this, "Iterable")
 
-infix fun <R, T> Map<R, T>.`should have key`(theKey: R) = if (this.containsKey(theKey)) Unit else fail("$this should contain key $theKey", "$theKey", join(this.keys))
-infix fun <R, T> Map<R, T>.shouldHaveKey(theKey: R) = this `should have key` theKey
+infix fun <R, T> Map<R, T>.shouldHaveKey(theKey: R) = if (this.containsKey(theKey)) Unit else fail("$this should contain key $theKey", "$theKey", join(this.keys))
 
-infix fun <R, T> Map<R, T>.`should not have key`(theKey: R) = if (!this.containsKey(theKey)) Unit else fail("$this should not contain key $theKey", "the map to not have the key $theKey", join(this.keys))
-infix fun <R, T> Map<R, T>.shouldNotHaveKey(theKey: R) = this `should not have key` theKey
+infix fun <R, T> Map<R, T>.shouldNotHaveKey(theKey: R) = if (!this.containsKey(theKey)) Unit else fail("$this should not contain key $theKey", "the map to not have the key $theKey", join(this.keys))
 
-infix fun <R, T> Map<R, T>.`should have value`(theValue: T) = if (this.values.contains(theValue)) Unit else fail("$this should contain the value $theValue", "$theValue", join(this.values))
-infix fun <R, T> Map<R, T>.shouldHaveValue(theValue: T) = this `should have value` theValue
+infix fun <R, T> Map<R, T>.shouldHaveValue(theValue: T) = if (this.values.contains(theValue)) Unit else fail("$this should contain the value $theValue", "$theValue", join(this.values))
 
-infix fun <R, T> Map<R, T>.`should not have value`(theValue: T) = if (!this.values.contains(theValue)) Unit else fail("$this should not contain the value $theValue", "the map to not have the value $theValue", join(this.values))
-infix fun <R, T> Map<R, T>.shouldNotHaveValue(theValue: T) = this `should not have value` theValue
+infix fun <R, T> Map<R, T>.shouldNotHaveValue(theValue: T) = if (!this.values.contains(theValue)) Unit else fail("$this should not contain the value $theValue", "the map to not have the value $theValue", join(this.values))
 
-infix fun <R, T> Map<R, T>.`should contain`(theThing: Pair<R, T>) = if (this[theThing.first] == theThing.second) Unit else fail("$this should contain $theThing", "$theThing", join(this))
-infix fun <R, T> Map<R, T>.shouldContain(thePair: Pair<R, T>) = this `should contain` thePair
+infix fun <R, T> Map<R, T>.shouldContain(theThing: Pair<R, T>) = if (this[theThing.first] == theThing.second) Unit else fail("$this should contain $theThing", "$theThing", join(this))
 
 infix fun <R, T> Map<R, T>.shouldContainAll(things: Map<R, T>) = things.forEach { shouldContain(it.toPair()) }
-infix fun <R, T> Map<R, T>.`should contain all`(things: Map<R, T>) = this.shouldContainAll(things)
 
-infix fun <R, T> Map<R, T>.`should not contain`(theThing: Pair<R, T>) = if (this[theThing.first] != theThing.second) Unit else fail("$this should not contain $theThing", "the map to not contain the pair $theThing", join(this))
-infix fun <R, T> Map<R, T>.shouldNotContain(thePair: Pair<R, T>) = this `should not contain` thePair
+infix fun <R, T> Map<R, T>.shouldNotContain(theThing: Pair<R, T>) = if (this[theThing.first] != theThing.second) Unit else fail("$this should not contain $theThing", "the map to not contain the pair $theThing", join(this))
 
 infix fun <R, T> Map<R, T>.shouldNotContainAny(things: Map<R, T>) = things.forEach { shouldNotContain(it.toPair()) }
-infix fun <R, T> Map<R, T>.`should not contain any`(things: Map<R, T>) = this.shouldNotContainAny(things)
 
-fun <R, T> Map<R, T>.`should be empty`() = assertEmpty(this.toList(), "Map")
-fun <R, T> Map<R, T>.shouldBeEmpty() = this.`should be empty`()
+fun <R, T> Map<R, T>.shouldBeEmpty() = assertEmpty(this.toList(), "Map")
 
-fun <R, T> Map<R, T>.`should not be empty`() = assertNotEmpty(this.toList(), "Map")
-fun <R, T> Map<R, T>.shouldNotBeEmpty() = this.`should not be empty`()
+fun <R, T> Map<R, T>.shouldNotBeEmpty() = assertNotEmpty(this.toList(), "Map")
 
-infix fun <T> Any?.`should not be in`(array: Array<T>) = if (!array.contains(this)) Unit else fail("$this should not be in $array", "the value $this to not be in the Array", join(array))
-infix fun <T> Any?.shouldNotBeIn(array: Array<T>) = this `should not be in` array
+infix fun <T> Any?.shouldNotBeIn(array: Array<T>) = if (!array.contains(this)) Unit else fail("$this should not be in $array", "the value $this to not be in the Array", join(array))
 
-infix fun <T> Any?.`should be in`(iterable: Iterable<T>) = if (iterable.contains(this)) Unit else fail("$this should be in $iterable", "$this", join(iterable))
-infix fun <T> Any?.shouldBeIn(iterable: Iterable<T>) = this `should be in` iterable
+infix fun <T> Any?.shouldBeIn(iterable: Iterable<T>) = if (iterable.contains(this)) Unit else fail("$this should be in $iterable", "$this", join(iterable))
 
-infix fun <T> Any?.`should not be in`(iterable: Iterable<T>) = if (!iterable.contains(this)) Unit else fail("$this should not be in $iterable", "the value $this to not be in the Iterable", join(iterable))
-infix fun <T> Any?.shouldNotBeIn(iterable: Iterable<T>) = this `should not be in` iterable
+infix fun <T> Any?.shouldNotBeIn(iterable: Iterable<T>) = if (!iterable.contains(this)) Unit else fail("$this should not be in $iterable", "the value $this to not be in the Iterable", join(iterable))
 
-infix fun <T> Any?.`should be in`(array: Array<T>) = if (array.contains(this)) Unit else fail("$this should be in $array", "$this", join(array))
-infix fun <T> Any?.shouldBeIn(array: Array<T>) = this `should be in` array
+infix fun <T> Any?.shouldBeIn(array: Array<T>) = if (array.contains(this)) Unit else fail("$this should be in $array", "$this", join(array))
 
-private fun <T> assertEmpty(iterable: Iterable<T>, collectionType: String) = assertTrue("Expected the $collectionType to be empty, but has ${iterable.count()} elements", iterable.count() == 0)
-private fun <T> assertNotEmpty(iterable: Iterable<T>, collectionType: String) = assertTrue("Expected the $collectionType to contain elements, but is empty", iterable.count() > 0)
+internal fun <T> assertEmpty(iterable: Iterable<T>, collectionType: String) = assertTrue("Expected the $collectionType to be empty, but has ${iterable.count()} elements", iterable.count() == 0)
+internal fun <T> assertNotEmpty(iterable: Iterable<T>, collectionType: String) = assertTrue("Expected the $collectionType to contain elements, but is empty", iterable.count() > 0)

--- a/src/main/kotlin/org/amshove/kluent/CollectionsBacktick.kt
+++ b/src/main/kotlin/org/amshove/kluent/CollectionsBacktick.kt
@@ -1,0 +1,201 @@
+package org.amshove.kluent
+
+infix fun <T> Array<T>.`should contain`(theThing: T) = this.shouldContain(theThing)
+
+infix fun <T> Array<T>.`should contain all`(things: Array<T>) = this.shouldContainAll(things)
+
+infix fun <T> Array<T>.`should not contain`(theThing: T) = this.shouldNotContain(theThing)
+
+infix fun <T> Array<T>.`should not contain any`(things: Array<T>) = this.shouldNotContainAny(things)
+
+infix fun <T> Array<T>?.`should equal`(theOther: Array<T>?) = this.shouldEqual(theOther)
+
+fun <T> Array<T>.`should be empty`() = this.shouldBeEmpty()
+
+fun <T> Array<T>.`should not be empty`() = this.shouldNotBeEmpty()
+
+infix fun IntArray.`should equal`(theOther: IntArray) = this.shouldEqual(theOther)
+
+fun IntArray.`should be empty`() = this.shouldBeEmpty()
+
+fun IntArray.`should not be empty`() = this.shouldNotBeEmpty()
+
+infix fun IntArray.`should contain`(theThing: Int) = this.shouldContain(theThing)
+
+infix fun IntArray.`should contain all`(things: IntArray) = this.shouldContainAll(things)
+
+infix fun IntArray.`should not contain`(theThing: Int) = this.shouldNotContain(theThing)
+
+infix fun IntArray.`should not contain any`(things: IntArray) = this.shouldNotContainAny(things)
+
+infix fun Int.`should be in`(theArray: IntArray) = this.shouldBeIn(theArray)
+
+infix fun Int.`should not be in`(theArray: IntArray) = this.shouldNotBeIn(theArray)
+
+infix fun BooleanArray.`should equal`(theOther: BooleanArray) = this.shouldEqual(theOther)
+
+fun BooleanArray.`should be empty`() = this.shouldBeEmpty()
+
+fun BooleanArray.`should not be empty`() = this.shouldNotBeEmpty()
+
+infix fun BooleanArray.`should contain`(theThing: Boolean) = this.shouldContain(theThing)
+
+infix fun BooleanArray.`should contain all`(things: BooleanArray) = this.shouldContainAll(things)
+
+infix fun BooleanArray.`should not contain`(theThing: Boolean) = this.shouldNotContain(theThing)
+
+infix fun BooleanArray.`should not contain any`(things: BooleanArray) = this.shouldNotContainAny(things)
+
+infix fun Boolean.`should be in`(theArray: BooleanArray) = this.shouldBeIn(theArray)
+
+infix fun Boolean.`should not be in`(theArray: BooleanArray) = this.shouldNotBeIn(theArray)
+
+infix fun ByteArray.`should equal`(theOther: ByteArray) = this.shouldEqual(theOther)
+
+fun ByteArray.`should be empty`() = this.shouldBeEmpty()
+
+fun ByteArray.`should not be empty`() = this.shouldNotBeEmpty()
+
+infix fun ByteArray.`should contain`(theThing: Byte) = this.shouldContain(theThing)
+
+infix fun ByteArray.`should contain all`(things: ByteArray) = this.shouldContainAll(things)
+
+infix fun ByteArray.`should not contain`(theThing: Byte) = this.shouldNotContain(theThing)
+
+infix fun ByteArray.`should not contain any`(things: ByteArray) = this.shouldNotContainAny(things)
+
+infix fun Byte.`should be in`(theArray: ByteArray) = this.shouldBeIn(theArray)
+
+infix fun Byte.`should not be in`(theArray: ByteArray) = this.shouldNotBeIn(theArray)
+
+infix fun CharArray.`should equal`(theOther: CharArray) = this.shouldEqual(theOther)
+
+fun CharArray.`should be empty`() = this.shouldBeEmpty()
+
+fun CharArray.`should not be empty`() = this.shouldNotBeEmpty()
+
+infix fun CharArray.`should contain`(theThing: Char) = this.shouldContain(theThing)
+
+infix fun CharArray.`should contain all`(things: CharArray) = this.shouldContainAll(things)
+
+infix fun CharArray.`should not contain`(theThing: Char) = this.shouldNotContain(theThing)
+
+infix fun CharArray.`should not contain any`(things: CharArray) = this.shouldNotContainAny(things)
+
+infix fun Char.`should be in`(theArray: CharArray) = this.shouldBeIn(theArray)
+
+infix fun Char.`should not be in`(theArray: CharArray) = this.shouldNotBeIn(theArray)
+
+infix fun DoubleArray.`should equal`(theOther: DoubleArray) = this.shouldEqual(theOther)
+
+fun DoubleArray.`should be empty`() = this.shouldBeEmpty()
+
+fun DoubleArray.`should not be empty`() = this.shouldNotBeEmpty()
+
+infix fun DoubleArray.`should contain`(theThing: Double) = this.shouldContain(theThing)
+
+infix fun DoubleArray.`should contain all`(things: DoubleArray) = this.shouldContainAll(things)
+
+infix fun DoubleArray.`should not contain`(theThing: Double) = this.shouldNotContain(theThing)
+
+infix fun DoubleArray.`should not contain any`(things: DoubleArray) = this.shouldNotContainAny(things)
+
+infix fun Double.`should be in`(theArray: DoubleArray) = this.shouldBeIn(theArray)
+
+infix fun Double.`should not be in`(theArray: DoubleArray) = this.shouldNotBeIn(theArray)
+
+infix fun FloatArray.`should equal`(theOther: FloatArray) = this.shouldEqual(theOther)
+
+fun FloatArray.`should be empty`() = this.shouldBeEmpty()
+
+fun FloatArray.`should not be empty`() = this.shouldNotBeEmpty()
+
+infix fun FloatArray.`should contain`(theThing: Float) = this.shouldContain(theThing)
+
+infix fun FloatArray.`should contain all`(things: FloatArray) = this.shouldContainAll(things)
+
+infix fun FloatArray.`should not contain`(theThing: Float) = this.shouldNotContain(theThing)
+
+infix fun FloatArray.`should not contain any`(things: FloatArray) = this.shouldNotContainAny(things)
+
+infix fun Float.`should be in`(theArray: FloatArray) = this.shouldBeIn(theArray)
+
+infix fun Float.`should not be in`(theArray: FloatArray) = this.shouldNotBeIn(theArray)
+
+infix fun LongArray.`should equal`(theOther: LongArray) = this.shouldEqual(theOther)
+
+fun LongArray.`should be empty`() = this.shouldBeEmpty()
+
+fun LongArray.`should not be empty`() = this.shouldNotBeEmpty()
+
+infix fun LongArray.`should contain`(theThing: Long) = this.shouldContain(theThing)
+
+infix fun LongArray.`should contain all`(things: LongArray) = this.shouldContainAll(things)
+
+infix fun LongArray.`should not contain`(theThing: Long) = this.shouldNotContain(theThing)
+
+infix fun LongArray.`should not contain any`(things: LongArray) = this.shouldNotContainAny(things)
+
+infix fun Long.`should be in`(theArray: LongArray) = this.shouldBeIn(theArray)
+
+infix fun Long.`should not be in`(theArray: LongArray) = this.shouldNotBeIn(theArray)
+
+infix fun ShortArray.`should equal`(theOther: ShortArray) = this.shouldEqual(theOther)
+
+fun ShortArray.`should be empty`() = this.shouldBeEmpty()
+
+fun ShortArray.`should not be empty`() = this.shouldNotBeEmpty()
+
+infix fun ShortArray.`should contain`(theThing: Short) = this.shouldContain(theThing)
+
+infix fun ShortArray.`should contain all`(things: ShortArray) = this.shouldContainAll(things)
+
+infix fun ShortArray.`should not contain`(theThing: Short) = this.shouldNotContain(theThing)
+
+infix fun ShortArray.`should not contain any`(things: ShortArray) = this.shouldNotContainAny(things)
+
+infix fun Short.`should be in`(theArray: ShortArray) = this.shouldBeIn(theArray)
+
+infix fun Short.`should not be in`(theArray: ShortArray) = this.shouldNotBeIn(theArray)
+
+infix fun <T> Iterable<T>.`should contain`(theThing: T) = this.shouldContain(theThing)
+
+infix fun <T> Iterable<T>.`should contain all`(things: Iterable<T>) = this.shouldContainAll(things)
+
+infix fun <T> Iterable<T>.`should not contain`(theThing: T) = this.shouldNotContain(theThing)
+
+infix fun <T> Iterable<T>.`should not contain any`(things: Iterable<T>) = this.shouldNotContainAny(things)
+
+infix fun <T> Iterable<T>?.`should equal`(theOther: Iterable<T>?) = this.shouldEqual(theOther)
+
+fun <T> Iterable<T>.`should be empty`() = this.shouldBeEmpty()
+
+fun <T> Iterable<T>.`should not be empty`() = this.shouldNotBeEmpty()
+
+infix fun <R, T> Map<R, T>.`should have key`(theKey: R) = this.shouldHaveKey(theKey)
+
+infix fun <R, T> Map<R, T>.`should not have key`(theKey: R) = this.shouldNotHaveKey(theKey)
+
+infix fun <R, T> Map<R, T>.`should have value`(theValue: T) = this.shouldHaveValue(theValue)
+
+infix fun <R, T> Map<R, T>.`should not have value`(theValue: T) = this.shouldNotHaveValue(theValue)
+
+infix fun <R, T> Map<R, T>.`should contain`(theThing: Pair<R, T>) = this.shouldContain(theThing)
+
+infix fun <R, T> Map<R, T>.`should contain all`(things: Map<R, T>) = this.shouldContainAll(things)
+
+infix fun <R, T> Map<R, T>.`should not contain`(theThing: Pair<R, T>) = this.shouldNotContain(theThing)
+
+infix fun <R, T> Map<R, T>.`should not contain any`(things: Map<R, T>) = this.shouldNotContainAny(things)
+
+fun <R, T> Map<R, T>.`should be empty`() = this.shouldBeEmpty()
+
+fun <R, T> Map<R, T>.`should not be empty`() = this.shouldNotBeEmpty()
+
+infix fun <T> Any?.`should not be in`(array: Array<T>) = this.shouldNotBeIn(array)
+
+infix fun <T> Any?.`should be in`(iterable: Iterable<T>) = this.shouldBeIn(iterable)
+
+infix fun <T> Any?.`should not be in`(iterable: Iterable<T>) = this.shouldNotBeIn(iterable)
+
+infix fun <T> Any?.`should be in`(array: Array<T>) = this.shouldBeIn(array)

--- a/src/main/kotlin/org/amshove/kluent/DateTime.kt
+++ b/src/main/kotlin/org/amshove/kluent/DateTime.kt
@@ -3,89 +3,61 @@ package org.amshove.kluent
 import org.junit.Assert.assertTrue
 import java.time.*
 
-infix fun LocalDateTime.`should be after`(theOther: LocalDateTime) = assertTrue("Expected $this to be after $theOther", this > theOther)
-infix fun LocalDateTime.shouldBeAfter(theOther: LocalDateTime) = this `should be after` theOther
+infix fun LocalDateTime.shouldBeAfter(theOther: LocalDateTime) = assertTrue("Expected $this to be after $theOther", this > theOther)
 
-infix fun LocalDateTime.`should be after`(theTime: LocalTime) = assertTrue("Expected $this to be after $theTime", this.toLocalTime() > theTime)
-infix fun LocalDateTime.shouldBeAfter(theTime: LocalTime) = this `should be after` theTime
+infix fun LocalDateTime.shouldBeAfter(theTime: LocalTime) = assertTrue("Expected $this to be after $theTime", this.toLocalTime() > theTime)
 
-infix fun LocalDateTime.`should be before`(theOther: LocalDateTime) = assertTrue("Expected $this to be before $theOther", this < theOther)
-infix fun LocalDateTime.shouldBeBefore(theOther: LocalDateTime) = this `should be before` theOther
+infix fun LocalDateTime.shouldBeBefore(theOther: LocalDateTime) = assertTrue("Expected $this to be before $theOther", this < theOther)
 
-infix fun LocalDateTime.`should be before`(theTime: LocalTime) = assertTrue("Expected $this to be before $theTime", this.toLocalTime() < theTime)
-infix fun LocalDateTime.shouldBeBefore(theTime: LocalTime) = this `should be before` theTime
+infix fun LocalDateTime.shouldBeBefore(theTime: LocalTime) = assertTrue("Expected $this to be before $theTime", this.toLocalTime() < theTime)
 
-infix fun LocalDateTime.`should be in hour`(theHour: Int) = this.toLocalTime() `should be in hour` theHour
-infix fun LocalDateTime.shouldBeInHour(theHour: Int) = this `should be in hour` theHour
+infix fun LocalDateTime.shouldBeInHour(theHour: Int) = this.toLocalTime() shouldBeInHour theHour
 
-infix fun LocalDateTime.`should not be in hour`(theHour: Int) = this.toLocalTime() `should not be in hour` theHour
-infix fun LocalDateTime.shouldNotBeInHour(theHour: Int) = this `should not be in hour` theHour
+infix fun LocalDateTime.shouldNotBeInHour(theHour: Int) = this.toLocalTime() shouldNotBeInHour theHour
 
-infix fun LocalDateTime.`should be in minute`(theMinute: Int) = this.toLocalTime() `should be in minute` theMinute
-infix fun LocalDateTime.shouldBeInMinute(theMinute: Int) = this `should be in minute` theMinute
+infix fun LocalDateTime.shouldBeInMinute(theMinute: Int) = this.toLocalTime() shouldBeInMinute theMinute
 
-infix fun LocalDateTime.`should not be in minute`(theMinute: Int) = this.toLocalTime() `should not be in minute` theMinute
-infix fun LocalDateTime.shouldNotBeInMinute(theMinute: Int) = this `should not be in minute` theMinute
+infix fun LocalDateTime.shouldNotBeInMinute(theMinute: Int) = this.toLocalTime() shouldNotBeInMinute theMinute
 
-infix fun LocalDateTime.`should be in second`(theSecond: Int) = this.toLocalTime() `should be in second` theSecond
-infix fun LocalDateTime.shouldBeInSecond(theSecond: Int) = this `should be in second` theSecond
+infix fun LocalDateTime.shouldBeInSecond(theSecond: Int) = this.toLocalTime() shouldBeInSecond theSecond
 
-infix fun LocalDateTime.`should not be in second`(theSecond: Int) = this.toLocalTime() `should not be in second` theSecond
-infix fun LocalDateTime.shouldNotBeInSecond(theSecond: Int) = this `should not be in second` theSecond
+infix fun LocalDateTime.shouldNotBeInSecond(theSecond: Int) = this.toLocalTime() shouldNotBeInSecond theSecond
 
-infix fun LocalDateTime.`should be on or after`(theDate: LocalDateTime) = assertTrue("Expected $this to be on or after $theDate", this >= theDate)
-infix fun LocalDateTime.shouldBeOnOrAfter(theDate: LocalDateTime) = this `should be on or after` theDate
+infix fun LocalDateTime.shouldBeOnOrAfter(theDate: LocalDateTime) = assertTrue("Expected $this to be on or after $theDate", this >= theDate)
 
-infix fun LocalDateTime.`should be on or before`(theDate: LocalDateTime) = assertTrue("Expected $this to be on or before $theDate", this <= theDate)
-infix fun LocalDateTime.shouldBeOnOrBefore(theDate: LocalDateTime) = this `should be on or before` theDate
+infix fun LocalDateTime.shouldBeOnOrBefore(theDate: LocalDateTime) = assertTrue("Expected $this to be on or before $theDate", this <= theDate)
 
-infix fun LocalDateTime.`should be on`(theDay: DayOfWeek) = assertTrue("Expected $this to be a $theDay, but was ${this.dayOfWeek}", this.dayOfWeek == theDay)
-infix fun LocalDateTime.shouldBeOn(theDay: DayOfWeek) = this `should be on` theDay
+infix fun LocalDateTime.shouldBeOn(theDay: DayOfWeek) = assertTrue("Expected $this to be a $theDay, but was ${this.dayOfWeek}", this.dayOfWeek == theDay)
 
-infix fun LocalDateTime.`should not be on`(theDay: DayOfWeek) = this.toLocalDate() `should not be on` theDay
-infix fun LocalDateTime.shouldNotBeOn(theDay: DayOfWeek) = this `should not be on` theDay
+infix fun LocalDateTime.shouldNotBeOn(theDay: DayOfWeek) = this.toLocalDate() shouldNotBeOn theDay
 
-infix fun LocalDateTime.`should be in`(theMonth: Month) = assertTrue("Expected $this to be in $theMonth, but was ${this.month}", this.month == theMonth)
-infix fun LocalDateTime.shouldBeIn(theMonth: Month) = this `should be in` theMonth
+infix fun LocalDateTime.shouldBeIn(theMonth: Month) = assertTrue("Expected $this to be in $theMonth, but was ${this.month}", this.month == theMonth)
 
-infix fun LocalDateTime.`should not be in`(theMonth: Month) = this.toLocalDate() `should not be in` theMonth
-infix fun LocalDateTime.shouldNotBeIn(theMonth: Month) = this `should not be in` theMonth
+infix fun LocalDateTime.shouldNotBeIn(theMonth: Month) = this.toLocalDate() shouldNotBeIn theMonth
 
-infix fun LocalDateTime.`should be in year`(theYear: Int) = assertTrue("Expected $this to be in $theYear, but was ${this.year}", this.year == theYear)
-infix fun LocalDateTime.shouldBeInYear(theYear: Int) = this `should be in year` theYear
+infix fun LocalDateTime.shouldBeInYear(theYear: Int) = assertTrue("Expected $this to be in $theYear, but was ${this.year}", this.year == theYear)
 
-infix fun LocalDateTime.`should not be in year`(theYear: Int) = this.toLocalDate() `should not be in year` theYear
-infix fun LocalDateTime.shouldNotBeInYear(theYear: Int) = this `should not be in year` theYear
+infix fun LocalDateTime.shouldNotBeInYear(theYear: Int) = this.toLocalDate() shouldNotBeInYear theYear
 
-infix fun LocalDate.`should be after`(theOther: LocalDate) = assertTrue("Expected $this to be after $theOther", this > theOther)
-infix fun LocalDate.shouldBeAfter(theOther: LocalDate) = this `should be after` theOther
+infix fun LocalDate.shouldBeAfter(theOther: LocalDate) = assertTrue("Expected $this to be after $theOther", this > theOther)
 
-infix fun LocalDate.`should be before`(theOther: LocalDate) = assertTrue("Expected $this to be before $theOther", this < theOther)
-infix fun LocalDate.shouldBeBefore(theOther: LocalDate) = this `should be before` theOther
+infix fun LocalDate.shouldBeBefore(theOther: LocalDate) = assertTrue("Expected $this to be before $theOther", this < theOther)
 
-infix fun LocalDate.`should be on or after`(theDate: LocalDate) = assertTrue("Expected $this to be on or after $theDate", this >= theDate)
-infix fun LocalDate.shouldBeOnOrAfter(theDate: LocalDate) = this `should be on or after` theDate
+infix fun LocalDate.shouldBeOnOrAfter(theDate: LocalDate) = assertTrue("Expected $this to be on or after $theDate", this >= theDate)
 
-infix fun LocalDate.`should be on or before`(theDate: LocalDate) = assertTrue("Expected $this to be on or before $theDate", this <= theDate)
-infix fun LocalDate.shouldBeOnOrBefore(theDate: LocalDate) = this `should be on or before` theDate
+infix fun LocalDate.shouldBeOnOrBefore(theDate: LocalDate) = assertTrue("Expected $this to be on or before $theDate", this <= theDate)
 
-infix fun LocalDate.`should be on`(theDay: DayOfWeek) = assertTrue("Expected $this to be a $theDay, but was ${this.dayOfWeek}", this.dayOfWeek == theDay)
-infix fun LocalDate.shouldBeOn(theDay: DayOfWeek) = this `should be on` theDay
+infix fun LocalDate.shouldBeOn(theDay: DayOfWeek) = assertTrue("Expected $this to be a $theDay, but was ${this.dayOfWeek}", this.dayOfWeek == theDay)
 
-infix fun LocalDate.`should not be on`(theDay: DayOfWeek) = assertTrue("Expected $this to not be a $theDay, but was ${this.dayOfWeek}", this.dayOfWeek != theDay)
-infix fun LocalDate.shouldNotBeOn(theDay: DayOfWeek) = this `should not be on` theDay
+infix fun LocalDate.shouldNotBeOn(theDay: DayOfWeek) = assertTrue("Expected $this to not be a $theDay, but was ${this.dayOfWeek}", this.dayOfWeek != theDay)
 
-infix fun LocalDate.`should be in`(theMonth: Month) = assertTrue("Expected $this to be in $theMonth, but was ${this.month}", this.month == theMonth)
-infix fun LocalDate.shouldBeIn(theMonth: Month) = this `should be in` theMonth
+infix fun LocalDate.shouldBeIn(theMonth: Month) = assertTrue("Expected $this to be in $theMonth, but was ${this.month}", this.month == theMonth)
 
-infix fun LocalDate.`should not be in`(theMonth: Month) = assertTrue("Expected $this to not be in $theMonth, but was ${this.month}", this.month != theMonth)
-infix fun LocalDate.shouldNotBeIn(theMonth: Month) = this `should not be in` theMonth
+infix fun LocalDate.shouldNotBeIn(theMonth: Month) = assertTrue("Expected $this to not be in $theMonth, but was ${this.month}", this.month != theMonth)
 
-infix fun LocalDate.`should be in year`(theYear: Int) = assertTrue("Expected $this to be in $theYear, but was ${this.year}", this.year == theYear)
-infix fun LocalDate.shouldBeInYear(theYear: Int) = this `should be in year` theYear
+infix fun LocalDate.shouldBeInYear(theYear: Int) = assertTrue("Expected $this to be in $theYear, but was ${this.year}", this.year == theYear)
 
-infix fun LocalDate.`should not be in year`(theYear: Int) = assertTrue("Expected $this to not be in $theYear, but was ${this.year}", this.year != theYear)
-infix fun LocalDate.shouldNotBeInYear(theYear: Int) = this `should not be in year` theYear
+infix fun LocalDate.shouldNotBeInYear(theYear: Int) = assertTrue("Expected $this to not be in $theYear, but was ${this.year}", this.year != theYear)
 
 fun Int.hours() = TimeComparator(addedHours = this)
 fun Int.minutes() = TimeComparator(addedMinutes = this)
@@ -94,59 +66,41 @@ fun Int.years() = DateComparator(addedYears = this)
 fun Int.months() = DateComparator(addedMonths = this)
 fun Int.days() = DateComparator(addedDays = this)
 
-infix fun LocalTime.`should be`(timeComparator: TimeComparator) = timeComparator.withStartValue(this)
-infix fun LocalTime.shouldBe(timeComparator: TimeComparator) = this `should be` timeComparator
+infix fun LocalTime.shouldBe(timeComparator: TimeComparator) = timeComparator.withStartValue(this)
 
-infix fun LocalTime.`should be at least`(timeComparator: TimeComparator) = timeComparator.withStartValue(this).withComparatorType(ComparatorType.AtLeast)
-infix fun LocalTime.shouldBeAtLeast(timeComparator: TimeComparator) = this `should be at least` timeComparator
+infix fun LocalTime.shouldBeAtLeast(timeComparator: TimeComparator) = timeComparator.withStartValue(this).withComparatorType(ComparatorType.AtLeast)
 
-infix fun LocalTime.`should be at most`(timeComparator: TimeComparator) = timeComparator.withStartValue(this).withComparatorType(ComparatorType.AtMost)
-infix fun LocalTime.shouldBeAtMost(timeComparator: TimeComparator) = this `should be at most` timeComparator
+infix fun LocalTime.shouldBeAtMost(timeComparator: TimeComparator) = timeComparator.withStartValue(this).withComparatorType(ComparatorType.AtMost)
 
-infix fun LocalTime.`should be in hour`(theHour: Int) = assertTrue("Expected $this to be in hour $theHour", this.hour == theHour)
-infix fun LocalTime.shouldBeInHour(theHour: Int) = this `should be in hour` theHour
+infix fun LocalTime.shouldBeInHour(theHour: Int) = assertTrue("Expected $this to be in hour $theHour", this.hour == theHour)
 
-infix fun LocalTime.`should not be in hour`(theHour: Int) = assertTrue("Expected $this to not be in hour $theHour", this.hour != theHour)
-infix fun LocalTime.shouldNotBeInHour(theHour: Int) = this `should not be in hour` theHour
+infix fun LocalTime.shouldNotBeInHour(theHour: Int) = assertTrue("Expected $this to not be in hour $theHour", this.hour != theHour)
 
-infix fun LocalTime.`should be in minute`(theMinute: Int) = assertTrue("Expected $this to be in minute $theMinute", this.minute == theMinute)
-infix fun LocalTime.shouldBeInMinute(theMinute: Int) = this `should be in minute` theMinute
+infix fun LocalTime.shouldBeInMinute(theMinute: Int) = assertTrue("Expected $this to be in minute $theMinute", this.minute == theMinute)
 
-infix fun LocalTime.`should not be in minute`(theMinute: Int) = assertTrue("Expected $this to not be in minute $theMinute", this.minute != theMinute)
-infix fun LocalTime.shouldNotBeInMinute(theMinute: Int) = this `should not be in minute` theMinute
+infix fun LocalTime.shouldNotBeInMinute(theMinute: Int) = assertTrue("Expected $this to not be in minute $theMinute", this.minute != theMinute)
 
-infix fun LocalTime.`should be in second`(theSecond: Int) = assertTrue("Expected $this to be in second $theSecond", this.second == theSecond)
-infix fun LocalTime.shouldBeInSecond(theSecond: Int) = this `should be in second` theSecond
+infix fun LocalTime.shouldBeInSecond(theSecond: Int) = assertTrue("Expected $this to be in second $theSecond", this.second == theSecond)
 
-infix fun LocalTime.`should not be in second`(theSecond: Int) = assertTrue("Expected $this to not be in second $theSecond", this.second != theSecond)
-infix fun LocalTime.shouldNotBeInSecond(theSecond: Int) = this `should not be in second` theSecond
+infix fun LocalTime.shouldNotBeInSecond(theSecond: Int) = assertTrue("Expected $this to not be in second $theSecond", this.second != theSecond)
 
-infix fun LocalDate.`should be`(dateComparator: DateComparator) = dateComparator.withStartValue(this)
-infix fun LocalDate.shouldBe(dateComparator: DateComparator) = this `should be` dateComparator
+infix fun LocalDate.shouldBe(dateComparator: DateComparator) = dateComparator.withStartValue(this)
 
-infix fun LocalDate.`should be at least`(dateComparator: DateComparator) = dateComparator.withStartValue(this).withComparatorType(ComparatorType.AtLeast)
-infix fun LocalDate.shouldBeAtLeast(dateComparator: DateComparator) = this `should be at least` dateComparator
+infix fun LocalDate.shouldBeAtLeast(dateComparator: DateComparator) = dateComparator.withStartValue(this).withComparatorType(ComparatorType.AtLeast)
 
-infix fun LocalDate.`should be at most`(dateComparator: DateComparator) = dateComparator.withStartValue(this).withComparatorType(ComparatorType.AtMost)
-infix fun LocalDate.shouldBeAtMost(dateComparator: DateComparator) = this `should be at most` dateComparator
+infix fun LocalDate.shouldBeAtMost(dateComparator: DateComparator) = dateComparator.withStartValue(this).withComparatorType(ComparatorType.AtMost)
 
-infix fun LocalDateTime.`should be`(dateComparator: DateComparator): DateTimeComparator = DateTimeComparator(dateComparator).withStartValue(this) as DateTimeComparator
-infix fun LocalDateTime.shouldBe(dateComparator: DateComparator) = this `should be` dateComparator
+infix fun LocalDateTime.shouldBe(dateComparator: DateComparator): DateTimeComparator = DateTimeComparator(dateComparator).withStartValue(this) as DateTimeComparator
 
-infix fun LocalDateTime.`should be at least`(dateComparator: DateComparator) = DateTimeComparator(dateComparator).withStartValue(this).withComparatorType(ComparatorType.AtLeast)
-infix fun LocalDateTime.shouldBeAtLeast(dateComparator: DateComparator) = this `should be at least` dateComparator
+infix fun LocalDateTime.shouldBeAtLeast(dateComparator: DateComparator) = DateTimeComparator(dateComparator).withStartValue(this).withComparatorType(ComparatorType.AtLeast)
 
-infix fun LocalDateTime.`should be at most`(dateComparator: DateComparator) = DateTimeComparator(dateComparator).withStartValue(this).withComparatorType(ComparatorType.AtMost)
-infix fun LocalDateTime.shouldBeAtMost(dateComparator: DateComparator) = this `should be at most` dateComparator
+infix fun LocalDateTime.shouldBeAtMost(dateComparator: DateComparator) = DateTimeComparator(dateComparator).withStartValue(this).withComparatorType(ComparatorType.AtMost)
 
-infix fun LocalDateTime.`should be`(timeComparator: TimeComparator) = DateTimeComparator(timeComparator = timeComparator).withStartValue(this) as DateTimeComparator
-infix fun LocalDateTime.shouldBe(timeComparator: TimeComparator) = this `should be` timeComparator
+infix fun LocalDateTime.shouldBe(timeComparator: TimeComparator) = DateTimeComparator(timeComparator = timeComparator).withStartValue(this) as DateTimeComparator
 
-infix fun LocalDateTime.`should be at least`(timeComparator: TimeComparator) = DateTimeComparator(timeComparator = timeComparator).withStartValue(this).withComparatorType(ComparatorType.AtLeast)
-infix fun LocalDateTime.shouldBeAtLeast(timeComparator: TimeComparator) = this `should be at least` timeComparator
+infix fun LocalDateTime.shouldBeAtLeast(timeComparator: TimeComparator) = DateTimeComparator(timeComparator = timeComparator).withStartValue(this).withComparatorType(ComparatorType.AtLeast)
 
-infix fun LocalDateTime.`should be at most`(timeComparator: TimeComparator) = DateTimeComparator(timeComparator = timeComparator).withStartValue(this).withComparatorType(ComparatorType.AtMost)
-infix fun LocalDateTime.shouldBeAtMost(timeComparator: TimeComparator) = this `should be at most` timeComparator
+infix fun LocalDateTime.shouldBeAtMost(timeComparator: TimeComparator) = DateTimeComparator(timeComparator = timeComparator).withStartValue(this).withComparatorType(ComparatorType.AtMost)
 
 infix fun <T : Comparable<T>> AbstractJavaTimeComparator<T>.after(theOther: T) = this.assertAfter(theOther)
 infix fun <T : Comparable<T>> AbstractJavaTimeComparator<T>.before(theOther: T) = this.assertBefore(theOther)

--- a/src/main/kotlin/org/amshove/kluent/DateTimeBacktick.kt
+++ b/src/main/kotlin/org/amshove/kluent/DateTimeBacktick.kt
@@ -1,0 +1,95 @@
+package org.amshove.kluent
+
+import java.time.*
+
+infix fun LocalDateTime.`should be after`(theOther: LocalDateTime) = this.shouldBeAfter(theOther)
+
+infix fun LocalDateTime.`should be after`(theTime: LocalTime) = this.shouldBeAfter(theTime)
+
+infix fun LocalDateTime.`should be before`(theOther: LocalDateTime) = this.shouldBeBefore(theOther)
+
+infix fun LocalDateTime.`should be before`(theTime: LocalTime) = this.shouldBeBefore(theTime)
+
+infix fun LocalDateTime.`should be in hour`(theHour: Int) = this.shouldBeInHour(theHour)
+
+infix fun LocalDateTime.`should not be in hour`(theHour: Int) = this.shouldNotBeInHour(theHour)
+
+infix fun LocalDateTime.`should be in minute`(theMinute: Int) = this.shouldBeInMinute(theMinute)
+
+infix fun LocalDateTime.`should not be in minute`(theMinute: Int) = this.shouldNotBeInMinute(theMinute)
+
+infix fun LocalDateTime.`should be in second`(theSecond: Int) = this.shouldBeInSecond(theSecond)
+
+infix fun LocalDateTime.`should not be in second`(theSecond: Int) = this.shouldNotBeInSecond(theSecond)
+
+infix fun LocalDateTime.`should be on or after`(theDate: LocalDateTime) = this.shouldBeOnOrAfter(theDate)
+
+infix fun LocalDateTime.`should be on or before`(theDate: LocalDateTime) = this.shouldBeOnOrBefore(theDate)
+
+infix fun LocalDateTime.`should be on`(theDay: DayOfWeek) = this.shouldBeOn(theDay)
+
+infix fun LocalDateTime.`should not be on`(theDay: DayOfWeek) = this.shouldNotBeOn(theDay)
+
+infix fun LocalDateTime.`should be in`(theMonth: Month) = this.shouldBeIn(theMonth)
+
+infix fun LocalDateTime.`should not be in`(theMonth: Month) = this.shouldNotBeIn(theMonth)
+
+infix fun LocalDateTime.`should be in year`(theYear: Int) = this.shouldBeInYear(theYear)
+
+infix fun LocalDateTime.`should not be in year`(theYear: Int) = this.shouldNotBeInYear(theYear)
+
+infix fun LocalDate.`should be after`(theOther: LocalDate) = this.shouldBeAfter(theOther)
+
+infix fun LocalDate.`should be before`(theOther: LocalDate) = this.shouldBeBefore(theOther)
+
+infix fun LocalDate.`should be on or after`(theDate: LocalDate) = this.shouldBeOnOrAfter(theDate)
+
+infix fun LocalDate.`should be on or before`(theDate: LocalDate) = this.shouldBeOnOrBefore(theDate)
+
+infix fun LocalDate.`should be on`(theDay: DayOfWeek) = this.shouldBeOn(theDay)
+
+infix fun LocalDate.`should not be on`(theDay: DayOfWeek) = this.shouldNotBeOn(theDay)
+
+infix fun LocalDate.`should be in`(theMonth: Month) = this.shouldBeIn(theMonth)
+
+infix fun LocalDate.`should not be in`(theMonth: Month) = this.shouldNotBeIn(theMonth)
+
+infix fun LocalDate.`should be in year`(theYear: Int) = this.shouldBeInYear(theYear)
+
+infix fun LocalDate.`should not be in year`(theYear: Int) = this.shouldNotBeInYear(theYear)
+
+infix fun LocalTime.`should be`(timeComparator: TimeComparator) = this.shouldBe(timeComparator)
+
+infix fun LocalTime.`should be at least`(timeComparator: TimeComparator) = this.shouldBeAtLeast(timeComparator)
+
+infix fun LocalTime.`should be at most`(timeComparator: TimeComparator) = this.shouldBeAtMost(timeComparator)
+
+infix fun LocalTime.`should be in hour`(theHour: Int) = this.shouldBeInHour(theHour)
+
+infix fun LocalTime.`should not be in hour`(theHour: Int) = this.shouldNotBeInHour(theHour)
+
+infix fun LocalTime.`should be in minute`(theMinute: Int) = this.shouldBeInMinute(theMinute)
+
+infix fun LocalTime.`should not be in minute`(theMinute: Int) = this.shouldNotBeInMinute(theMinute)
+
+infix fun LocalTime.`should be in second`(theSecond: Int) = this.shouldBeInSecond(theSecond)
+
+infix fun LocalTime.`should not be in second`(theSecond: Int) = this.shouldNotBeInSecond(theSecond)
+
+infix fun LocalDate.`should be`(dateComparator: DateComparator) = this.shouldBe(dateComparator)
+
+infix fun LocalDate.`should be at least`(dateComparator: DateComparator) = this.shouldBeAtLeast(dateComparator)
+
+infix fun LocalDate.`should be at most`(dateComparator: DateComparator) = this.shouldBeAtMost(dateComparator)
+
+infix fun LocalDateTime.`should be`(dateComparator: DateComparator): DateTimeComparator = this.shouldBe(dateComparator)
+
+infix fun LocalDateTime.`should be at least`(dateComparator: DateComparator) = this.shouldBeAtLeast(dateComparator)
+
+infix fun LocalDateTime.`should be at most`(dateComparator: DateComparator) = this.shouldBeAtMost(dateComparator)
+
+infix fun LocalDateTime.`should be`(timeComparator: TimeComparator) = this.shouldBe(timeComparator)
+
+infix fun LocalDateTime.`should be at least`(timeComparator: TimeComparator) = this.shouldBeAtLeast(timeComparator)
+
+infix fun LocalDateTime.`should be at most`(timeComparator: TimeComparator) = this.shouldBeAtMost(timeComparator)

--- a/src/main/kotlin/org/amshove/kluent/Exceptions.kt
+++ b/src/main/kotlin/org/amshove/kluent/Exceptions.kt
@@ -3,7 +3,7 @@ package org.amshove.kluent
 import org.junit.ComparisonFailure
 import kotlin.reflect.KClass
 
-infix fun <T : Throwable> (() -> Any).`should throw`(expectedException: KClass<T>): ExceptionResult<T> {
+infix fun <T : Throwable> (() -> Any).shouldThrow(expectedException: KClass<T>): ExceptionResult<T> {
     try {
         this.invoke()
         fail("There was an Exception expected to be thrown, but nothing was thrown", "$expectedException", "None")
@@ -15,10 +15,7 @@ infix fun <T : Throwable> (() -> Any).`should throw`(expectedException: KClass<T
     }
 }
 
-infix fun <T : Throwable> (() -> Any).shouldThrow(expectedException: KClass<T>) = this `should throw` expectedException
-
-
-infix fun <T : Throwable> (() -> Any).`should not throw`(expectedException: KClass<T>) {
+infix fun <T : Throwable> (() -> Any).shouldNotThrow(expectedException: KClass<T>) {
     try {
         this.invoke()
     } catch (e: Throwable) {
@@ -30,16 +27,10 @@ infix fun <T : Throwable> (() -> Any).`should not throw`(expectedException: KCla
     }
 }
 
-infix fun <T : Throwable> (() -> Any).shouldNotThrow(expectedException: KClass<T>) = this `should not throw` expectedException
-
-@Deprecated("Use `should throw` instead", ReplaceWith("x `should throw` expectedException"))
-infix fun <T : Throwable> (() -> Any).`should throw the Exception`(expectedException: KClass<T>): ExceptionResult<T>
-        = this `should throw` expectedException
-
 @Deprecated("Use shouldThrow instead", ReplaceWith("x shouldThrow expectedException"))
 infix fun <T : Throwable> (() -> Any).shouldThrowTheException(expectedException: KClass<T>): ExceptionResult<T> = this shouldThrow expectedException
 
-infix fun <T : Throwable> (() -> Any).`should not throw the Exception`(expectedException: KClass<T>): NotThrowExceptionResult {
+infix fun <T : Throwable> (() -> Any).shouldNotThrowTheException(expectedException: KClass<T>): NotThrowExceptionResult {
     try {
         this.invoke()
         return NotThrowExceptionResult(noException)
@@ -51,40 +42,25 @@ infix fun <T : Throwable> (() -> Any).`should not throw the Exception`(expectedE
     }
 }
 
-infix fun <T : Throwable> (() -> Any).shouldNotThrowTheException(expectedException: KClass<T>): NotThrowExceptionResult = this `should not throw the Exception` expectedException
-
-
-infix fun <T : Throwable> ExceptionResult<T>.`with message`(theMessage: String): ExceptionResult<T> {
-    this.exceptionMessage `should equal` theMessage
+infix fun <T : Throwable> ExceptionResult<T>.withMessage(theMessage: String): ExceptionResult<T> {
+    this.exceptionMessage shouldEqual theMessage
     return this
 }
 
-infix fun <T : Throwable> ExceptionResult<T>.withMessage(theMessage: String) = this `with message` theMessage
-
-
-infix fun NotThrowExceptionResult.`with message`(theMessage: String): NotThrowExceptionResult {
-    this.exceptionMessage `should not equal` theMessage
+infix fun NotThrowExceptionResult.withMessage(theMessage: String): NotThrowExceptionResult {
+    this.exceptionMessage shouldNotEqual theMessage
     return this;
 }
 
-infix fun NotThrowExceptionResult.withMessage(theMessage: String) = this `with message` theMessage
-
-
-infix fun <T : Throwable> ExceptionResult<T>.`with cause`(expectedCause: KClass<out Throwable>): ExceptionResult<T> {
-    this.exceptionCause `should be instance of` expectedCause.java
+infix fun <T : Throwable> ExceptionResult<T>.withCause(expectedCause: KClass<out Throwable>): ExceptionResult<T> {
+    this.exceptionCause shouldBeInstanceOf expectedCause.java
     return this
 }
 
-infix fun <T : Throwable> ExceptionResult<T>.withCause(expectedCause: KClass<out Throwable>) = this `with cause` expectedCause
-
-
-infix fun NotThrowExceptionResult.`with cause`(expectedCause: KClass<out Throwable>): NotThrowExceptionResult {
-    this.exceptionCause `should not be instance of` expectedCause.java
+infix fun NotThrowExceptionResult.withCause(expectedCause: KClass<out Throwable>): NotThrowExceptionResult {
+    this.exceptionCause shouldNotBeInstanceOf expectedCause.java
     return this
 }
-
-infix fun NotThrowExceptionResult.withCause(expectedCause: KClass<out Throwable>) = this `with cause` expectedCause
-
 
 val AnyException = AnyExceptionType::class
 

--- a/src/main/kotlin/org/amshove/kluent/ExceptionsBacktick.kt
+++ b/src/main/kotlin/org/amshove/kluent/ExceptionsBacktick.kt
@@ -1,0 +1,20 @@
+package org.amshove.kluent
+
+import kotlin.reflect.KClass
+
+infix fun <T : Throwable> (() -> Any).`should throw`(expectedException: KClass<T>) = this.shouldThrow(expectedException)
+
+infix fun <T : Throwable> (() -> Any).`should not throw`(expectedException: KClass<T>) = this.shouldNotThrow(expectedException)
+
+@Deprecated("Use `should throw` instead", ReplaceWith("x `should throw` expectedException"))
+infix fun <T : Throwable> (() -> Any).`should throw the Exception`(expectedException: KClass<T>) = this.shouldThrow(expectedException)
+
+infix fun <T : Throwable> (() -> Any).`should not throw the Exception`(expectedException: KClass<T>) = this.shouldNotThrowTheException(expectedException)
+
+infix fun <T : Throwable> ExceptionResult<T>.`with message`(theMessage: String) = this.withMessage(theMessage)
+
+infix fun NotThrowExceptionResult.`with message`(theMessage: String) = this.withMessage(theMessage)
+
+infix fun <T : Throwable> ExceptionResult<T>.`with cause`(expectedCause: KClass<out Throwable>) = this.withCause(expectedCause)
+
+infix fun NotThrowExceptionResult.`with cause`(expectedCause: KClass<out Throwable>) = this.withCause(expectedCause)

--- a/src/main/kotlin/org/amshove/kluent/File.kt
+++ b/src/main/kotlin/org/amshove/kluent/File.kt
@@ -15,11 +15,7 @@ fun File.shouldNotBeFile() = assertFalse("The file is a file", this.isFile)
 
 infix fun File.shouldHaveExtension(other: String) = this.extension shouldEqualTo other
 infix fun File.shouldNotHaveExtension(other: String) = this.extension shouldNotEqualTo other
-infix fun File.`should have extension`(other: String) = this shouldHaveExtension other
-infix fun File.`should not have extension`(other: String) = this shouldNotHaveExtension other
 
 infix fun File.shouldHaveName(other: String) = this.name shouldEqualTo other
 infix fun File.shouldNotHaveName(other: String) = this.name shouldNotEqualTo other
-infix fun File.`should have name`(other: String) = this shouldHaveName other
-infix fun File.`should not have name`(other: String) = this shouldNotHaveName other
 

--- a/src/main/kotlin/org/amshove/kluent/FileBacktick.kt
+++ b/src/main/kotlin/org/amshove/kluent/FileBacktick.kt
@@ -1,0 +1,19 @@
+package org.amshove.kluent
+
+import java.io.File
+
+fun File.`should exist`() = this.shouldExist()
+fun File.`should not exist`() = this.shouldNotExist()
+
+fun File.`should be dir`() = this.shouldBeDir()
+fun File.`should not be dir`() = this.shouldNotBeDir()
+
+fun File.`should be file`() = this.shouldBeFile()
+fun File.`should not be file`() = this.shouldNotBeFile()
+
+infix fun File.`should have extension`(other: String) = this shouldHaveExtension(other)
+infix fun File.`should not have extension`(other: String) = this shouldNotHaveExtension(other)
+
+infix fun File.`should have name`(other: String) = this shouldHaveName(other)
+infix fun File.`should not have name`(other: String) = this shouldNotHaveName(other)
+

--- a/src/main/kotlin/org/amshove/kluent/Mocking.kt
+++ b/src/main/kotlin/org/amshove/kluent/Mocking.kt
@@ -1,10 +1,13 @@
 package org.amshove.kluent
 
-import kotlin.reflect.KClass
-import com.nhaarman.mockito_kotlin.*
+import com.nhaarman.mockito_kotlin.never
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
+import com.nhaarman.mockito_kotlin.verifyZeroInteractions
 import org.mockito.Mockito.`when`
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.OngoingStubbing
+import kotlin.reflect.KClass
 
 @Suppress("UNUSED_PARAMETER") // Backward compatibility
 inline fun <reified T : Any> mock(targetClass: KClass<out T>): T = mock()
@@ -27,17 +30,13 @@ infix fun <T> T.was(n: CalledKeyword) = n
 inline fun <reified T : Any> any(kClass: KClass<T>): T = any()
 inline fun <reified T : Any> any(): T = com.nhaarman.mockito_kotlin.any()
 
-infix fun <T> OngoingStubbing<T>.`it returns`(value: T): OngoingStubbing<T> = this.thenReturn(value)
-infix fun <T> OngoingStubbing<T>.itReturns(value: T): OngoingStubbing<T> = this `it returns` value
+infix fun <T> OngoingStubbing<T>.itReturns(value: T): OngoingStubbing<T> = this.thenReturn(value)
 
-infix fun <T> OngoingStubbing<T>.`it throws`(value: RuntimeException): OngoingStubbing<T> = this.thenThrow(value)
-infix fun <T> OngoingStubbing<T>.itThrows(value: RuntimeException): OngoingStubbing<T> = this `it throws` value
+infix fun <T> OngoingStubbing<T>.itThrows(value: RuntimeException): OngoingStubbing<T> = this.thenThrow(value)
 
-infix fun <T> OngoingStubbing<T>.`it throws`(value: Error): OngoingStubbing<T> = this.thenThrow(value)
-infix fun <T> OngoingStubbing<T>.itThrows(value: Error): OngoingStubbing<T> = this `it throws` value
+infix fun <T> OngoingStubbing<T>.itThrows(value: Error): OngoingStubbing<T> = this.thenThrow(value)
 
-infix fun <T> OngoingStubbing<T>.`it answers`(value: (InvocationOnMock) -> T): OngoingStubbing<T> = this.thenAnswer(value)
-infix fun <T> OngoingStubbing<T>.itAnswers(value: (InvocationOnMock) -> T): OngoingStubbing<T> = this `it answers` value
+infix fun <T> OngoingStubbing<T>.itAnswers(value: (InvocationOnMock) -> T): OngoingStubbing<T> = this.thenAnswer(value)
 
 infix fun <T> WhenKeyword.calling(methodCall: T): OngoingStubbing<T> = `when`(methodCall)
 
@@ -47,9 +46,7 @@ val Verify = VerifyKeyword()
 val VerifyNotCalled = VerifyNotCalledKeyword()
 val called = CalledKeyword()
 val VerifyNoInteractions = VerifyNoInteractionsKeyword()
-val `Verify no interactions` = VerifyNoInteractions
 val VerifyNoFurtherInteractions = VerifyNoFurtherInteractionsKeyword()
-val `Verify no further interactions` = VerifyNoFurtherInteractions
 
 class VerifyKeyword internal constructor() {}
 class VerifyNotCalledKeyword internal constructor()

--- a/src/main/kotlin/org/amshove/kluent/MockingBacktick.kt
+++ b/src/main/kotlin/org/amshove/kluent/MockingBacktick.kt
@@ -1,0 +1,11 @@
+package org.amshove.kluent
+
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.OngoingStubbing
+
+infix fun <T> OngoingStubbing<T>.`it returns`(value: T) = this.itReturns(value)
+infix fun <T> OngoingStubbing<T>.`it throws`(value: RuntimeException) = this.itThrows(value)
+infix fun <T> OngoingStubbing<T>.`it throws`(value: Error) = this.itThrows(value)
+infix fun <T> OngoingStubbing<T>.`it answers`(value: (InvocationOnMock) -> T) = this.itAnswers(value)
+val `Verify no interactions` = VerifyNoInteractions
+val `Verify no further interactions` = VerifyNoFurtherInteractions

--- a/src/main/kotlin/org/amshove/kluent/Numerical.kt
+++ b/src/main/kotlin/org/amshove/kluent/Numerical.kt
@@ -2,285 +2,191 @@ package org.amshove.kluent
 
 import org.junit.Assert.*
 
-infix fun Boolean.`should equal to`(theOther: Boolean) = assertEquals(theOther, this)
-infix fun Boolean.shouldEqualTo(theOther: Boolean) = this `should equal to` theOther
+infix fun Boolean.shouldEqualTo(theOther: Boolean) = assertEquals(theOther, this)
 
-infix fun Byte.`should equal to`(theOther: Byte) = assertEquals(theOther, this)
-infix fun Byte.shouldEqualTo(theOther: Byte) = this `should equal to` theOther
+infix fun Byte.shouldEqualTo(theOther: Byte) = assertEquals(theOther, this)
 
-infix fun Short.`should equal to`(theOther: Short) = assertEquals(theOther, this)
-infix fun Short.shouldEqualTo(theOther: Short) = this `should equal to` theOther
+infix fun Short.shouldEqualTo(theOther: Short) = assertEquals(theOther, this)
 
-infix fun Int.`should equal to`(theOther: Int) = assertEquals(theOther, this)
-infix fun Int.shouldEqualTo(theOther: Int) = this `should equal to` theOther
+infix fun Int.shouldEqualTo(theOther: Int) = assertEquals(theOther, this)
 
-infix fun Long.`should equal to`(theOther: Long) = assertEquals(theOther, this)
-infix fun Long.shouldEqualTo(theOther: Long) = this `should equal to` theOther
+infix fun Long.shouldEqualTo(theOther: Long) = assertEquals(theOther, this)
 
-infix fun Float.`should equal to`(theOther: Float) = assertEquals(theOther, this, 0f)
-infix fun Float.shouldEqualTo(theOther: Float) = this `should equal to` theOther
+infix fun Float.shouldEqualTo(theOther: Float) = assertEquals(theOther, this, 0f)
 
-infix fun Double.`should equal to`(theOther: Double) = assertEquals(theOther, this, 0.0)
-infix fun Double.shouldEqualTo(theOther: Double) = this `should equal to` theOther
+infix fun Double.shouldEqualTo(theOther: Double) = assertEquals(theOther, this, 0.0)
 
-infix fun Boolean.`should not equal to`(theOther: Boolean) = assertNotEquals(theOther, this)
-infix fun Boolean.shouldNotEqualTo(theOther: Boolean) = this `should not equal to` theOther
+infix fun Boolean.shouldNotEqualTo(theOther: Boolean) = assertNotEquals(theOther, this)
 
-infix fun Byte.`should not equal to`(theOther: Byte) = assertNotEquals(theOther, this)
-infix fun Byte.shouldNotEqualTo(theOther: Byte) = this `should not equal to` theOther
+infix fun Byte.shouldNotEqualTo(theOther: Byte) = assertNotEquals(theOther, this)
 
-infix fun Short.`should not equal to`(theOther: Short) = assertNotEquals(theOther, this)
-infix fun Short.shouldNotEqualTo(theOther: Short) = this `should not equal to` theOther
+infix fun Short.shouldNotEqualTo(theOther: Short) = assertNotEquals(theOther, this)
 
-infix fun Int.`should not equal to`(theOther: Int) = assertNotEquals(theOther, this)
-infix fun Int.shouldNotEqualTo(theOther: Int) = this `should not equal to` theOther
+infix fun Int.shouldNotEqualTo(theOther: Int) = assertNotEquals(theOther, this)
 
-infix fun Long.`should not equal to`(theOther: Long) = assertNotEquals(theOther, this)
-infix fun Long.shouldNotEqualTo(theOther: Long) = this `should not equal to` theOther
+infix fun Long.shouldNotEqualTo(theOther: Long) = assertNotEquals(theOther, this)
 
-infix fun Float.`should not equal to`(theOther: Float) = assertNotEquals(theOther, this)
-infix fun Float.shouldNotEqualTo(theOther: Float) = this `should not equal to` theOther
+infix fun Float.shouldNotEqualTo(theOther: Float) = assertNotEquals(theOther, this)
 
-infix fun Double.`should not equal to`(theOther: Double) = assertNotEquals(theOther, this)
-infix fun Double.shouldNotEqualTo(theOther: Double) = this `should not equal to` theOther
+infix fun Double.shouldNotEqualTo(theOther: Double) = assertNotEquals(theOther, this)
 
-infix fun Byte.`should be greater than`(theOther: Byte) = assertTrue("Expected $this to be greater than $theOther", this > theOther)
-infix fun Byte.shouldBeGreaterThan(theOther: Byte) = this `should be greater than` theOther
+infix fun Byte.shouldBeGreaterThan(theOther: Byte) = assertTrue("Expected $this to be greater than $theOther", this > theOther)
 
-infix fun Short.`should be greater than`(theOther: Short) = assertTrue("Expected $this to be greater than $theOther", this > theOther)
-infix fun Short.shouldBeGreaterThan(theOther: Short) = this `should be greater than` theOther
+infix fun Short.shouldBeGreaterThan(theOther: Short) = assertTrue("Expected $this to be greater than $theOther", this > theOther)
 
-infix fun Int.`should be greater than`(theOther: Int) = assertTrue("Expected $this to be greater than $theOther", this > theOther)
-infix fun Int.shouldBeGreaterThan(theOther: Int) = this `should be greater than` theOther
+infix fun Int.shouldBeGreaterThan(theOther: Int) = assertTrue("Expected $this to be greater than $theOther", this > theOther)
 
-infix fun Long.`should be greater than`(theOther: Long) = assertTrue("Expected $this to be greater than $theOther", this > theOther)
-infix fun Long.shouldBeGreaterThan(theOther: Long) = this `should be greater than` theOther
+infix fun Long.shouldBeGreaterThan(theOther: Long) = assertTrue("Expected $this to be greater than $theOther", this > theOther)
 
-infix fun Float.`should be greater than`(theOther: Float) = assertTrue("Expected $this to be greater than $theOther", this > theOther)
-infix fun Float.shouldBeGreaterThan(theOther: Float) = this `should be greater than` theOther
+infix fun Float.shouldBeGreaterThan(theOther: Float) = assertTrue("Expected $this to be greater than $theOther", this > theOther)
 
-infix fun Double.`should be greater than`(theOther: Double) = assertTrue("Expected $this to be greater than $theOther", this > theOther)
-infix fun Double.shouldBeGreaterThan(theOther: Double) = this `should be greater than` theOther
+infix fun Double.shouldBeGreaterThan(theOther: Double) = assertTrue("Expected $this to be greater than $theOther", this > theOther)
 
-infix fun Byte.`should not be greater than`(theOther: Byte) = assertTrue("Expected $this to not be greater than $theOther", this <= theOther)
-infix fun Byte.shouldNotBeGreaterThan(theOther: Byte) = this `should not be greater than` theOther
+infix fun Byte.shouldNotBeGreaterThan(theOther: Byte) = assertTrue("Expected $this to not be greater than $theOther", this <= theOther)
 
-infix fun Short.`should not be greater than`(theOther: Short) = assertTrue("Expected $this to not be greater than $theOther", this <= theOther)
-infix fun Short.shouldNotBeGreaterThan(theOther: Short) = this `should not be greater than` theOther
+infix fun Short.shouldNotBeGreaterThan(theOther: Short) = assertTrue("Expected $this to not be greater than $theOther", this <= theOther)
 
-infix fun Int.`should not be greater than`(theOther: Int) = assertTrue("Expected $this to not be greater than $theOther", this <= theOther)
-infix fun Int.shouldNotBeGreaterThan(theOther: Int) = this `should not be greater than` theOther
+infix fun Int.shouldNotBeGreaterThan(theOther: Int) = assertTrue("Expected $this to not be greater than $theOther", this <= theOther)
 
-infix fun Long.`should not be greater than`(theOther: Long) = assertTrue("Expected $this to not be greater than $theOther", this <= theOther)
-infix fun Long.shouldNotBeGreaterThan(theOther: Long) = this `should not be greater than` theOther
+infix fun Long.shouldNotBeGreaterThan(theOther: Long) = assertTrue("Expected $this to not be greater than $theOther", this <= theOther)
 
-infix fun Float.`should not be greater than`(theOther: Float) = assertTrue("Expected $this to not be greater than $theOther", this <= theOther)
-infix fun Float.shouldNotBeGreaterThan(theOther: Float) = this `should not be greater than` theOther
+infix fun Float.shouldNotBeGreaterThan(theOther: Float) = assertTrue("Expected $this to not be greater than $theOther", this <= theOther)
 
-infix fun Double.`should not be greater than`(theOther: Double) = assertTrue("Expected $this to not be greater than $theOther", this <= theOther)
-infix fun Double.shouldNotBeGreaterThan(theOther: Double) = this `should not be greater than` theOther
+infix fun Double.shouldNotBeGreaterThan(theOther: Double) = assertTrue("Expected $this to not be greater than $theOther", this <= theOther)
 
-infix fun Byte.`should be greater or equal to`(theOther: Byte) = assertTrue("Expected $this to be greater or equal to $theOther", this >= theOther)
-infix fun Byte.shouldBeGreaterOrEqualTo(theOther: Byte) = this `should be greater or equal to` theOther
+infix fun Byte.shouldBeGreaterOrEqualTo(theOther: Byte) = assertTrue("Expected $this to be greater or equal to $theOther", this >= theOther)
 
-infix fun Short.`should be greater or equal to`(theOther: Short) = assertTrue("Expected $this to be greater or equal to $theOther", this >= theOther)
-infix fun Short.shouldBeGreaterOrEqualTo(theOther: Short) = this `should be greater or equal to` theOther
+infix fun Short.shouldBeGreaterOrEqualTo(theOther: Short) = assertTrue("Expected $this to be greater or equal to $theOther", this >= theOther)
 
-infix fun Int.`should be greater or equal to`(theOther: Int) = assertTrue("Expected $this to be greater or equal to $theOther", this >= theOther)
-infix fun Int.shouldBeGreaterOrEqualTo(theOther: Int) = this `should be greater or equal to` theOther
+infix fun Int.shouldBeGreaterOrEqualTo(theOther: Int) = assertTrue("Expected $this to be greater or equal to $theOther", this >= theOther)
 
-infix fun Long.`should be greater or equal to`(theOther: Long) = assertTrue("Expected $this to be greater or equal to $theOther", this >= theOther)
-infix fun Long.shouldBeGreaterOrEqualTo(theOther: Long) = this `should be greater or equal to` theOther
+infix fun Long.shouldBeGreaterOrEqualTo(theOther: Long) = assertTrue("Expected $this to be greater or equal to $theOther", this >= theOther)
 
-infix fun Float.`should be greater or equal to`(theOther: Float) = assertTrue("Expected $this to be greater or equal to $theOther", this >= theOther)
-infix fun Float.shouldBeGreaterOrEqualTo(theOther: Float) = this `should be greater or equal to` theOther
+infix fun Float.shouldBeGreaterOrEqualTo(theOther: Float) = assertTrue("Expected $this to be greater or equal to $theOther", this >= theOther)
 
-infix fun Double.`should be greater or equal to`(theOther: Double) = assertTrue("Expected $this to be greater or equal to $theOther", this >= theOther)
-infix fun Double.shouldBeGreaterOrEqualTo(theOther: Double) = this `should be greater or equal to` theOther
+infix fun Double.shouldBeGreaterOrEqualTo(theOther: Double) = assertTrue("Expected $this to be greater or equal to $theOther", this >= theOther)
 
-infix fun Byte.`should not be greater or equal to`(theOther: Byte) = assertTrue("Expected $this to be not be greater or equal to $theOther", this < theOther)
-infix fun Byte.shouldNotBeGreaterOrEqualTo(theOther: Byte) = this `should not be greater or equal to` theOther
+infix fun Byte.shouldNotBeGreaterOrEqualTo(theOther: Byte) = assertTrue("Expected $this to be not be greater or equal to $theOther", this < theOther)
 
-infix fun Short.`should not be greater or equal to`(theOther: Short) = assertTrue("Expected $this to not be greater or equal to $theOther", this < theOther)
-infix fun Short.shouldNotBeGreaterOrEqualTo(theOther: Short) = this `should not be greater or equal to` theOther
+infix fun Short.shouldNotBeGreaterOrEqualTo(theOther: Short) = assertTrue("Expected $this to not be greater or equal to $theOther", this < theOther)
 
-infix fun Int.`should not be greater or equal to`(theOther: Int) = assertTrue("Expected $this to not be greater or equal to $theOther", this < theOther)
-infix fun Int.shouldNotBeGreaterOrEqualTo(theOther: Int) = this `should not be greater or equal to` theOther
+infix fun Int.shouldNotBeGreaterOrEqualTo(theOther: Int) = assertTrue("Expected $this to not be greater or equal to $theOther", this < theOther)
 
-infix fun Long.`should not be greater or equal to`(theOther: Long) = assertTrue("Expected $this to not be greater or equal to $theOther", this < theOther)
-infix fun Long.shouldNotBeGreaterOrEqualTo(theOther: Long) = this `should not be greater or equal to` theOther
+infix fun Long.shouldNotBeGreaterOrEqualTo(theOther: Long) = assertTrue("Expected $this to not be greater or equal to $theOther", this < theOther)
 
-infix fun Float.`should not be greater or equal to`(theOther: Float) = assertTrue("Expected $this to not be greater or equal to $theOther", this < theOther)
-infix fun Float.shouldNotBeGreaterOrEqualTo(theOther: Float) = this `should not be greater or equal to` theOther
+infix fun Float.shouldNotBeGreaterOrEqualTo(theOther: Float) = assertTrue("Expected $this to not be greater or equal to $theOther", this < theOther)
 
-infix fun Double.`should not be greater or equal to`(theOther: Double) = assertTrue("Expected $this to not be greater or equal to $theOther", this < theOther)
-infix fun Double.shouldNotBeGreaterOrEqualTo(theOther: Double) = this `should not be greater or equal to` theOther
+infix fun Double.shouldNotBeGreaterOrEqualTo(theOther: Double) = assertTrue("Expected $this to not be greater or equal to $theOther", this < theOther)
 
-infix fun Byte.`should be less than`(theOther: Byte) = assertTrue("Expected $this to be less than $theOther", this < theOther)
-infix fun Byte.shouldBeLessThan(theOther: Byte) = this `should be less than` theOther
+infix fun Byte.shouldBeLessThan(theOther: Byte) = assertTrue("Expected $this to be less than $theOther", this < theOther)
 
-infix fun Short.`should be less than`(theOther: Short) = assertTrue("Expected $this to be less than $theOther", this < theOther)
-infix fun Short.shouldBeLessThan(theOther: Short) = this `should be less than` theOther
+infix fun Short.shouldBeLessThan(theOther: Short) = assertTrue("Expected $this to be less than $theOther", this < theOther)
 
-infix fun Int.`should be less than`(theOther: Int) = assertTrue("Expected $this to be less than $theOther", this < theOther)
-infix fun Int.shouldBeLessThan(theOther: Int) = this `should be less than` theOther
+infix fun Int.shouldBeLessThan(theOther: Int) = assertTrue("Expected $this to be less than $theOther", this < theOther)
 
-infix fun Long.`should be less than`(theOther: Long) = assertTrue("Expected $this to be less than $theOther", this < theOther)
-infix fun Long.shouldBeLessThan(theOther: Long) = this `should be less than` theOther
+infix fun Long.shouldBeLessThan(theOther: Long) = assertTrue("Expected $this to be less than $theOther", this < theOther)
 
-infix fun Float.`should be less than`(theOther: Float) = assertTrue("Expected $this to be less than $theOther", this < theOther)
-infix fun Float.shouldBeLessThan(theOther: Float) = this `should be less than` theOther
+infix fun Float.shouldBeLessThan(theOther: Float) = assertTrue("Expected $this to be less than $theOther", this < theOther)
 
-infix fun Double.`should be less than`(theOther: Double) = assertTrue("Expected $this to be less than $theOther", this < theOther)
-infix fun Double.shouldBeLessThan(theOther: Double) = this `should be less than` theOther
+infix fun Double.shouldBeLessThan(theOther: Double) = assertTrue("Expected $this to be less than $theOther", this < theOther)
 
-infix fun Byte.`should not be less than`(theOther: Byte) = assertTrue("Expected $this to not be less than $theOther", this >= theOther)
-infix fun Byte.shouldNotBeLessThan(theOther: Byte) = this `should not be less than` theOther
+infix fun Byte.shouldNotBeLessThan(theOther: Byte) = assertTrue("Expected $this to not be less than $theOther", this >= theOther)
 
-infix fun Short.`should not be less than`(theOther: Short) = assertTrue("Expected $this to not be less than $theOther", this >= theOther)
-infix fun Short.shouldNotBeLessThan(theOther: Short) = this `should not be less than` theOther
+infix fun Short.shouldNotBeLessThan(theOther: Short) = assertTrue("Expected $this to not be less than $theOther", this >= theOther)
 
-infix fun Int.`should not be less than`(theOther: Int) = assertTrue("Expected $this to not be less than $theOther", this >= theOther)
-infix fun Int.shouldNotBeLessThan(theOther: Int) = this `should not be less than` theOther
+infix fun Int.shouldNotBeLessThan(theOther: Int) = assertTrue("Expected $this to not be less than $theOther", this >= theOther)
 
-infix fun Long.`should not be less than`(theOther: Long) = assertTrue("Expected $this to not be less than $theOther", this >= theOther)
-infix fun Long.shouldNotBeLessThan(theOther: Long) = this `should not be less than` theOther
+infix fun Long.shouldNotBeLessThan(theOther: Long) = assertTrue("Expected $this to not be less than $theOther", this >= theOther)
 
-infix fun Float.`should not be less than`(theOther: Float) = assertTrue("Expected $this to not be less than $theOther", this >= theOther)
-infix fun Float.shouldNotBeLessThan(theOther: Float) = this `should not be less than` theOther
+infix fun Float.shouldNotBeLessThan(theOther: Float) = assertTrue("Expected $this to not be less than $theOther", this >= theOther)
 
-infix fun Double.`should not be less than`(theOther: Double) = assertTrue("Expected $this to not be less than $theOther", this >= theOther)
-infix fun Double.shouldNotBeLessThan(theOther: Double) = this `should not be less than` theOther
+infix fun Double.shouldNotBeLessThan(theOther: Double) = assertTrue("Expected $this to not be less than $theOther", this >= theOther)
 
-infix fun Byte.`should be less or equal to`(theOther: Byte) = assertTrue("Expected $this to be less or equal to $theOther", this <= theOther)
-infix fun Byte.shouldBeLessOrEqualTo(theOther: Byte) = this `should be less or equal to` theOther
+infix fun Byte.shouldBeLessOrEqualTo(theOther: Byte) = assertTrue("Expected $this to be less or equal to $theOther", this <= theOther)
 
-infix fun Short.`should be less or equal to`(theOther: Short) = assertTrue("Expected $this to be less or equal to $theOther", this <= theOther)
-infix fun Short.shouldBeLessOrEqualTo(theOther: Short) = this `should be less or equal to` theOther
+infix fun Short.shouldBeLessOrEqualTo(theOther: Short) = assertTrue("Expected $this to be less or equal to $theOther", this <= theOther)
 
-infix fun Int.`should be less or equal to`(theOther: Int) = assertTrue("Expected $this to be less or equal to $theOther", this <= theOther)
-infix fun Int.shouldBeLessOrEqualTo(theOther: Int) = this `should be less or equal to` theOther
+infix fun Int.shouldBeLessOrEqualTo(theOther: Int) = assertTrue("Expected $this to be less or equal to $theOther", this <= theOther)
 
-infix fun Long.`should be less or equal to`(theOther: Long) = assertTrue("Expected $this to be less or equal to $theOther", this <= theOther)
-infix fun Long.shouldBeLessOrEqualTo(theOther: Long) = this `should be less or equal to` theOther
+infix fun Long.shouldBeLessOrEqualTo(theOther: Long) = assertTrue("Expected $this to be less or equal to $theOther", this <= theOther)
 
-infix fun Float.`should be less or equal to`(theOther: Float) = assertTrue("Expected $this to be less or equal to $theOther", this <= theOther)
-infix fun Float.shouldBeLessOrEqualTo(theOther: Float) = this `should be less or equal to` theOther
+infix fun Float.shouldBeLessOrEqualTo(theOther: Float) = assertTrue("Expected $this to be less or equal to $theOther", this <= theOther)
 
-infix fun Double.`should be less or equal to`(theOther: Double) = assertTrue("Expected $this to be less or equal to $theOther", this <= theOther)
-infix fun Double.shouldBeLessOrEqualTo(theOther: Double) = this `should be less or equal to` theOther
+infix fun Double.shouldBeLessOrEqualTo(theOther: Double) = assertTrue("Expected $this to be less or equal to $theOther", this <= theOther)
 
-infix fun Byte.`should not be less or equal to`(theOther: Byte) = assertTrue("Expected $this to not be less or equal to $theOther", this > theOther)
-infix fun Byte.shouldNotBeLessOrEqualTo(theOther: Byte) = this `should not be less or equal to` theOther
+infix fun Byte.shouldNotBeLessOrEqualTo(theOther: Byte) = assertTrue("Expected $this to not be less or equal to $theOther", this > theOther)
 
-infix fun Short.`should not be less or equal to`(theOther: Short) = assertTrue("Expected $this to not be less or equal to $theOther", this > theOther)
-infix fun Short.shouldNotBeLessOrEqualTo(theOther: Short) = this `should not be less or equal to` theOther
+infix fun Short.shouldNotBeLessOrEqualTo(theOther: Short) = assertTrue("Expected $this to not be less or equal to $theOther", this > theOther)
 
-infix fun Int.`should not be less or equal to`(theOther: Int) = assertTrue("Expected $this to not be less or equal to $theOther", this > theOther)
-infix fun Int.shouldNotBeLessOrEqualTo(theOther: Int) = this `should not be less or equal to` theOther
+infix fun Int.shouldNotBeLessOrEqualTo(theOther: Int) = assertTrue("Expected $this to not be less or equal to $theOther", this > theOther)
 
-infix fun Long.`should not be less or equal to`(theOther: Long) = assertTrue("Expected $this to not be less or equal to $theOther", this > theOther)
-infix fun Long.shouldNotBeLessOrEqualTo(theOther: Long) = this `should not be less or equal to` theOther
+infix fun Long.shouldNotBeLessOrEqualTo(theOther: Long) = assertTrue("Expected $this to not be less or equal to $theOther", this > theOther)
 
-infix fun Float.`should not be less or equal to`(theOther: Float) = assertTrue("Expected $this to not be less or equal to $theOther", this > theOther)
-infix fun Float.shouldNotBeLessOrEqualTo(theOther: Float) = this `should not be less or equal to` theOther
+infix fun Float.shouldNotBeLessOrEqualTo(theOther: Float) = assertTrue("Expected $this to not be less or equal to $theOther", this > theOther)
 
-infix fun Double.`should not be less or equal to`(theOther: Double) = assertTrue("Expected $this to not be less or equal to $theOther", this > theOther)
-infix fun Double.shouldNotBeLessOrEqualTo(theOther: Double) = this `should not be less or equal to` theOther
+infix fun Double.shouldNotBeLessOrEqualTo(theOther: Double) = assertTrue("Expected $this to not be less or equal to $theOther", this > theOther)
 
-fun Byte.`should be positive`() = assertTrue("Expected $this to be positive", this > 0)
-fun Byte.shouldBePositive() = this.`should be positive`()
+fun Byte.shouldBePositive() = assertTrue("Expected $this to be positive", this > 0)
 
-fun Short.`should be positive`() = assertTrue("Expected $this to be positive", this > 0)
-fun Short.shouldBePositive() = this.`should be positive`()
+fun Short.shouldBePositive() = assertTrue("Expected $this to be positive", this > 0)
 
-fun Int.`should be positive`() = assertTrue("Expected $this to be positive", this > 0)
-fun Int.shouldBePositive() = this.`should be positive`()
+fun Int.shouldBePositive() = assertTrue("Expected $this to be positive", this > 0)
 
-fun Long.`should be positive`() = assertTrue("Expected $this to be positive", this > 0)
-fun Long.shouldBePositive() = this.`should be positive`()
+fun Long.shouldBePositive() = assertTrue("Expected $this to be positive", this > 0)
 
-fun Float.`should be positive`() = assertTrue("Expected $this to be positive", this > 0)
-fun Float.shouldBePositive() = this.`should be positive`()
+fun Float.shouldBePositive() = assertTrue("Expected $this to be positive", this > 0)
 
-fun Double.`should be positive`() = assertTrue("Expected $this to be positive", this > 0)
-fun Double.shouldBePositive() = this.`should be positive`()
+fun Double.shouldBePositive() = assertTrue("Expected $this to be positive", this > 0)
 
-fun Byte.`should be negative`() = assertTrue("Expected $this to be negative", this < 0)
-fun Byte.shouldBeNegative() = this.`should be negative`()
+fun Byte.shouldBeNegative() = assertTrue("Expected $this to be negative", this < 0)
 
-fun Short.`should be negative`() = assertTrue("Expected $this to be negative", this < 0)
-fun Short.shouldBeNegative() = this.`should be negative`()
+fun Short.shouldBeNegative() = assertTrue("Expected $this to be negative", this < 0)
 
-fun Int.`should be negative`() = assertTrue("Expected $this to be negative", this < 0)
-fun Int.shouldBeNegative() = this.`should be negative`()
+fun Int.shouldBeNegative() = assertTrue("Expected $this to be negative", this < 0)
 
-fun Long.`should be negative`() = assertTrue("Expected $this to be negative", this < 0)
-fun Long.shouldBeNegative() = this.`should be negative`()
+fun Long.shouldBeNegative() = assertTrue("Expected $this to be negative", this < 0)
 
-fun Float.`should be negative`() = assertTrue("Expected $this to be negative", this < 0)
-fun Float.shouldBeNegative() = this.`should be negative`()
+fun Float.shouldBeNegative() = assertTrue("Expected $this to be negative", this < 0)
 
-fun Double.`should be negative`() = assertTrue("Expected $this to be negative", this < 0)
-fun Double.shouldBeNegative() = this.`should be negative`()
+fun Double.shouldBeNegative() = assertTrue("Expected $this to be negative", this < 0)
 
-fun Byte.`should be in range`(lowerBound: Byte, upperBound: Byte) = assertTrue("Expected $this to be between (and including) $lowerBound and $upperBound", this >= lowerBound && this <= upperBound)
-fun Byte.shouldBeInRange(lowerBound: Byte, upperBound: Byte) = this.`should be in range`(lowerBound, upperBound)
+fun Byte.shouldBeInRange(lowerBound: Byte, upperBound: Byte) = assertTrue("Expected $this to be between (and including) $lowerBound and $upperBound", this >= lowerBound && this <= upperBound)
 
-fun Short.`should be in range`(lowerBound: Short, upperBound: Short) = assertTrue("Expected $this to be between (and including) $lowerBound and $upperBound", this >= lowerBound && this <= upperBound)
-fun Short.shouldBeInRange(lowerBound: Short, upperBound: Short) = this.`should be in range`(lowerBound, upperBound)
+fun Short.shouldBeInRange(lowerBound: Short, upperBound: Short) = assertTrue("Expected $this to be between (and including) $lowerBound and $upperBound", this >= lowerBound && this <= upperBound)
 
-fun Int.`should be in range`(lowerBound: Int, upperBound: Int) = assertTrue("Expected $this to be between (and including) $lowerBound and $upperBound", this >= lowerBound && this <= upperBound)
-fun Int.shouldBeInRange(lowerBound: Int, upperBound: Int) = this.`should be in range`(lowerBound, upperBound)
+fun Int.shouldBeInRange(lowerBound: Int, upperBound: Int) = assertTrue("Expected $this to be between (and including) $lowerBound and $upperBound", this >= lowerBound && this <= upperBound)
 
-fun Long.`should be in range`(lowerBound: Long, upperBound: Long) = assertTrue("Expected $this to be between (and including) $lowerBound and $upperBound", this >= lowerBound && this <= upperBound)
-fun Long.shouldBeInRange(lowerBound: Long, upperBound: Long) = this.`should be in range`(lowerBound, upperBound)
+fun Long.shouldBeInRange(lowerBound: Long, upperBound: Long) = assertTrue("Expected $this to be between (and including) $lowerBound and $upperBound", this >= lowerBound && this <= upperBound)
 
-fun Float.`should be in range`(lowerBound: Float, upperBound: Float) = assertTrue("Expected $this to be between (and including) $lowerBound and $upperBound", this >= lowerBound && this <= upperBound)
-fun Float.shouldBeInRange(lowerBound: Float, upperBound: Float) = this.`should be in range`(lowerBound, upperBound)
+fun Float.shouldBeInRange(lowerBound: Float, upperBound: Float) = assertTrue("Expected $this to be between (and including) $lowerBound and $upperBound", this >= lowerBound && this <= upperBound)
 
-fun Double.`should be in range`(lowerBound: Double, upperBound: Double) = assertTrue("Expected $this to be between (and including) $lowerBound and $upperBound", this >= lowerBound && this <= upperBound)
-fun Double.shouldBeInRange(lowerBound: Double, upperBound: Double) = this.`should be in range`(lowerBound, upperBound)
+fun Double.shouldBeInRange(lowerBound: Double, upperBound: Double) = assertTrue("Expected $this to be between (and including) $lowerBound and $upperBound", this >= lowerBound && this <= upperBound)
 
-fun Byte.`should not be in range`(lowerBound: Byte, upperBound: Byte) = assertTrue("Expected $this to not be between (and including) $lowerBound and $upperBound", this < lowerBound || this > upperBound)
-fun Byte.shouldNotBeInRange(lowerBound: Byte, upperBound: Byte) = this.`should not be in range`(lowerBound, upperBound)
+fun Byte.shouldNotBeInRange(lowerBound: Byte, upperBound: Byte) = assertTrue("Expected $this to not be between (and including) $lowerBound and $upperBound", this < lowerBound || this > upperBound)
 
-fun Short.`should not be in range`(lowerBound: Short, upperBound: Short) = assertTrue("Expected $this to not be between (and including) $lowerBound and $upperBound", this < lowerBound || this > upperBound)
-fun Short.shouldNotBeInRange(lowerBound: Short, upperBound: Short) = this.`should not be in range`(lowerBound, upperBound)
+fun Short.shouldNotBeInRange(lowerBound: Short, upperBound: Short) = assertTrue("Expected $this to not be between (and including) $lowerBound and $upperBound", this < lowerBound || this > upperBound)
 
-fun Int.`should not be in range`(lowerBound: Int, upperBound: Int) = assertTrue("Expected $this to not be between (and including) $lowerBound and $upperBound", this < lowerBound || this > upperBound)
-fun Int.shouldNotBeInRange(lowerBound: Int, upperBound: Int) = this.`should not be in range`(lowerBound, upperBound)
+fun Int.shouldNotBeInRange(lowerBound: Int, upperBound: Int) = assertTrue("Expected $this to not be between (and including) $lowerBound and $upperBound", this < lowerBound || this > upperBound)
 
-fun Long.`should not be in range`(lowerBound: Long, upperBound: Long) = assertTrue("Expected $this to not be between (and including) $lowerBound and $upperBound", this < lowerBound || this > upperBound)
-fun Long.shouldNotBeInRange(lowerBound: Long, upperBound: Long) = this.`should not be in range`(lowerBound, upperBound)
+fun Long.shouldNotBeInRange(lowerBound: Long, upperBound: Long) = assertTrue("Expected $this to not be between (and including) $lowerBound and $upperBound", this < lowerBound || this > upperBound)
 
-fun Float.`should not be in range`(lowerBound: Float, upperBound: Float) = assertTrue("Expected $this to not be between (and including) $lowerBound and $upperBound", this < lowerBound || this > upperBound)
-fun Float.shouldNotBeInRange(lowerBound: Float, upperBound: Float) = this.`should not be in range`(lowerBound, upperBound)
+fun Float.shouldNotBeInRange(lowerBound: Float, upperBound: Float) = assertTrue("Expected $this to not be between (and including) $lowerBound and $upperBound", this < lowerBound || this > upperBound)
 
-fun Double.`should not be in range`(lowerBound: Double, upperBound: Double) = assertTrue("Expected $this to not be between (and including) $lowerBound and $upperBound", this < lowerBound || this > upperBound)
-fun Double.shouldNotBeInRange(lowerBound: Double, upperBound: Double) = this.`should not be in range`(lowerBound, upperBound)
+fun Double.shouldNotBeInRange(lowerBound: Double, upperBound: Double) = assertTrue("Expected $this to not be between (and including) $lowerBound and $upperBound", this < lowerBound || this > upperBound)
 
-infix fun Byte.`should be in range`(range: IntRange) = (this.toInt()).`should be in range`(range)
-infix fun Byte.shouldBeInRange(range: IntRange) = this.`should be in range`(range)
+infix fun Byte.shouldBeInRange(range: IntRange) = (this.toInt()).shouldBeInRange(range)
 
-infix fun Short.`should be in range`(range: IntRange) = (this.toInt()).`should be in range`(range)
-infix fun Short.shouldBeInRange(range: IntRange) = this.`should be in range`(range)
+infix fun Short.shouldBeInRange(range: IntRange) = (this.toInt()).shouldBeInRange(range)
 
-infix fun Int.`should be in range`(range: IntRange) = this.`should be in range`(range.first, range.last)
-infix fun Int.shouldBeInRange(range: IntRange) = this.`should be in range`(range)
+infix fun Int.shouldBeInRange(range: IntRange) = this.shouldBeInRange(range.first, range.last)
 
-infix fun Long.`should be in range`(range: LongRange) = this.`should be in range`(range.first, range.last)
-infix fun Long.shouldBeInRange(range: LongRange) = this.`should be in range`(range)
+infix fun Long.shouldBeInRange(range: LongRange) = this.shouldBeInRange(range.first, range.last)
 
-infix fun Byte.`should not be in range`(range: IntRange) = (this.toInt()).`should not be in range`(range)
-infix fun Byte.shouldNotBeInRange(range: IntRange) = this.`should not be in range`(range)
+infix fun Byte.shouldNotBeInRange(range: IntRange) = (this.toInt()).shouldNotBeInRange(range)
 
-infix fun Short.`should not be in range`(range: IntRange) = (this.toInt()).`should not be in range`(range)
-infix fun Short.shouldNotBeInRange(range: IntRange) = this.`should not be in range`(range)
+infix fun Short.shouldNotBeInRange(range: IntRange) = (this.toInt()).shouldNotBeInRange(range)
 
-infix fun Int.`should not be in range`(range: IntRange) = this.`should not be in range`(range.first, range.last)
-infix fun Int.shouldNotBeInRange(range: IntRange) = this.`should not be in range`(range)
+infix fun Int.shouldNotBeInRange(range: IntRange) = this.shouldNotBeInRange(range.first, range.last)
 
-infix fun Long.`should not be in range`(range: LongRange) = this.`should not be in range`(range.first, range.last)
-infix fun Long.shouldNotBeInRange(range: LongRange) = this.`should not be in range`(range)
+infix fun Long.shouldNotBeInRange(range: LongRange) = this.shouldNotBeInRange(range.first, range.last)
 

--- a/src/main/kotlin/org/amshove/kluent/NumericalBacktick.kt
+++ b/src/main/kotlin/org/amshove/kluent/NumericalBacktick.kt
@@ -1,0 +1,189 @@
+package org.amshove.kluent
+
+infix fun Boolean.`should equal to`(theOther: Boolean) = this.shouldEqualTo(theOther)
+
+infix fun Byte.`should equal to`(theOther: Byte) = this.shouldEqualTo(theOther)
+
+infix fun Short.`should equal to`(theOther: Short) = this.shouldEqualTo(theOther)
+
+infix fun Int.`should equal to`(theOther: Int) = this.shouldEqualTo(theOther)
+
+infix fun Long.`should equal to`(theOther: Long) = this.shouldEqualTo(theOther)
+
+infix fun Float.`should equal to`(theOther: Float) = this.shouldEqualTo(theOther)
+
+infix fun Double.`should equal to`(theOther: Double) = this.shouldEqualTo(theOther)
+
+infix fun Boolean.`should not equal to`(theOther: Boolean) = this.shouldNotEqualTo(theOther)
+
+infix fun Byte.`should not equal to`(theOther: Byte) = this.shouldNotEqualTo(theOther)
+
+infix fun Short.`should not equal to`(theOther: Short) = this.shouldNotEqualTo(theOther)
+
+infix fun Int.`should not equal to`(theOther: Int) = this.shouldNotEqualTo(theOther)
+
+infix fun Long.`should not equal to`(theOther: Long) = this.shouldNotEqualTo(theOther)
+
+infix fun Float.`should not equal to`(theOther: Float) = this.shouldNotEqualTo(theOther)
+
+infix fun Double.`should not equal to`(theOther: Double) = this.shouldNotEqualTo(theOther)
+
+infix fun Byte.`should be greater than`(theOther: Byte) = this.shouldBeGreaterThan(theOther)
+
+infix fun Short.`should be greater than`(theOther: Short) = this.shouldBeGreaterThan(theOther)
+
+infix fun Int.`should be greater than`(theOther: Int) = this.shouldBeGreaterThan(theOther)
+
+infix fun Long.`should be greater than`(theOther: Long) = this.shouldBeGreaterThan(theOther)
+
+infix fun Float.`should be greater than`(theOther: Float) = this.shouldBeGreaterThan(theOther)
+
+infix fun Double.`should be greater than`(theOther: Double) = this.shouldBeGreaterThan(theOther)
+
+infix fun Byte.`should not be greater than`(theOther: Byte) = this.shouldNotBeGreaterThan(theOther)
+
+infix fun Short.`should not be greater than`(theOther: Short) = this.shouldNotBeGreaterThan(theOther)
+
+infix fun Int.`should not be greater than`(theOther: Int) = this.shouldNotBeGreaterThan(theOther)
+
+infix fun Long.`should not be greater than`(theOther: Long) = this.shouldNotBeGreaterThan(theOther)
+
+infix fun Float.`should not be greater than`(theOther: Float) = this.shouldNotBeGreaterThan(theOther)
+
+infix fun Double.`should not be greater than`(theOther: Double) = this.shouldNotBeGreaterThan(theOther)
+
+infix fun Byte.`should be greater or equal to`(theOther: Byte) = this.shouldBeGreaterOrEqualTo(theOther)
+
+infix fun Short.`should be greater or equal to`(theOther: Short) = this.shouldBeGreaterOrEqualTo(theOther)
+
+infix fun Int.`should be greater or equal to`(theOther: Int) = this.shouldBeGreaterOrEqualTo(theOther)
+
+infix fun Long.`should be greater or equal to`(theOther: Long) = this.shouldBeGreaterOrEqualTo(theOther)
+
+infix fun Float.`should be greater or equal to`(theOther: Float) = this.shouldBeGreaterOrEqualTo(theOther)
+
+infix fun Double.`should be greater or equal to`(theOther: Double) = this.shouldBeGreaterOrEqualTo(theOther)
+
+infix fun Byte.`should not be greater or equal to`(theOther: Byte) = this.shouldNotBeGreaterOrEqualTo(theOther)
+
+infix fun Short.`should not be greater or equal to`(theOther: Short) = this.shouldNotBeGreaterOrEqualTo(theOther)
+
+infix fun Int.`should not be greater or equal to`(theOther: Int) = this.shouldNotBeGreaterOrEqualTo(theOther)
+
+infix fun Long.`should not be greater or equal to`(theOther: Long) = this.shouldNotBeGreaterOrEqualTo(theOther)
+
+infix fun Float.`should not be greater or equal to`(theOther: Float) = this.shouldNotBeGreaterOrEqualTo(theOther)
+
+infix fun Double.`should not be greater or equal to`(theOther: Double) = this.shouldNotBeGreaterOrEqualTo(theOther)
+
+infix fun Byte.`should be less than`(theOther: Byte) = this.shouldBeLessThan(theOther)
+
+infix fun Short.`should be less than`(theOther: Short) = this.shouldBeLessThan(theOther)
+
+infix fun Int.`should be less than`(theOther: Int) = this.shouldBeLessThan(theOther)
+
+infix fun Long.`should be less than`(theOther: Long) = this.shouldBeLessThan(theOther)
+
+infix fun Float.`should be less than`(theOther: Float) = this.shouldBeLessThan(theOther)
+
+infix fun Double.`should be less than`(theOther: Double) = this.shouldBeLessThan(theOther)
+
+infix fun Byte.`should not be less than`(theOther: Byte) = this.shouldNotBeLessThan(theOther)
+
+infix fun Short.`should not be less than`(theOther: Short) = this.shouldNotBeLessThan(theOther)
+
+infix fun Int.`should not be less than`(theOther: Int) = this.shouldNotBeLessThan(theOther)
+
+infix fun Long.`should not be less than`(theOther: Long) = this.shouldNotBeLessThan(theOther)
+
+infix fun Float.`should not be less than`(theOther: Float) = this.shouldNotBeLessThan(theOther)
+
+infix fun Double.`should not be less than`(theOther: Double) = this.shouldNotBeLessThan(theOther)
+
+infix fun Byte.`should be less or equal to`(theOther: Byte) = this.shouldBeLessOrEqualTo(theOther)
+
+infix fun Short.`should be less or equal to`(theOther: Short) = this.shouldBeLessOrEqualTo(theOther)
+
+infix fun Int.`should be less or equal to`(theOther: Int) = this.shouldBeLessOrEqualTo(theOther)
+
+infix fun Long.`should be less or equal to`(theOther: Long) = this.shouldBeLessOrEqualTo(theOther)
+
+infix fun Float.`should be less or equal to`(theOther: Float) = this.shouldBeLessOrEqualTo(theOther)
+
+infix fun Double.`should be less or equal to`(theOther: Double) = this.shouldBeLessOrEqualTo(theOther)
+
+infix fun Byte.`should not be less or equal to`(theOther: Byte) = this.shouldNotBeLessOrEqualTo(theOther)
+
+infix fun Short.`should not be less or equal to`(theOther: Short) = this.shouldNotBeLessOrEqualTo(theOther)
+
+infix fun Int.`should not be less or equal to`(theOther: Int) = this.shouldNotBeLessOrEqualTo(theOther)
+
+infix fun Long.`should not be less or equal to`(theOther: Long) = this.shouldNotBeLessOrEqualTo(theOther)
+
+infix fun Float.`should not be less or equal to`(theOther: Float) = this.shouldNotBeLessOrEqualTo(theOther)
+
+infix fun Double.`should not be less or equal to`(theOther: Double) = this.shouldNotBeLessOrEqualTo(theOther)
+
+fun Byte.`should be positive`() = this.shouldBePositive()
+
+fun Short.`should be positive`() = this.shouldBePositive()
+
+fun Int.`should be positive`() = this.shouldBePositive()
+
+fun Long.`should be positive`() = this.shouldBePositive()
+
+fun Float.`should be positive`() = this.shouldBePositive()
+
+fun Double.`should be positive`() = this.shouldBePositive()
+
+fun Byte.`should be negative`() = this.shouldBeNegative()
+
+fun Short.`should be negative`() = this.shouldBeNegative()
+
+fun Int.`should be negative`() = this.shouldBeNegative()
+
+fun Long.`should be negative`() = this.shouldBeNegative()
+
+fun Float.`should be negative`() = this.shouldBeNegative()
+
+fun Double.`should be negative`() = this.shouldBeNegative()
+
+fun Byte.`should be in range`(lowerBound: Byte, upperBound: Byte) = this.shouldBeInRange(lowerBound, upperBound)
+
+fun Short.`should be in range`(lowerBound: Short, upperBound: Short) = this.shouldBeInRange(lowerBound, upperBound)
+
+fun Int.`should be in range`(lowerBound: Int, upperBound: Int) = this.shouldBeInRange(lowerBound, upperBound)
+
+fun Long.`should be in range`(lowerBound: Long, upperBound: Long) = this.shouldBeInRange(lowerBound, upperBound)
+
+fun Float.`should be in range`(lowerBound: Float, upperBound: Float) = this.shouldBeInRange(lowerBound, upperBound)
+
+fun Double.`should be in range`(lowerBound: Double, upperBound: Double) = this.shouldBeInRange(lowerBound, upperBound)
+
+fun Byte.`should not be in range`(lowerBound: Byte, upperBound: Byte) = this.shouldNotBeInRange(lowerBound, upperBound)
+
+fun Short.`should not be in range`(lowerBound: Short, upperBound: Short) = this.shouldNotBeInRange(lowerBound, upperBound)
+
+fun Int.`should not be in range`(lowerBound: Int, upperBound: Int) = this.shouldNotBeInRange(lowerBound, upperBound)
+
+fun Long.`should not be in range`(lowerBound: Long, upperBound: Long) = this.shouldNotBeInRange(lowerBound, upperBound)
+
+fun Float.`should not be in range`(lowerBound: Float, upperBound: Float) = this.shouldNotBeInRange(lowerBound, upperBound)
+
+fun Double.`should not be in range`(lowerBound: Double, upperBound: Double) = this.shouldNotBeInRange(lowerBound, upperBound)
+
+infix fun Byte.`should be in range`(range: IntRange) = this.shouldBeInRange(range)
+
+infix fun Short.`should be in range`(range: IntRange) = this.shouldBeInRange(range)
+
+infix fun Int.`should be in range`(range: IntRange) = this.shouldBeInRange(range)
+
+infix fun Long.`should be in range`(range: LongRange) = this.shouldBeInRange(range)
+
+infix fun Byte.`should not be in range`(range: IntRange) = this.shouldNotBeInRange(range)
+
+infix fun Short.`should not be in range`(range: IntRange) = this.shouldNotBeInRange(range)
+
+infix fun Int.`should not be in range`(range: IntRange) = this.shouldNotBeInRange(range)
+
+infix fun Long.`should not be in range`(range: LongRange) = this.shouldNotBeInRange(range)


### PR DESCRIPTION
It turns out that Android does not support having spaces in method names.  As a result, Android instrumentation tests fail to run due to a runtime failure with the backtick versions of the methods in Kluent.

I moved the backtick code into separate files.  I also made the code more uniform in that the camelCase methods have the actual code, where the backtick methods simply forward to the camelCase methods.

If you set the "ANDROID" property on the project, it will exclude the backtick files.  When publishing, it will name the artifact "kluent-android".

For Android builds: `./gradlew -PANDROID assemble`

I ensured that all unit tests run with and without the ANDROID property.  I also verified that if I don't exclude the backtick tests, but I do exclude the backtick source, that the tests do in fact fail.

I also tested publishing to maven local and using the artifact in my Android projects.  Everything works as expected.