### PR TITLE
Allow should(Not)Throw on nullable lambdas Kluent #63

### DIFF
--- a/src/main/kotlin/org/amshove/kluent/Exceptions.kt
+++ b/src/main/kotlin/org/amshove/kluent/Exceptions.kt
@@ -3,7 +3,7 @@ package org.amshove.kluent
 import org.junit.ComparisonFailure
 import kotlin.reflect.KClass
 
-infix fun <T : Throwable> (() -> Any).shouldThrow(expectedException: KClass<T>): ExceptionResult<T> {
+infix fun <T : Throwable> (() -> Any?).shouldThrow(expectedException: KClass<T>): ExceptionResult<T> {
     try {
         this.invoke()
         fail("There was an Exception expected to be thrown, but nothing was thrown", "$expectedException", "None")
@@ -15,7 +15,7 @@ infix fun <T : Throwable> (() -> Any).shouldThrow(expectedException: KClass<T>):
     }
 }
 
-infix fun <T : Throwable> (() -> Any).shouldNotThrow(expectedException: KClass<T>) {
+infix fun <T : Throwable> (() -> Any?).shouldNotThrow(expectedException: KClass<T>) {
     try {
         this.invoke()
     } catch (e: Throwable) {

--- a/src/main/kotlin/org/amshove/kluent/ExceptionsBacktick.kt
+++ b/src/main/kotlin/org/amshove/kluent/ExceptionsBacktick.kt
@@ -2,9 +2,9 @@ package org.amshove.kluent
 
 import kotlin.reflect.KClass
 
-infix fun <T : Throwable> (() -> Any).`should throw`(expectedException: KClass<T>) = this.shouldThrow(expectedException)
+infix fun <T : Throwable> (() -> Any?).`should throw`(expectedException: KClass<T>) = this.shouldThrow(expectedException)
 
-infix fun <T : Throwable> (() -> Any).`should not throw`(expectedException: KClass<T>) = this.shouldNotThrow(expectedException)
+infix fun <T : Throwable> (() -> Any?).`should not throw`(expectedException: KClass<T>) = this.shouldNotThrow(expectedException)
 
 @Deprecated("Use `should throw` instead", ReplaceWith("x `should throw` expectedException"))
 infix fun <T : Throwable> (() -> Any).`should throw the Exception`(expectedException: KClass<T>) = this.shouldThrow(expectedException)

--- a/src/test/kotlin/org/amshove/kluent/tests/assertions/ShouldNotThrowTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/assertions/ShouldNotThrowTests.kt
@@ -40,6 +40,13 @@ class ShouldNotThrowTests : Spek({
                 assertEquals(failure.expected, expected.toString())
             }
         }
+
+        given("providing a function that returns null") {
+            val func = { null }
+            it("should not throw exception") {
+                func shouldNotThrow AnyException
+            }
+        }
     }
 })
 

--- a/src/test/kotlin/org/amshove/kluent/tests/assertions/ShouldThrowTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/assertions/ShouldThrowTests.kt
@@ -110,13 +110,6 @@ class ShouldThrowTests : Spek({
             }
         }
 
-        given("a lambda that returns null") {
-            val func = { null }
-            it("should not throw exception") {
-                func shouldNotThrow AnyException
-            }
-        }
-
         given("a lambda that can return null") {
             val func = { if (0 == 1) null else throw IllegalStateException() }
             it("should throw exception") {

--- a/src/test/kotlin/org/amshove/kluent/tests/assertions/ShouldThrowTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/assertions/ShouldThrowTests.kt
@@ -109,5 +109,19 @@ class ShouldThrowTests : Spek({
                 }
             }
         }
+
+        given("a lambda that returns null") {
+            val func = { null }
+            it("should not throw exception") {
+                func shouldNotThrow AnyException
+            }
+        }
+
+        given("a lambda that can return null") {
+            val func = { if (0 == 1) null else throw IllegalStateException() }
+            it("should throw exception") {
+                func shouldThrow IllegalStateException::class
+            }
+        }
     }
 })

--- a/src/test/kotlin/org/amshove/kluent/tests/backtickassertions/ShouldNotThrowTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/backtickassertions/ShouldNotThrowTests.kt
@@ -2,6 +2,7 @@ package org.amshove.kluent.tests.backtickassertions
 
 import org.amshove.kluent.AnyException
 import org.amshove.kluent.`should not throw`
+import org.amshove.kluent.shouldNotThrow
 import org.jetbrains.spek.api.Spek
 import kotlin.test.assertFails
 
@@ -23,6 +24,13 @@ class ShouldNotThrowTests : Spek({
             it("should pass") {
                 val func = { throw IllegalArgumentException() }
                 func `should not throw` ArrayIndexOutOfBoundsException::class
+            }
+        }
+
+        on("providing a function that returns null") {
+            val func = { null }
+            it("should not throw exception") {
+                func `should not throw` AnyException
             }
         }
     }

--- a/src/test/kotlin/org/amshove/kluent/tests/backtickassertions/ShouldThrowTheExceptionTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/backtickassertions/ShouldThrowTheExceptionTests.kt
@@ -84,5 +84,12 @@ class ShouldThrowTheExceptionTests : Spek({
                 }
             }
         }
+
+        given("a lambda that can return null") {
+            val func = { if (0 == 1) null else throw IllegalStateException() }
+            it("should throw exception") {
+                func `should throw` IllegalStateException::class
+            }
+        }
     }
 })


### PR DESCRIPTION
Allow should(Not)Throw as extensions to Any? instead of Any. This allows exception verification on functions and lambdas that are nullable.