### PR TITLE
Add shouldContainSome and shouldContainNone to collections

### DIFF
--- a/docs/CharSequenceAssertions.md
+++ b/docs/CharSequenceAssertions.md
@@ -15,6 +15,9 @@ The following assertions work with every subtype of `CharSequence` (e.g. `Sring`
 "name" shouldContain "am"
 "name" shouldNotContain "abc"
 
+"I like fluent assertions" shouldContainSome listOf("fluent", "not", "test")
+"I like fluent assertions" shouldContainNone listOf("test, "compile")
+
 "name" shouldMatch "\\w+"
 "name" shouldNotMatch "\\d+"
 

--- a/docs/CollectionAssertions.md
+++ b/docs/CollectionAssertions.md
@@ -8,6 +8,9 @@ The following assertions work for `Array` and `Iterable`
 theIntArray shouldContain 2
 theIntArray shouldNotContain 10
 
+theIntArray shouldContainSome arrayOf(1, 10, 15, 2)
+theIntArray shouldContainNone arrayOf(5, 10, 11)
+
 arrayOf(1, 2, 3) shouldEqual arrayOf(1, 2, 3)
 arrayOf(4, 5, 6) shouldNotEqual arrayOf(7, 8, 9)
 

--- a/src/main/kotlin/org/amshove/kluent/CharSequence.kt
+++ b/src/main/kotlin/org/amshove/kluent/CharSequence.kt
@@ -6,7 +6,13 @@ infix fun CharSequence.shouldStartWith(theOther: CharSequence) = assertTrue("Exp
 
 infix fun CharSequence.shouldEndWith(theOther: CharSequence) = assertTrue("Expected the CharSequence $this to end with $theOther", this.endsWith(theOther))
 
+infix fun CharSequence.shouldContainSome(things: Iterable<CharSequence>) = assertTrue("Expected '$this' to contain at least one of $things", things.any { this.contains(it) })
+
+infix fun CharSequence.shouldContainNone(things: Iterable<CharSequence>) = assertTrue("Expected '$this' to not contain any of $things", things.none { this.contains(it) })
+
 infix fun CharSequence.shouldContain(theOther: CharSequence) = assertTrue("Expected the CharSequence $this to contain $theOther", this.contains(theOther))
+
+infix fun CharSequence.shouldNotContainAny(things: Iterable<CharSequence>) = this shouldContainNone things
 
 infix fun CharSequence.shouldMatch(regex: String) = assertTrue("Expected $this to match $regex", this.matches(Regex(regex)))
 
@@ -24,7 +30,7 @@ infix fun String.shouldEqualTo(theOther: String) = assertEquals(theOther, this)
 
 infix fun String.shouldNotEqualTo(theOther: String) = assertNotEquals(theOther, this)
 
-infix fun CharSequence.shouldNotStartWith(theOther: CharSequence) =assertFalse("Expected the CharSequence $this to not start with $theOther", this.startsWith(theOther))
+infix fun CharSequence.shouldNotStartWith(theOther: CharSequence) = assertFalse("Expected the CharSequence $this to not start with $theOther", this.startsWith(theOther))
 
 infix fun CharSequence.shouldNotEndWith(theOther: CharSequence) = assertFalse("Expected the CharSequence $this to not end with $theOther", this.endsWith(theOther))
 

--- a/src/main/kotlin/org/amshove/kluent/CharSequenceBacktick.kt
+++ b/src/main/kotlin/org/amshove/kluent/CharSequenceBacktick.kt
@@ -4,7 +4,13 @@ infix fun CharSequence.`should start with`(theOther: CharSequence) = this.should
 
 infix fun CharSequence.`should end with`(theOther: CharSequence) = this.shouldEndWith(theOther)
 
+infix fun CharSequence.`should contain some`(things: Iterable<CharSequence>) = this.shouldContainSome(things)
+
+infix fun CharSequence.`should contain none`(things: Iterable<CharSequence>) = this.shouldContainNone(things)
+
 infix fun CharSequence.`should contain`(theOther: CharSequence) = this.shouldContain(theOther)
+
+infix fun CharSequence.`should not contain any`(things: Iterable<CharSequence>) = this.shouldNotContainAny(things)
 
 infix fun CharSequence.`should match`(regex: String) = this.shouldMatch(regex)
 

--- a/src/main/kotlin/org/amshove/kluent/Collections.kt
+++ b/src/main/kotlin/org/amshove/kluent/Collections.kt
@@ -4,6 +4,10 @@ import org.junit.Assert.*
 
 infix fun <T> Array<T>.shouldContain(theThing: T) = if (this.contains(theThing)) Unit else fail("$this should contain $theThing", "$theThing", join(this))
 
+infix fun <T> Array<T>.shouldContainSome(things: Array<T>) = assertTrue("Expected $this to contain at least one of $things", this.any { things.contains(it) })
+
+infix fun <T> Array<T>.shouldContainNone(things: Array<T>) = assertTrue("Expected $this to contain none of $things", this.none { things.contains(it) })
+
 infix fun <T> Array<T>.shouldContainAll(things: Array<T>) = things.forEach { shouldContain(it) }
 
 infix fun <T> Array<T>.shouldNotContain(theThing: T) = if (!this.contains(theThing)) Unit else fail("$this should not contain $theThing", "the Array to not contain $theThing", join(this))
@@ -24,6 +28,10 @@ fun IntArray.shouldNotBeEmpty() = this.toTypedArray().shouldNotBeEmpty()
 
 infix fun IntArray.shouldContain(theThing: Int) = this.toTypedArray() shouldContain theThing
 
+infix fun IntArray.shouldContainSome(things: IntArray) = this.toTypedArray().shouldContainSome(things.toTypedArray())
+
+infix fun IntArray.shouldContainNone(things: IntArray) = this.toTypedArray().shouldContainNone(things.toTypedArray())
+
 infix fun IntArray.shouldContainAll(things: IntArray) = things.forEach { shouldContain(it) }
 
 infix fun IntArray.shouldNotContain(theThing: Int) = this.toTypedArray() shouldNotContain theThing
@@ -42,6 +50,10 @@ fun BooleanArray.shouldNotBeEmpty() = this.toTypedArray().shouldNotBeEmpty()
 
 infix fun BooleanArray.shouldContain(theThing: Boolean) = this.toTypedArray() shouldContain theThing
 
+infix fun BooleanArray.shouldContainSome(things: BooleanArray) = this.toTypedArray().shouldContainSome(things.toTypedArray())
+
+infix fun BooleanArray.shouldContainNone(things: BooleanArray) = this.toTypedArray().shouldContainNone(things.toTypedArray())
+
 infix fun BooleanArray.shouldContainAll(things: BooleanArray) = things.forEach { shouldContain(it) }
 
 infix fun BooleanArray.shouldNotContain(theThing: Boolean) = this.toTypedArray() shouldNotContain theThing
@@ -59,6 +71,10 @@ fun ByteArray.shouldBeEmpty() = this.toTypedArray().shouldBeEmpty()
 fun ByteArray.shouldNotBeEmpty() = this.toTypedArray().shouldNotBeEmpty()
 
 infix fun ByteArray.shouldContain(theThing: Byte) = this.toTypedArray() shouldContain theThing
+
+infix fun ByteArray.shouldContainSome(things: ByteArray) = this.toTypedArray().shouldContainSome(things.toTypedArray())
+
+infix fun ByteArray.shouldContainNone(things: ByteArray) = this.toTypedArray().shouldContainNone(things.toTypedArray())
 
 infix fun ByteArray.shouldContainAll(things: ByteArray) = things.forEach { shouldContain(it) }
 
@@ -80,6 +96,10 @@ fun CharArray.shouldNotBeEmpty() = this.toTypedArray().shouldNotBeEmpty()
 
 infix fun CharArray.shouldContain(theThing: Char) = this.toTypedArray() shouldContain theThing
 
+infix fun CharArray.shouldContainSome(things: CharArray) = this.toTypedArray().shouldContainSome(things.toTypedArray())
+
+infix fun CharArray.shouldContainNone(things: CharArray) = this.toTypedArray().shouldContainNone(things.toTypedArray())
+
 infix fun CharArray.shouldContainAll(things: CharArray) = things.forEach { shouldContain(it) }
 
 infix fun CharArray.shouldNotContain(theThing: Char) = this.toTypedArray() shouldNotContain theThing
@@ -97,6 +117,10 @@ fun DoubleArray.shouldBeEmpty() = this.toTypedArray().shouldBeEmpty()
 fun DoubleArray.shouldNotBeEmpty() = this.toTypedArray().shouldNotBeEmpty()
 
 infix fun DoubleArray.shouldContain(theThing: Double) = this.toTypedArray() shouldContain theThing
+
+infix fun DoubleArray.shouldContainSome(things: DoubleArray) = this.toTypedArray().shouldContainSome(things.toTypedArray())
+
+infix fun DoubleArray.shouldContainNone(things: DoubleArray) = this.toTypedArray().shouldContainNone(things.toTypedArray())
 
 infix fun DoubleArray.shouldContainAll(things: DoubleArray) = things.forEach { shouldContain(it) }
 
@@ -116,6 +140,10 @@ fun FloatArray.shouldNotBeEmpty() = this.toTypedArray().shouldNotBeEmpty()
 
 infix fun FloatArray.shouldContain(theThing: Float) = this.toTypedArray() shouldContain theThing
 
+infix fun FloatArray.shouldContainSome(things: FloatArray) = this.toTypedArray().shouldContainSome(things.toTypedArray())
+
+infix fun FloatArray.shouldContainNone(things: FloatArray) = this.toTypedArray().shouldContainNone(things.toTypedArray())
+
 infix fun FloatArray.shouldContainAll(things: FloatArray) = things.forEach { shouldContain(it) }
 
 infix fun FloatArray.shouldNotContain(theThing: Float) = this.toTypedArray() shouldNotContain theThing
@@ -133,6 +161,10 @@ fun LongArray.shouldBeEmpty() = this.toTypedArray().shouldBeEmpty()
 fun LongArray.shouldNotBeEmpty() = this.toTypedArray().shouldNotBeEmpty()
 
 infix fun LongArray.shouldContain(theThing: Long) = this.toTypedArray() shouldContain theThing
+
+infix fun LongArray.shouldContainSome(things: LongArray) = this.toTypedArray().shouldContainSome(things.toTypedArray())
+
+infix fun LongArray.shouldContainNone(things: LongArray) = this.toTypedArray().shouldContainNone(things.toTypedArray())
 
 infix fun LongArray.shouldContainAll(things: LongArray) = things.forEach { shouldContain(it) }
 
@@ -152,6 +184,10 @@ fun ShortArray.shouldNotBeEmpty() = this.toTypedArray().shouldNotBeEmpty()
 
 infix fun ShortArray.shouldContain(theThing: Short) = this.toTypedArray() shouldContain theThing
 
+infix fun ShortArray.shouldContainSome(things: ShortArray) = this.toTypedArray().shouldContainSome(things.toTypedArray())
+
+infix fun ShortArray.shouldContainNone(things: ShortArray) = this.toTypedArray().shouldContainNone(things.toTypedArray())
+
 infix fun ShortArray.shouldContainAll(things: ShortArray) = things.forEach { shouldContain(it) }
 
 infix fun ShortArray.shouldNotContain(theThing: Short) = this.toTypedArray() shouldNotContain theThing
@@ -163,6 +199,10 @@ infix fun Short.shouldBeIn(theArray: ShortArray) = this shouldBeIn theArray.toTy
 infix fun Short.shouldNotBeIn(theArray: ShortArray) = this shouldNotBeIn theArray.toTypedArray()
 
 infix fun <T> Iterable<T>.shouldContain(theThing: T) = if (this.contains(theThing)) Unit else fail("$this should contain $theThing", "$theThing", join(this))
+
+infix fun <T> Iterable<T>.shouldContainSome(things: Iterable<T>) = assertTrue("Expected $this to contain at least one of $things", this.any { things.contains(it) })
+
+infix fun <T> Iterable<T>.shouldContainNone(things: Iterable<T>) = assertTrue("Expected $this to contain none of $things", this.none { things.contains(it) })
 
 infix fun <T> Iterable<T>.shouldContainAll(things: Iterable<T>) = things.forEach { shouldContain(it) }
 

--- a/src/main/kotlin/org/amshove/kluent/CollectionsBacktick.kt
+++ b/src/main/kotlin/org/amshove/kluent/CollectionsBacktick.kt
@@ -2,6 +2,10 @@ package org.amshove.kluent
 
 infix fun <T> Array<T>.`should contain`(theThing: T) = this.shouldContain(theThing)
 
+infix fun <T> Array<T>.`should contain some`(things: Array<T>) = this.shouldContainSome(things)
+
+infix fun <T> Array<T>.`should contain none`(things: Array<T>) = this.shouldContainNone(things)
+
 infix fun <T> Array<T>.`should contain all`(things: Array<T>) = this.shouldContainAll(things)
 
 infix fun <T> Array<T>.`should not contain`(theThing: T) = this.shouldNotContain(theThing)
@@ -22,6 +26,10 @@ fun IntArray.`should not be empty`() = this.shouldNotBeEmpty()
 
 infix fun IntArray.`should contain`(theThing: Int) = this.shouldContain(theThing)
 
+infix fun IntArray.`should contain some`(things: IntArray) = this.shouldContainSome(things)
+
+infix fun IntArray.`should contain none`(things: IntArray) = this.shouldContainNone(things)
+
 infix fun IntArray.`should contain all`(things: IntArray) = this.shouldContainAll(things)
 
 infix fun IntArray.`should not contain`(theThing: Int) = this.shouldNotContain(theThing)
@@ -39,6 +47,10 @@ fun BooleanArray.`should be empty`() = this.shouldBeEmpty()
 fun BooleanArray.`should not be empty`() = this.shouldNotBeEmpty()
 
 infix fun BooleanArray.`should contain`(theThing: Boolean) = this.shouldContain(theThing)
+
+infix fun BooleanArray.`should contain some`(things: BooleanArray) = this.shouldContainSome(things)
+
+infix fun BooleanArray.`should contain none`(things: BooleanArray) = this.shouldContainNone(things)
 
 infix fun BooleanArray.`should contain all`(things: BooleanArray) = this.shouldContainAll(things)
 
@@ -58,6 +70,10 @@ fun ByteArray.`should not be empty`() = this.shouldNotBeEmpty()
 
 infix fun ByteArray.`should contain`(theThing: Byte) = this.shouldContain(theThing)
 
+infix fun ByteArray.`should contain some`(things: ByteArray) = this.shouldContainSome(things)
+
+infix fun ByteArray.`should contain none`(things: ByteArray) = this.shouldContainNone(things)
+
 infix fun ByteArray.`should contain all`(things: ByteArray) = this.shouldContainAll(things)
 
 infix fun ByteArray.`should not contain`(theThing: Byte) = this.shouldNotContain(theThing)
@@ -75,6 +91,10 @@ fun CharArray.`should be empty`() = this.shouldBeEmpty()
 fun CharArray.`should not be empty`() = this.shouldNotBeEmpty()
 
 infix fun CharArray.`should contain`(theThing: Char) = this.shouldContain(theThing)
+
+infix fun CharArray.`should contain some`(things: CharArray) = this.shouldContainSome(things)
+
+infix fun CharArray.`should contain none`(things: CharArray) = this.shouldContainNone(things)
 
 infix fun CharArray.`should contain all`(things: CharArray) = this.shouldContainAll(things)
 
@@ -94,6 +114,10 @@ fun DoubleArray.`should not be empty`() = this.shouldNotBeEmpty()
 
 infix fun DoubleArray.`should contain`(theThing: Double) = this.shouldContain(theThing)
 
+infix fun DoubleArray.`should contain some`(things: DoubleArray) = this.shouldContainSome(things)
+
+infix fun DoubleArray.`should contain none`(things: DoubleArray) = this.shouldContainNone(things)
+
 infix fun DoubleArray.`should contain all`(things: DoubleArray) = this.shouldContainAll(things)
 
 infix fun DoubleArray.`should not contain`(theThing: Double) = this.shouldNotContain(theThing)
@@ -111,6 +135,10 @@ fun FloatArray.`should be empty`() = this.shouldBeEmpty()
 fun FloatArray.`should not be empty`() = this.shouldNotBeEmpty()
 
 infix fun FloatArray.`should contain`(theThing: Float) = this.shouldContain(theThing)
+
+infix fun FloatArray.`should contain some`(things: FloatArray) = this.shouldContainSome(things)
+
+infix fun FloatArray.`should contain none`(things: FloatArray) = this.shouldContainNone(things)
 
 infix fun FloatArray.`should contain all`(things: FloatArray) = this.shouldContainAll(things)
 
@@ -130,6 +158,10 @@ fun LongArray.`should not be empty`() = this.shouldNotBeEmpty()
 
 infix fun LongArray.`should contain`(theThing: Long) = this.shouldContain(theThing)
 
+infix fun LongArray.`should contain some`(things: LongArray) = this.shouldContainSome(things)
+
+infix fun LongArray.`should contain none`(things: LongArray) = this.shouldContainNone(things)
+
 infix fun LongArray.`should contain all`(things: LongArray) = this.shouldContainAll(things)
 
 infix fun LongArray.`should not contain`(theThing: Long) = this.shouldNotContain(theThing)
@@ -148,6 +180,10 @@ fun ShortArray.`should not be empty`() = this.shouldNotBeEmpty()
 
 infix fun ShortArray.`should contain`(theThing: Short) = this.shouldContain(theThing)
 
+infix fun ShortArray.`should contain some`(things: ShortArray) = this.shouldContainSome(things)
+
+infix fun ShortArray.`should contain none`(things: ShortArray) = this.shouldContainNone(things)
+
 infix fun ShortArray.`should contain all`(things: ShortArray) = this.shouldContainAll(things)
 
 infix fun ShortArray.`should not contain`(theThing: Short) = this.shouldNotContain(theThing)
@@ -159,6 +195,10 @@ infix fun Short.`should be in`(theArray: ShortArray) = this.shouldBeIn(theArray)
 infix fun Short.`should not be in`(theArray: ShortArray) = this.shouldNotBeIn(theArray)
 
 infix fun <T> Iterable<T>.`should contain`(theThing: T) = this.shouldContain(theThing)
+
+infix fun <T> Iterable<T>.`should contain some`(things: Iterable<T>) = this.shouldContainSome(things)
+
+infix fun <T> Iterable<T>.`should contain none`(things: Iterable<T>) = this.shouldContainNone(things)
 
 infix fun <T> Iterable<T>.`should contain all`(things: Iterable<T>) = this.shouldContainAll(things)
 

--- a/src/test/kotlin/org/amshove/kluent/tests/assertions/ShouldContainNoneTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/assertions/ShouldContainNoneTests.kt
@@ -1,0 +1,26 @@
+package org.amshove.kluent.tests.assertions
+
+import org.amshove.kluent.shouldContainNone
+import org.jetbrains.spek.api.Spek
+import kotlin.test.assertFails
+
+class ShouldContainNoneTests : Spek({
+    given("the shouldContainNone method") {
+        on("testing a list which doesn't contain at least one element") {
+            it("should pass") {
+                val cities = listOf("Israel", "Phoenix", "Egypt")
+                val actual = listOf("Berlin", "Stuttgart")
+
+                actual shouldContainNone cities
+            }
+        }
+        on("testing a list which contains at least one element") {
+            it("should fail") {
+                val cities = listOf("Israel", "Phoenix", "Stuttgart", "Egypt")
+                val actual = listOf("Berlin", "Stuttgart")
+
+                assertFails { actual shouldContainNone cities }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/org/amshove/kluent/tests/assertions/ShouldContainSomeTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/assertions/ShouldContainSomeTests.kt
@@ -1,0 +1,26 @@
+package org.amshove.kluent.tests.assertions
+
+import org.amshove.kluent.shouldContainSome
+import org.jetbrains.spek.api.Spek
+import kotlin.test.assertFails
+
+class ShouldContainSomeTests : Spek({
+    given("the shouldContainSome method") {
+        on("testing a list which contains at least one element") {
+            it("should pass") {
+                val cities = listOf("Israel", "Berlin", "Phoenix", "Egypt")
+                val actual = listOf("Berlin", "Stuttgart")
+
+                actual shouldContainSome cities
+            }
+        }
+        on("testing a list which doesn't contain at least one element") {
+            it("should fail") {
+                val cities = listOf("Israel", "Phoenix", "Egypt")
+                val actual = listOf("Berlin", "Stuttgart")
+
+                assertFails { actual shouldContainSome cities }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/org/amshove/kluent/tests/assertions/charsequence/ShouldContainNoneTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/assertions/charsequence/ShouldContainNoneTests.kt
@@ -1,0 +1,26 @@
+package org.amshove.kluent.tests.assertions.charsequence
+
+import org.amshove.kluent.shouldContainNone
+import org.jetbrains.spek.api.Spek
+import kotlin.test.assertFails
+
+class ShouldContainNoneTests : Spek({
+    given("the shouldContainNone method") {
+        on("testing if a string contains some substrings which it doesn't contain") {
+            it("should pass") {
+                val message = "I love to write fluent tests"
+                val otherStrings = listOf("testing", "writing", "code")
+
+                message shouldContainNone otherStrings
+            }
+        }
+        on("testing if a string contains some substrings") {
+            it("should fail") {
+                val message = "I love to write fluent tests"
+                val otherStrings = listOf("Berlin", "write")
+
+                assertFails { message shouldContainNone otherStrings }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/org/amshove/kluent/tests/assertions/charsequence/ShouldContainSomeTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/assertions/charsequence/ShouldContainSomeTests.kt
@@ -1,0 +1,26 @@
+package org.amshove.kluent.tests.assertions.charsequence
+
+import org.amshove.kluent.shouldContainSome
+import org.jetbrains.spek.api.Spek
+import kotlin.test.assertFails
+
+class ShouldContainSomeTests : Spek({
+    given("the shouldContainSome method") {
+        on("testing if a string contains some substrings") {
+            it("should pass") {
+                val message = "I love to write fluent tests"
+                val otherStrings = listOf("Berlin", "write")
+
+                message shouldContainSome otherStrings
+            }
+        }
+        on("testing if a string contains some substrings which it doesn't contain") {
+            it("should fail") {
+                val message = "I love to write fluent tests"
+                val otherStrings = listOf("testing", "writing", "code")
+
+                assertFails { message shouldContainSome otherStrings }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/org/amshove/kluent/tests/backtickassertions/ShouldContainNoneTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/backtickassertions/ShouldContainNoneTests.kt
@@ -1,0 +1,26 @@
+package org.amshove.kluent.tests.backtickassertions
+
+import org.amshove.kluent.`should contain none`
+import org.jetbrains.spek.api.Spek
+import kotlin.test.assertFails
+
+class ShouldContainNoneTests : Spek({
+    given("the shouldContainNone method") {
+        on("testing a list which doesn't contain at least one element") {
+            it("should pass") {
+                val cities = listOf("Israel", "Phoenix", "Egypt")
+                val actual = listOf("Berlin", "Stuttgart")
+
+                actual `should contain none` cities
+            }
+        }
+        on("testing a list which contains at least one element") {
+            it("should fail") {
+                val cities = listOf("Israel", "Phoenix", "Stuttgart", "Egypt")
+                val actual = listOf("Berlin", "Stuttgart")
+
+                assertFails { actual `should contain none` cities }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/org/amshove/kluent/tests/backtickassertions/ShouldContainSomeTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/backtickassertions/ShouldContainSomeTests.kt
@@ -1,0 +1,26 @@
+package org.amshove.kluent.tests.backtickassertions
+
+import org.amshove.kluent.`should contain some`
+import org.jetbrains.spek.api.Spek
+import kotlin.test.assertFails
+
+class ShouldContainSomeTests : Spek({
+    given("the shouldContainSome method") {
+        on("testing a list which contains at least one element") {
+            it("should pass") {
+                val cities = listOf("Israel", "Berlin", "Phoenix", "Egypt")
+                val actual = listOf("Berlin", "Stuttgart")
+
+                actual `should contain some` cities
+            }
+        }
+        on("testing a list which doesn't contain at least one element") {
+            it("should fail") {
+                val cities = listOf("Israel", "Phoenix", "Egypt")
+                val actual = listOf("Berlin", "Stuttgart")
+
+                assertFails { actual `should contain some` cities }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/org/amshove/kluent/tests/backtickassertions/charsequence/ShouldContainNoneTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/backtickassertions/charsequence/ShouldContainNoneTests.kt
@@ -1,0 +1,26 @@
+package org.amshove.kluent.tests.backtickassertions.charsequence
+
+import org.amshove.kluent.`should contain none`
+import org.jetbrains.spek.api.Spek
+import kotlin.test.assertFails
+
+class ShouldContainNoneTests : Spek({
+    given("the shouldContainNone method") {
+        on("testing if a string contains some substrings which it doesn't contain") {
+            it("should pass") {
+                val message = "I love to write fluent tests"
+                val otherStrings = listOf("testing", "writing", "code")
+
+                message `should contain none` otherStrings
+            }
+        }
+        on("testing if a string contains some substrings") {
+            it("should fail") {
+                val message = "I love to write fluent tests"
+                val otherStrings = listOf("Berlin", "write")
+
+                assertFails { message `should contain none` otherStrings }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/org/amshove/kluent/tests/backtickassertions/charsequence/ShouldContainSomeTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/backtickassertions/charsequence/ShouldContainSomeTests.kt
@@ -1,0 +1,26 @@
+package org.amshove.kluent.tests.backtickassertions.charsequence
+
+import org.amshove.kluent.`should contain some`
+import org.jetbrains.spek.api.Spek
+import kotlin.test.assertFails
+
+class ShouldContainSomeTests : Spek({
+    given("the shouldContainSome method") {
+        on("testing if a string contains some substrings") {
+            it("should pass") {
+                val message = "I love to write fluent tests"
+                val otherStrings = listOf("Berlin", "write")
+
+                message `should contain some` otherStrings
+            }
+        }
+        on("testing if a string contains some substrings which it doesn't contain") {
+            it("should fail") {
+                val message = "I love to write fluent tests"
+                val otherStrings = listOf("testing", "writing", "code")
+
+                assertFails { message `should contain some` otherStrings }
+            }
+        }
+    }
+})


### PR DESCRIPTION
Issue: #59 

Added the following methods:

`shouldContainSome`
`shouldContainNone`

for all yet supported types of collections.

Note: The `shouldContainSome` is almost the same as `shouldNotContainAny`, but is added to have the same semantic as `shouldContainSome`.

`CharSequence` will also have `shouldContainSome` and `shouldContainNone`

# Failure messages

## Collection shouldContainSome

![image](https://user-images.githubusercontent.com/2401875/30247272-c816ac58-9610-11e7-8644-50847e1a2686.png)

## Collection shouldContainNone

![image](https://user-images.githubusercontent.com/2401875/30247283-eeee1fbe-9610-11e7-8d75-dbd0320b99f7.png)

## CharSequence shouldContainSome

![image](https://user-images.githubusercontent.com/2401875/30247297-2d09afde-9611-11e7-855e-d53e92b993e1.png)

## CharSequence shouldContainNone

![image](https://user-images.githubusercontent.com/2401875/30247316-9335eee4-9611-11e7-8154-931cd5f656e8.png)
