### PR TITLE
Consistent test assert names for Numericals

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,6 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "com.nhaarman:mockito-kotlin-kt1.1:$mockito_version"
-    testCompile 'junit:junit:4.12'
     testCompile "org.jetbrains.spek:spek:$spek_version"
     testCompile "com.nhaarman:mockito-kotlin-kt1.1:$mockito_version"
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,26 +4,18 @@ Kluent is a "Fluent Assertions" library written specifically for Kotlin.
 
 It uses the [Infix-Notations](https://kotlinlang.org/docs/reference/functions.html#infix-notation "Infix-Notation") and [Extension Functions](https://kotlinlang.org/docs/reference/extensions.html#extension-functions "Extension Functions") of Kotlin to provide a fluent wrapper around JUnit-Asserts and Mockito.
 
- [ ![Download](https://api.bintray.com/packages/markusamshove/maven/Kluent/images/download.svg) ](https://bintray.com/markusamshove/maven/Kluent/_latestVersion) [![Build Status](https://travis-ci.org/MarkusAmshove/Kluent.svg?branch=master)](https://travis-ci.org/MarkusAmshove/Kluent)
-
+[![Download](https://api.bintray.com/packages/markusamshove/maven/Kluent/images/download.svg) ](https://bintray.com/markusamshove/maven/Kluent/_latestVersion) [![Build Status](https://travis-ci.org/MarkusAmshove/Kluent.svg?branch=master)](https://travis-ci.org/MarkusAmshove/Kluent)
 
 # Guide
 
-[Basic Assertions](BasicAssertions.md)
-
-[Numerical Assertions](NumericalAssertions.md)
-
-[CharSequence Assertions](CharSequenceAssertions.md)
-
-[Collection Assertions](CollectionAssertions.md)
-
-[Exception handling](Exceptions.md)
-
-[Mocking](Mocking.md)
-
-[java.time Assertions](JavaTime.md)
-
-[FileSystem](FileSystem.md)
+* [Basic Assertions](BasicAssertions.md)
+* [Numerical Assertions](NumericalAssertions.md)
+* [CharSequence Assertions](CharSequenceAssertions.md)
+* [Collection Assertions](CollectionAssertions.md)
+* [Exception handling](Exceptions.md)
+* [Mocking](Mocking.md)
+* [java.time Assertions](JavaTime.md)
+* [FileSystem](FileSystem.md)
 
 ## Using backticks
 
@@ -31,58 +23,53 @@ Every method that is included in Kluent also has a "backtick version", to make i
 
 Some examples:
 
-### assertEquals ##
-    "hello" shouldEqual "hello"
-    "hello" `should equal` "hello"
-
-### assertNotEquals ##
-    "hello" shouldNotEqual "world"
-    "hello" `should not equal` "world"
+1. assertEquals: ``` "hello" `should equal` "hello" ```
+2. assertNotEquals: ```"hello" `should not equal` "world"```
 
 # Changelog
-# 1.30 (WIP)
+## 1.30 (WIP)
 * Allow should(Not)Throw to on functions returning nullables | [Issue](https://github.com/MarkusAmshove/Kluent/issues/63) | [PR](https://github.com/MarkusAmshove/Kluent/pull/64) | thanks to [@gregwoodfill](https://github.com/gregwoodfill)
 * Update mockito-kotlin to kt1.1 | [Issue](https://github.com/MarkusAmshove/Kluent/issues/61)
 
-# 1.29
+## 1.29
 * Add shouldContainSome and shouldContainNone to collections | [Issue](https://github.com/MarkusAmshove/Kluent/issues/59) | [PR](https://github.com/MarkusAmshove/Kluent/pull/60)
 
-# 1.28
+## 1.28
 * Starting with this version, Kluent is now available for Android! Thanks to [@eburke](https://github.com/eburke56) for making this possible! | [PR](https://github.com/MarkusAmshove/Kluent/pull/58) | thanks to [@eburke](https://github.com/eburke56)
 * Fix order of arguments to assertArrayEquals() calls | [PR](https://github.com/MarkusAmshove/Kluent/pull/56) | thanks to [@cketti](https://github.com/cketti)
 
-# 1.27
+## 1.27
 * Deprecate `shouldThrowTheException` for `shouldThrow` | [PR](https://github.com/MarkusAmshove/Kluent/pull/54) | thanks to [@goreRatzete](https://github.com/goreRatzete)
 * Update `mockito-kotlin` to 1.5.0
 
-# 1.26
+## 1.26
 * Fix wrong assertion in `shouldNotBeGreaterThan` | [Issue](https://github.com/MarkusAmshove/Kluent/issues/51) | [PR](https://github.com/MarkusAmshove/Kluent/pull/52) | thanks to [@goreRatzete](https://github.com/goreRatzete) and [@guenhter](https://github.com/guenhter)
 
-# 1.25
+## 1.25
 * Allow Errors to be thrown from a stub  | [PR](https://github.com/MarkusAmshove/Kluent/pull/50) | thanks to [@guenhter](https://github.com/guenhter)
 
-# 1.24
+## 1.24
 * Add assertions for `java.io.File` | [Issue](https://github.com/MarkusAmshove/Kluent/issues/47) | [PR](https://github.com/MarkusAmshove/Kluent/pull/48) | thanks to [@goreRatzete](https://github.com/goreRatzete)
 
-# 1.23
+## 1.23
 * Add shouldContainAll and shouldNotContainAny assertions | [PR](https://github.com/MarkusAmshove/Kluent/pull/44) | thanks to [@Egorand](https://github.com/Egorand)
 
-# 1.22
+## 1.22
 * Verify that a method was not called | [PR](https://github.com/MarkusAmshove/Kluent/pull/43) | thanks to [@miszmaniac](https://github.com/miszmaniac)
 
-# 1.21
+## 1.21
 * Support primitive Arrays | [Issue](https://github.com/MarkusAmshove/Kluent/issues/42) | thanks to [@Tapchicoma](https://github.com/Tapchicoma)
 
-# 1.20
+## 1.20
 * Use `Throwable` instead of `Exception` as base type for asserts on `Exception`s | [Issue](https://github.com/MarkusAmshove/Kluent/issues/40) | [PR](https://github.com/MarkusAmshove/Kluent/pull/41) | thanks to [@westonal](https://github.com/westonal)
 
-# 1.19
+## 1.19
 * ExceptionResult is now Typed and withCause and withMessage are now fluent | [PR](https://github.com/MarkusAmshove/Kluent/pull/38) | thanks to [@vjames19](https://github.com/vjames19)
 
-# 1.18
+## 1.18
 * Fix generation of maven poms | [Issue](https://github.com/MarkusAmshove/Kluent/issues/37) | thanks to [@binkley](https://github.com/binkley)
 
-# 1.17
+## 1.17
 * Update Kotlin to 1.1.1 | [PR](https://github.com/MarkusAmshove/Kluent/pull/28) | thanks to [@Egorand](https://github.com/Egorand)
 * Update Gradle to 3.4.1 | [PR](https://github.com/MarkusAmshove/Kluent/pull/29) | thanks to [@Egorand](https://github.com/Egorand)
 * Fix compiler warnings in tests | [PR](https://github.com/MarkusAmshove/Kluent/pull/30) | thanks to [@Egorand](https://github.com/Egorand)
@@ -91,123 +78,92 @@ Some examples:
 * Use mockito-kotlin for mocking | [Issue](https://github.com/MarkusAmshove/Kluent/issues/32) | [PR](https://github.com/MarkusAmshove/Kluent/pull/35) | thanks to [@fishb6nes](https://github.com/fishb6nes)
 * Add Assertions for LocalDateTime, LocalTime, LocalDate | [PR](https://github.com/MarkusAmshove/Kluent/pull/36) | [Documentation](JavaTime.md)
 
-# 1.16
+## 1.16
 * Update Kotlin to 1.1.0
 * Correct assertion message for `Collection.shouldBeEmpty` | [Issue](https://github.com/MarkusAmshove/Kluent/issues/27)
 
-# 1.15
+## 1.15
 * Rework failure messages of shouldNotContain assertions | [Issue](https://github.com/MarkusAmshove/Kluent/issues/20)
 * Extract assertions into different files
 * Add withCause for Exception-Assertions | [Issue](https://github.com/MarkusAmshove/Kluent/issues/24) | [PR](https://github.com/MarkusAmshove/Kluent/pull/25) | thanks to [@okkero](https://github.com/okkero)
 * Add common non infix assertions | [Issue](https://github.com/MarkusAmshove/Kluent/issues/21) | [PR](https://github.com/MarkusAmshove/Kluent/pull/26)
 
-## Collections
+### Collections
 
     shouldBeEmpty
-
     shouldNotBeEmpty
 
-## CharSequence
+### CharSequence
 
     shouldBeEmpty
-
     shouldNotBeEmpty
-
     shouldBeBlank
-
     shouldNotBeBlank
 
-## CharSequence?
+### CharSequence?
 
     shouldBeNullOrEmpty
-
     shouldNotBeNullOrEmpty
-
     shouldBeNullOrBlank
-
     shouldNotBeNullOrBlank
 
-## Nullables
+### Nullables
 
     shouldBeNull
-
     shouldNotBeNull
 
-## Boolean
+### Boolean
 
     shouldBeTrue
-
     shouldBeFalse
-
     shouldNotBeTrue
-
     shouldNotBeFalse
 
 
-# 1.14
-* Introduce numerical operations | [Issue](https://github.com/MarkusAmshove/Kluent/issues/17) | [PR](https://github.com/MarkusAmshove/Kluent/pull/18)
+## 1.14
+
+Introduce numerical operations | [Issue](https://github.com/MarkusAmshove/Kluent/issues/17) | [PR](https://github.com/MarkusAmshove/Kluent/pull/18)
 
     shouldBeGreaterOrEqualTo
-
     shouldBeGreaterThan
-
     shouldBeLessOrEqualTo
-
     shouldBeLessThan
-
     shouldBePositive
-
     shouldBeNegative
-
     shouldBeInRange
 
 # 1.13
-* Provide methods to check if an object is a given instance | [PR](https://github.com/MarkusAmshove/Kluent/pull/16) | thanks to [@GAumala](https://github.com/GAumala)
+Provide methods to check if an object is a given instance | [PR](https://github.com/MarkusAmshove/Kluent/pull/16) | thanks to [@GAumala](https://github.com/GAumala)
 
     shouldBeInstanceOf
-
     shouldNotBeInstanceOf
 
 # 1.12
-* Update Kotlin to 1.0.6 | [Issue](https://github.com/MarkusAmshove/Kluent/issues/14) | [PR](https://github.com/MarkusAmshove/Kluent/pull/15)
+Update Kotlin to 1.0.6 | [Issue](https://github.com/MarkusAmshove/Kluent/issues/14) | [PR](https://github.com/MarkusAmshove/Kluent/pull/15)
 
 # 1.11
-* Provide methods for common String operations | [Issue](https://github.com/MarkusAmshove/Kluent/issues/12) | [PR](https://github.com/MarkusAmshove/Kluent/pull/13) | thanks to [@goreRatzeze](https://github.com/goreRatzete)
+Provide methods for common String operations | [Issue](https://github.com/MarkusAmshove/Kluent/issues/12) | [PR](https://github.com/MarkusAmshove/Kluent/pull/13) | thanks to [@goreRatzeze](https://github.com/goreRatzete)
 
     shouldStartWith
-
     shouldNotStartWith
-
     shouldEndWith
-
     shouldNotEndWith
-
     shouldContain
-
     shouldNotContain
-
     shouldMatch
-
     shouldNotMatch
 
 # 1.10
 
-* Provide methods to test maps | [Issue](https://github.com/MarkusAmshove/Kluent/issues/10) | [PR](https://github.com/MarkusAmshove/Kluent/pull/11) | thanks to [@goreRatzeze](https://github.com/goreRatzete)
+Provide methods to test maps | [Issue](https://github.com/MarkusAmshove/Kluent/issues/10) | [PR](https://github.com/MarkusAmshove/Kluent/pull/11) | thanks to [@goreRatzeze](https://github.com/goreRatzete)
 
     shouldHaveKey
-    
     shouldNotHaveKey
-    
     shouldHaveValue
-    
     shouldNotHaveValue
-    
     shouldContain (pair)
-    
     shouldNotContain (pair)
-
 
 # 1.9
 
-* Allow subtyping of exceptions | [Issue](https://github.com/MarkusAmshove/Kluent/issues/7) | [PR](https://github.com/MarkusAmshove/Kluent/pull/8) | thanks to [@neyb](https://github.com/neyb)
-
+Allow subtyping of exceptions | [Issue](https://github.com/MarkusAmshove/Kluent/issues/7) | [PR](https://github.com/MarkusAmshove/Kluent/pull/8) | thanks to [@neyb](https://github.com/neyb)

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ Some examples:
 ## 1.30 (WIP)
 * Allow should(Not)Throw to on functions returning nullables | [Issue](https://github.com/MarkusAmshove/Kluent/issues/63) | [PR](https://github.com/MarkusAmshove/Kluent/pull/64) | thanks to [@gregwoodfill](https://github.com/gregwoodfill)
 * Update mockito-kotlin to kt1.1 | [Issue](https://github.com/MarkusAmshove/Kluent/issues/61)
+* Rename asserts in Numericals to contain 'be' for consistency | [PR](https://github.com/MarkusAmshove/Kluent/pull/71) | thanks to [@javatarz](https://github.com/javatarz) 
 
 ## 1.29
 * Add shouldContainSome and shouldContainNone to collections | [Issue](https://github.com/MarkusAmshove/Kluent/issues/59) | [PR](https://github.com/MarkusAmshove/Kluent/pull/60)

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,18 +4,26 @@ Kluent is a "Fluent Assertions" library written specifically for Kotlin.
 
 It uses the [Infix-Notations](https://kotlinlang.org/docs/reference/functions.html#infix-notation "Infix-Notation") and [Extension Functions](https://kotlinlang.org/docs/reference/extensions.html#extension-functions "Extension Functions") of Kotlin to provide a fluent wrapper around JUnit-Asserts and Mockito.
 
-[![Download](https://api.bintray.com/packages/markusamshove/maven/Kluent/images/download.svg) ](https://bintray.com/markusamshove/maven/Kluent/_latestVersion) [![Build Status](https://travis-ci.org/MarkusAmshove/Kluent.svg?branch=master)](https://travis-ci.org/MarkusAmshove/Kluent)
+ [ ![Download](https://api.bintray.com/packages/markusamshove/maven/Kluent/images/download.svg) ](https://bintray.com/markusamshove/maven/Kluent/_latestVersion) [![Build Status](https://travis-ci.org/MarkusAmshove/Kluent.svg?branch=master)](https://travis-ci.org/MarkusAmshove/Kluent)
+
 
 # Guide
 
-* [Basic Assertions](BasicAssertions.md)
-* [Numerical Assertions](NumericalAssertions.md)
-* [CharSequence Assertions](CharSequenceAssertions.md)
-* [Collection Assertions](CollectionAssertions.md)
-* [Exception handling](Exceptions.md)
-* [Mocking](Mocking.md)
-* [java.time Assertions](JavaTime.md)
-* [FileSystem](FileSystem.md)
+[Basic Assertions](BasicAssertions.md)
+
+[Numerical Assertions](NumericalAssertions.md)
+
+[CharSequence Assertions](CharSequenceAssertions.md)
+
+[Collection Assertions](CollectionAssertions.md)
+
+[Exception handling](Exceptions.md)
+
+[Mocking](Mocking.md)
+
+[java.time Assertions](JavaTime.md)
+
+[FileSystem](FileSystem.md)
 
 ## Using backticks
 
@@ -23,54 +31,58 @@ Every method that is included in Kluent also has a "backtick version", to make i
 
 Some examples:
 
-1. assertEquals: ``` "hello" `should equal` "hello" ```
-2. assertNotEquals: ```"hello" `should not equal` "world"```
+### assertEquals ##
+    "hello" shouldEqual "hello"
+    "hello" `should equal` "hello"
+
+### assertNotEquals ##
+    "hello" shouldNotEqual "world"
+    "hello" `should not equal` "world"
 
 # Changelog
-## 1.30 (WIP)
+# 1.30 (WIP)
 * Allow should(Not)Throw to on functions returning nullables | [Issue](https://github.com/MarkusAmshove/Kluent/issues/63) | [PR](https://github.com/MarkusAmshove/Kluent/pull/64) | thanks to [@gregwoodfill](https://github.com/gregwoodfill)
 * Update mockito-kotlin to kt1.1 | [Issue](https://github.com/MarkusAmshove/Kluent/issues/61)
-* Rename asserts in Numericals to contain 'be' for consistency | [PR](https://github.com/MarkusAmshove/Kluent/pull/71) | thanks to [@javatarz](https://github.com/javatarz) 
 
-## 1.29
+# 1.29
 * Add shouldContainSome and shouldContainNone to collections | [Issue](https://github.com/MarkusAmshove/Kluent/issues/59) | [PR](https://github.com/MarkusAmshove/Kluent/pull/60)
 
-## 1.28
+# 1.28
 * Starting with this version, Kluent is now available for Android! Thanks to [@eburke](https://github.com/eburke56) for making this possible! | [PR](https://github.com/MarkusAmshove/Kluent/pull/58) | thanks to [@eburke](https://github.com/eburke56)
 * Fix order of arguments to assertArrayEquals() calls | [PR](https://github.com/MarkusAmshove/Kluent/pull/56) | thanks to [@cketti](https://github.com/cketti)
 
-## 1.27
+# 1.27
 * Deprecate `shouldThrowTheException` for `shouldThrow` | [PR](https://github.com/MarkusAmshove/Kluent/pull/54) | thanks to [@goreRatzete](https://github.com/goreRatzete)
 * Update `mockito-kotlin` to 1.5.0
 
-## 1.26
+# 1.26
 * Fix wrong assertion in `shouldNotBeGreaterThan` | [Issue](https://github.com/MarkusAmshove/Kluent/issues/51) | [PR](https://github.com/MarkusAmshove/Kluent/pull/52) | thanks to [@goreRatzete](https://github.com/goreRatzete) and [@guenhter](https://github.com/guenhter)
 
-## 1.25
+# 1.25
 * Allow Errors to be thrown from a stub  | [PR](https://github.com/MarkusAmshove/Kluent/pull/50) | thanks to [@guenhter](https://github.com/guenhter)
 
-## 1.24
+# 1.24
 * Add assertions for `java.io.File` | [Issue](https://github.com/MarkusAmshove/Kluent/issues/47) | [PR](https://github.com/MarkusAmshove/Kluent/pull/48) | thanks to [@goreRatzete](https://github.com/goreRatzete)
 
-## 1.23
+# 1.23
 * Add shouldContainAll and shouldNotContainAny assertions | [PR](https://github.com/MarkusAmshove/Kluent/pull/44) | thanks to [@Egorand](https://github.com/Egorand)
 
-## 1.22
+# 1.22
 * Verify that a method was not called | [PR](https://github.com/MarkusAmshove/Kluent/pull/43) | thanks to [@miszmaniac](https://github.com/miszmaniac)
 
-## 1.21
+# 1.21
 * Support primitive Arrays | [Issue](https://github.com/MarkusAmshove/Kluent/issues/42) | thanks to [@Tapchicoma](https://github.com/Tapchicoma)
 
-## 1.20
+# 1.20
 * Use `Throwable` instead of `Exception` as base type for asserts on `Exception`s | [Issue](https://github.com/MarkusAmshove/Kluent/issues/40) | [PR](https://github.com/MarkusAmshove/Kluent/pull/41) | thanks to [@westonal](https://github.com/westonal)
 
-## 1.19
+# 1.19
 * ExceptionResult is now Typed and withCause and withMessage are now fluent | [PR](https://github.com/MarkusAmshove/Kluent/pull/38) | thanks to [@vjames19](https://github.com/vjames19)
 
-## 1.18
+# 1.18
 * Fix generation of maven poms | [Issue](https://github.com/MarkusAmshove/Kluent/issues/37) | thanks to [@binkley](https://github.com/binkley)
 
-## 1.17
+# 1.17
 * Update Kotlin to 1.1.1 | [PR](https://github.com/MarkusAmshove/Kluent/pull/28) | thanks to [@Egorand](https://github.com/Egorand)
 * Update Gradle to 3.4.1 | [PR](https://github.com/MarkusAmshove/Kluent/pull/29) | thanks to [@Egorand](https://github.com/Egorand)
 * Fix compiler warnings in tests | [PR](https://github.com/MarkusAmshove/Kluent/pull/30) | thanks to [@Egorand](https://github.com/Egorand)
@@ -79,65 +91,81 @@ Some examples:
 * Use mockito-kotlin for mocking | [Issue](https://github.com/MarkusAmshove/Kluent/issues/32) | [PR](https://github.com/MarkusAmshove/Kluent/pull/35) | thanks to [@fishb6nes](https://github.com/fishb6nes)
 * Add Assertions for LocalDateTime, LocalTime, LocalDate | [PR](https://github.com/MarkusAmshove/Kluent/pull/36) | [Documentation](JavaTime.md)
 
-## 1.16
+# 1.16
 * Update Kotlin to 1.1.0
 * Correct assertion message for `Collection.shouldBeEmpty` | [Issue](https://github.com/MarkusAmshove/Kluent/issues/27)
 
-## 1.15
+# 1.15
 * Rework failure messages of shouldNotContain assertions | [Issue](https://github.com/MarkusAmshove/Kluent/issues/20)
 * Extract assertions into different files
 * Add withCause for Exception-Assertions | [Issue](https://github.com/MarkusAmshove/Kluent/issues/24) | [PR](https://github.com/MarkusAmshove/Kluent/pull/25) | thanks to [@okkero](https://github.com/okkero)
 * Add common non infix assertions | [Issue](https://github.com/MarkusAmshove/Kluent/issues/21) | [PR](https://github.com/MarkusAmshove/Kluent/pull/26)
 
-### Collections
+## Collections
 
     shouldBeEmpty
+
     shouldNotBeEmpty
 
-### CharSequence
+## CharSequence
 
     shouldBeEmpty
+
     shouldNotBeEmpty
+
     shouldBeBlank
+
     shouldNotBeBlank
 
-### CharSequence?
+## CharSequence?
 
     shouldBeNullOrEmpty
+
     shouldNotBeNullOrEmpty
+
     shouldBeNullOrBlank
+
     shouldNotBeNullOrBlank
 
-### Nullables
+## Nullables
 
     shouldBeNull
+
     shouldNotBeNull
 
-### Boolean
+## Boolean
 
     shouldBeTrue
+
     shouldBeFalse
+
     shouldNotBeTrue
+
     shouldNotBeFalse
 
 
-## 1.14
+# 1.14
 * Introduce numerical operations | [Issue](https://github.com/MarkusAmshove/Kluent/issues/17) | [PR](https://github.com/MarkusAmshove/Kluent/pull/18)
 
-
     shouldBeGreaterOrEqualTo
+
     shouldBeGreaterThan
+
     shouldBeLessOrEqualTo
+
     shouldBeLessThan
+
     shouldBePositive
+
     shouldBeNegative
+
     shouldBeInRange
 
 # 1.13
 * Provide methods to check if an object is a given instance | [PR](https://github.com/MarkusAmshove/Kluent/pull/16) | thanks to [@GAumala](https://github.com/GAumala)
 
-
     shouldBeInstanceOf
+
     shouldNotBeInstanceOf
 
 # 1.12
@@ -146,25 +174,40 @@ Some examples:
 # 1.11
 * Provide methods for common String operations | [Issue](https://github.com/MarkusAmshove/Kluent/issues/12) | [PR](https://github.com/MarkusAmshove/Kluent/pull/13) | thanks to [@goreRatzeze](https://github.com/goreRatzete)
 
-
     shouldStartWith
+
     shouldNotStartWith
+
     shouldEndWith
+
     shouldNotEndWith
+
     shouldContain
+
     shouldNotContain
+
     shouldMatch
+
     shouldNotMatch
 
 # 1.10
+
 * Provide methods to test maps | [Issue](https://github.com/MarkusAmshove/Kluent/issues/10) | [PR](https://github.com/MarkusAmshove/Kluent/pull/11) | thanks to [@goreRatzeze](https://github.com/goreRatzete)
 
     shouldHaveKey
+    
     shouldNotHaveKey
+    
     shouldHaveValue
+    
     shouldNotHaveValue
+    
     shouldContain (pair)
+    
     shouldNotContain (pair)
 
+
 # 1.9
+
 * Allow subtyping of exceptions | [Issue](https://github.com/MarkusAmshove/Kluent/issues/7) | [PR](https://github.com/MarkusAmshove/Kluent/pull/8) | thanks to [@neyb](https://github.com/neyb)
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -122,8 +122,8 @@ Some examples:
 
 
 ## 1.14
+* Introduce numerical operations | [Issue](https://github.com/MarkusAmshove/Kluent/issues/17) | [PR](https://github.com/MarkusAmshove/Kluent/pull/18)
 
-Introduce numerical operations | [Issue](https://github.com/MarkusAmshove/Kluent/issues/17) | [PR](https://github.com/MarkusAmshove/Kluent/pull/18)
 
     shouldBeGreaterOrEqualTo
     shouldBeGreaterThan
@@ -134,16 +134,18 @@ Introduce numerical operations | [Issue](https://github.com/MarkusAmshove/Kluent
     shouldBeInRange
 
 # 1.13
-Provide methods to check if an object is a given instance | [PR](https://github.com/MarkusAmshove/Kluent/pull/16) | thanks to [@GAumala](https://github.com/GAumala)
+* Provide methods to check if an object is a given instance | [PR](https://github.com/MarkusAmshove/Kluent/pull/16) | thanks to [@GAumala](https://github.com/GAumala)
+
 
     shouldBeInstanceOf
     shouldNotBeInstanceOf
 
 # 1.12
-Update Kotlin to 1.0.6 | [Issue](https://github.com/MarkusAmshove/Kluent/issues/14) | [PR](https://github.com/MarkusAmshove/Kluent/pull/15)
+* Update Kotlin to 1.0.6 | [Issue](https://github.com/MarkusAmshove/Kluent/issues/14) | [PR](https://github.com/MarkusAmshove/Kluent/pull/15)
 
 # 1.11
-Provide methods for common String operations | [Issue](https://github.com/MarkusAmshove/Kluent/issues/12) | [PR](https://github.com/MarkusAmshove/Kluent/pull/13) | thanks to [@goreRatzeze](https://github.com/goreRatzete)
+* Provide methods for common String operations | [Issue](https://github.com/MarkusAmshove/Kluent/issues/12) | [PR](https://github.com/MarkusAmshove/Kluent/pull/13) | thanks to [@goreRatzeze](https://github.com/goreRatzete)
+
 
     shouldStartWith
     shouldNotStartWith
@@ -155,8 +157,7 @@ Provide methods for common String operations | [Issue](https://github.com/Markus
     shouldNotMatch
 
 # 1.10
-
-Provide methods to test maps | [Issue](https://github.com/MarkusAmshove/Kluent/issues/10) | [PR](https://github.com/MarkusAmshove/Kluent/pull/11) | thanks to [@goreRatzeze](https://github.com/goreRatzete)
+* Provide methods to test maps | [Issue](https://github.com/MarkusAmshove/Kluent/issues/10) | [PR](https://github.com/MarkusAmshove/Kluent/pull/11) | thanks to [@goreRatzeze](https://github.com/goreRatzete)
 
     shouldHaveKey
     shouldNotHaveKey
@@ -166,5 +167,4 @@ Provide methods to test maps | [Issue](https://github.com/MarkusAmshove/Kluent/i
     shouldNotContain (pair)
 
 # 1.9
-
-Allow subtyping of exceptions | [Issue](https://github.com/MarkusAmshove/Kluent/issues/7) | [PR](https://github.com/MarkusAmshove/Kluent/pull/8) | thanks to [@neyb](https://github.com/neyb)
+* Allow subtyping of exceptions | [Issue](https://github.com/MarkusAmshove/Kluent/issues/7) | [PR](https://github.com/MarkusAmshove/Kluent/pull/8) | thanks to [@neyb](https://github.com/neyb)

--- a/src/main/kotlin/org/amshove/kluent/CharSequence.kt
+++ b/src/main/kotlin/org/amshove/kluent/CharSequence.kt
@@ -26,9 +26,15 @@ fun CharSequence.shouldBeBlank() = assertTrue("Expected the CharSequence to be b
 
 fun CharSequence?.shouldBeNullOrBlank() = assertTrue("Expected $this to be null or blank", this == null || this.isBlank())
 
-infix fun String.shouldEqualTo(theOther: String) = assertEquals(theOther, this)
+@Deprecated("Use shouldBeEqualTo", ReplaceWith("this.shouldBeEqualTo(theOther)"))
+infix fun String.shouldEqualTo(theOther: String) = shouldBeEqualTo(theOther)
 
-infix fun String.shouldNotEqualTo(theOther: String) = assertNotEquals(theOther, this)
+infix fun String.shouldBeEqualTo(theOther: String) = assertEquals(theOther, this)
+
+@Deprecated("Use shouldNotBeEqualTo", ReplaceWith("this.shouldNotBeEqualTo(theOther)"))
+infix fun String.shouldNotEqualTo(theOther: String) = shouldNotBeEqualTo(theOther)
+
+infix fun String.shouldNotBeEqualTo(theOther: String) = assertNotEquals(theOther, this)
 
 infix fun CharSequence.shouldNotStartWith(theOther: CharSequence) = assertFalse("Expected the CharSequence $this to not start with $theOther", this.startsWith(theOther))
 

--- a/src/main/kotlin/org/amshove/kluent/CharSequenceBacktick.kt
+++ b/src/main/kotlin/org/amshove/kluent/CharSequenceBacktick.kt
@@ -24,9 +24,9 @@ fun CharSequence.`should be blank`() = this.shouldBeBlank()
 
 fun CharSequence?.`should be null or blank`() = this.shouldBeNullOrBlank()
 
-infix fun String.`should equal to`(theOther: String) = this.shouldEqualTo(theOther)
+infix fun String.`should be equal to`(theOther: String) = this.shouldEqualTo(theOther)
 
-infix fun String.`should not equal to`(theOther: String) = this.shouldNotEqualTo(theOther)
+infix fun String.`should not be equal to`(theOther: String) = this.shouldNotEqualTo(theOther)
 
 infix fun CharSequence.`should not start with`(theOther: CharSequence) = this.shouldNotStartWith(theOther)
 

--- a/src/main/kotlin/org/amshove/kluent/CharSequenceBacktick.kt
+++ b/src/main/kotlin/org/amshove/kluent/CharSequenceBacktick.kt
@@ -24,9 +24,15 @@ fun CharSequence.`should be blank`() = this.shouldBeBlank()
 
 fun CharSequence?.`should be null or blank`() = this.shouldBeNullOrBlank()
 
-infix fun String.`should be equal to`(theOther: String) = this.shouldEqualTo(theOther)
+@Deprecated("Use #`should be equal to`", ReplaceWith("this.`should be equal to`(theOther)"))
+infix fun String.`should equal to`(theOther: String) = this.`should be equal to`(theOther)
 
-infix fun String.`should not be equal to`(theOther: String) = this.shouldNotEqualTo(theOther)
+infix fun String.`should be equal to`(theOther: String) = this.shouldBeEqualTo(theOther)
+
+@Deprecated("Use #`should not be equal to`", ReplaceWith("this.`should not be equal to`(theOther)"))
+infix fun String.`should not equal to`(theOther: String) = this.`should not be equal to`(theOther)
+
+infix fun String.`should not be equal to`(theOther: String) = this.shouldNotBeEqualTo(theOther)
 
 infix fun CharSequence.`should not start with`(theOther: CharSequence) = this.shouldNotStartWith(theOther)
 

--- a/src/main/kotlin/org/amshove/kluent/File.kt
+++ b/src/main/kotlin/org/amshove/kluent/File.kt
@@ -13,9 +13,9 @@ fun File.shouldNotBeDir() = assertFalse("The file is a directory", this.isDirect
 fun File.shouldBeFile() = assertTrue("The file is not a file", this.isFile)
 fun File.shouldNotBeFile() = assertFalse("The file is a file", this.isFile)
 
-infix fun File.shouldHaveExtension(other: String) = this.extension shouldEqualTo other
-infix fun File.shouldNotHaveExtension(other: String) = this.extension shouldNotEqualTo other
+infix fun File.shouldHaveExtension(other: String) = this.extension shouldBeEqualTo other
+infix fun File.shouldNotHaveExtension(other: String) = this.extension shouldNotBeEqualTo other
 
-infix fun File.shouldHaveName(other: String) = this.name shouldEqualTo other
-infix fun File.shouldNotHaveName(other: String) = this.name shouldNotEqualTo other
+infix fun File.shouldHaveName(other: String) = this.name shouldBeEqualTo other
+infix fun File.shouldNotHaveName(other: String) = this.name shouldNotBeEqualTo other
 

--- a/src/main/kotlin/org/amshove/kluent/NumericalBacktick.kt
+++ b/src/main/kotlin/org/amshove/kluent/NumericalBacktick.kt
@@ -1,32 +1,32 @@
 package org.amshove.kluent
 
-infix fun Boolean.`should equal to`(theOther: Boolean) = this.shouldEqualTo(theOther)
+infix fun Boolean.`should be equal to`(theOther: Boolean) = this.shouldEqualTo(theOther)
 
-infix fun Byte.`should equal to`(theOther: Byte) = this.shouldEqualTo(theOther)
+infix fun Byte.`should be equal to`(theOther: Byte) = this.shouldEqualTo(theOther)
 
-infix fun Short.`should equal to`(theOther: Short) = this.shouldEqualTo(theOther)
+infix fun Short.`should be equal to`(theOther: Short) = this.shouldEqualTo(theOther)
 
-infix fun Int.`should equal to`(theOther: Int) = this.shouldEqualTo(theOther)
+infix fun Int.`should be equal to`(theOther: Int) = this.shouldEqualTo(theOther)
 
-infix fun Long.`should equal to`(theOther: Long) = this.shouldEqualTo(theOther)
+infix fun Long.`should be equal to`(theOther: Long) = this.shouldEqualTo(theOther)
 
-infix fun Float.`should equal to`(theOther: Float) = this.shouldEqualTo(theOther)
+infix fun Float.`should be equal to`(theOther: Float) = this.shouldEqualTo(theOther)
 
-infix fun Double.`should equal to`(theOther: Double) = this.shouldEqualTo(theOther)
+infix fun Double.`should be equal to`(theOther: Double) = this.shouldEqualTo(theOther)
 
-infix fun Boolean.`should not equal to`(theOther: Boolean) = this.shouldNotEqualTo(theOther)
+infix fun Boolean.`should not be equal to`(theOther: Boolean) = this.shouldNotEqualTo(theOther)
 
-infix fun Byte.`should not equal to`(theOther: Byte) = this.shouldNotEqualTo(theOther)
+infix fun Byte.`should not be equal to`(theOther: Byte) = this.shouldNotEqualTo(theOther)
 
-infix fun Short.`should not equal to`(theOther: Short) = this.shouldNotEqualTo(theOther)
+infix fun Short.`should not be equal to`(theOther: Short) = this.shouldNotEqualTo(theOther)
 
-infix fun Int.`should not equal to`(theOther: Int) = this.shouldNotEqualTo(theOther)
+infix fun Int.`should not be equal to`(theOther: Int) = this.shouldNotEqualTo(theOther)
 
-infix fun Long.`should not equal to`(theOther: Long) = this.shouldNotEqualTo(theOther)
+infix fun Long.`should not be equal to`(theOther: Long) = this.shouldNotEqualTo(theOther)
 
-infix fun Float.`should not equal to`(theOther: Float) = this.shouldNotEqualTo(theOther)
+infix fun Float.`should not be equal to`(theOther: Float) = this.shouldNotEqualTo(theOther)
 
-infix fun Double.`should not equal to`(theOther: Double) = this.shouldNotEqualTo(theOther)
+infix fun Double.`should not be equal to`(theOther: Double) = this.shouldNotEqualTo(theOther)
 
 infix fun Byte.`should be greater than`(theOther: Byte) = this.shouldBeGreaterThan(theOther)
 

--- a/src/main/kotlin/org/amshove/kluent/NumericalBacktick.kt
+++ b/src/main/kotlin/org/amshove/kluent/NumericalBacktick.kt
@@ -1,30 +1,72 @@
 package org.amshove.kluent
 
+@Deprecated("Use `should be equal to`", ReplaceWith("this.`should be equal to`(theOther)"))
+infix fun Boolean.`should equal to`(theOther: Boolean) = this.`should be equal to`(theOther)
+
 infix fun Boolean.`should be equal to`(theOther: Boolean) = this.shouldEqualTo(theOther)
+
+@Deprecated("Use `should be equal to`", ReplaceWith("this.`should be equal to`(theOther)"))
+infix fun Byte.`should equal to`(theOther: Byte) = this.`should be equal to`(theOther)
 
 infix fun Byte.`should be equal to`(theOther: Byte) = this.shouldEqualTo(theOther)
 
+@Deprecated("Use `should be equal to`", ReplaceWith("this.`should be equal to`(theOther)"))
+infix fun Short.`should equal to`(theOther: Short) = this.`should be equal to`(theOther)
+
 infix fun Short.`should be equal to`(theOther: Short) = this.shouldEqualTo(theOther)
+
+@Deprecated("Use `should be equal to`", ReplaceWith("this.`should be equal to`(theOther)"))
+infix fun Int.`should equal to`(theOther: Int) = this.`should be equal to`(theOther)
 
 infix fun Int.`should be equal to`(theOther: Int) = this.shouldEqualTo(theOther)
 
+@Deprecated("Use `should be equal to`", ReplaceWith("this.`should be equal to`(theOther)"))
+infix fun Long.`should equal to`(theOther: Long) = this.`should be equal to`(theOther)
+
 infix fun Long.`should be equal to`(theOther: Long) = this.shouldEqualTo(theOther)
+
+@Deprecated("Use `should be equal to`", ReplaceWith("this.`should be equal to`(theOther)"))
+infix fun Float.`should equal to`(theOther: Float) = this.`should be equal to`(theOther)
 
 infix fun Float.`should be equal to`(theOther: Float) = this.shouldEqualTo(theOther)
 
+@Deprecated("Use `should be equal to`", ReplaceWith("this.`should be equal to`(theOther)"))
+infix fun Double.`should equal to`(theOther: Double) = this.`should be equal to`(theOther)
+
 infix fun Double.`should be equal to`(theOther: Double) = this.shouldEqualTo(theOther)
+
+@Deprecated("Use `should not equal to`", ReplaceWith("this.`should not equal to`(theOther)"))
+infix fun Boolean.`should not equal to`(theOther: Boolean) = this.`should not be equal to`(theOther)
 
 infix fun Boolean.`should not be equal to`(theOther: Boolean) = this.shouldNotEqualTo(theOther)
 
+@Deprecated("Use `should not equal to`", ReplaceWith("this.`should not equal to`(theOther)"))
+infix fun Byte.`should not equal to`(theOther: Byte) = this.`should not be equal to`(theOther)
+
 infix fun Byte.`should not be equal to`(theOther: Byte) = this.shouldNotEqualTo(theOther)
+
+@Deprecated("Use `should not equal to`", ReplaceWith("this.`should not equal to`(theOther)"))
+infix fun Short.`should not equal to`(theOther: Short) = this.`should not be equal to`(theOther)
 
 infix fun Short.`should not be equal to`(theOther: Short) = this.shouldNotEqualTo(theOther)
 
+@Deprecated("Use `should not equal to`", ReplaceWith("this.`should not equal to`(theOther)"))
+infix fun Int.`should not equal to`(theOther: Int) = this.`should not be equal to`(theOther)
+
 infix fun Int.`should not be equal to`(theOther: Int) = this.shouldNotEqualTo(theOther)
+
+@Deprecated("Use `should not equal to`", ReplaceWith("this.`should not equal to`(theOther)"))
+infix fun Long.`should not equal to`(theOther: Long) = this.`should not be equal to`(theOther)
 
 infix fun Long.`should not be equal to`(theOther: Long) = this.shouldNotEqualTo(theOther)
 
+@Deprecated("Use `should not equal to`", ReplaceWith("this.`should not equal to`(theOther)"))
+infix fun Float.`should not equal to`(theOther: Float) = this.`should not be equal to`(theOther)
+
 infix fun Float.`should not be equal to`(theOther: Float) = this.shouldNotEqualTo(theOther)
+
+@Deprecated("Use `should not equal to`", ReplaceWith("this.`should not equal to`(theOther)"))
+infix fun Double.`should not equal to`(theOther: Double) = this.`should not be equal to`(theOther)
 
 infix fun Double.`should not be equal to`(theOther: Double) = this.shouldNotEqualTo(theOther)
 

--- a/src/test/kotlin/org/amshove/kluent/tests/backtickassertions/ShouldEqualToTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/backtickassertions/ShouldEqualToTests.kt
@@ -1,91 +1,91 @@
 package org.amshove.kluent.tests.backtickassertions
 
-import org.amshove.kluent.`should equal to`
+import org.amshove.kluent.`should be equal to`
 import org.jetbrains.spek.api.Spek
 import kotlin.test.assertFails
 
 class ShouldEqualToTests : Spek({
-    given("the should equal to method") {
+    given("the `should be equal to` method") {
         on("checking two equal boolean") {
             it("should pass") {
-                true `should equal to` true
+                true `should be equal to` true
             }
         }
         on("checking two different boolean") {
             it("should fail") {
-                assertFails { true `should equal to` false }
+                assertFails { true `should be equal to` false }
             }
         }
         on("checking two equal byte") {
             it("should pass") {
-                5.toByte() `should equal to` 5.toByte()
+                5.toByte() `should be equal to` 5.toByte()
             }
         }
         on("checking two different byte") {
             it("should fail") {
                 assertFails {
-                    5.toByte() `should equal to` 20.toByte()
+                    5.toByte() `should be equal to` 20.toByte()
                 }
             }
         }
         on("checking two equal short") {
             it("should pass") {
-                5.toShort() `should equal to` 5.toShort()
+                5.toShort() `should be equal to` 5.toShort()
             }
         }
         on("checking two different short") {
             it("should fail") {
-                assertFails { 5.toShort() `should equal to` 20.toShort() }
+                assertFails { 5.toShort() `should be equal to` 20.toShort() }
             }
         }
         on("checking two equal int") {
             it("should pass") {
-                5 `should equal to` 5
+                5 `should be equal to` 5
             }
         }
         on("checking two different int") {
             it("should fail") {
-                assertFails { 5 `should equal to` 20 }
+                assertFails { 5 `should be equal to` 20 }
             }
         }
         on("checking two equal long") {
             it("should pass") {
-                5L `should equal to` 5L
+                5L `should be equal to` 5L
             }
         }
         on("checking two different long") {
             it("should fail") {
-                assertFails { 5L `should equal to` 20L }
+                assertFails { 5L `should be equal to` 20L }
             }
         }
         on("checking two equal float") {
             it("should pass") {
-                5F `should equal to` 5F
+                5F `should be equal to` 5F
             }
         }
         on("checking two different float") {
             it("should fail") {
-                assertFails { 5F `should equal to` 20F }
+                assertFails { 5F `should be equal to` 20F }
             }
         }
         on("checking two equal double") {
             it("should pass") {
-                5.0 `should equal to` 5.0
+                5.0 `should be equal to` 5.0
             }
         }
         on("checking two different double") {
             it("should fail") {
-                assertFails { 5.0 `should equal to` 20.0 }
+                assertFails { 5.0 `should be equal to` 20.0 }
             }
         }
         on("checking two equal string") {
             it("should pass") {
-                "hello world" `should equal to` "hello world"
+                "hello world" `should be equal to` "hello world"
             }
         }
         on("checking two different string") {
             it("should fail") {
-                assertFails { "hello world" `should equal to` "hello" }
+                assertFails { "hello world" `should be equal to` "hello" }
             }
         }
     }

--- a/src/test/kotlin/org/amshove/kluent/tests/backtickassertions/ShouldNotEqualToTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/backtickassertions/ShouldNotEqualToTests.kt
@@ -1,89 +1,89 @@
 package org.amshove.kluent.tests.backtickassertions
 
-import org.amshove.kluent.`should not equal to`
+import org.amshove.kluent.`should not be equal to`
 import org.jetbrains.spek.api.Spek
 import kotlin.test.assertFails
 
 class ShouldNotEqualToTests : Spek({
-    given("the should not equal to method") {
+    given("the `should not be equal to` method") {
         on("checking two equal boolean") {
             it("should pass") {
-                true `should not equal to` false
+                true `should not be equal to` false
             }
         }
         on("checking two different boolean") {
             it("should fail") {
-                assertFails { true `should not equal to` true }
+                assertFails { true `should not be equal to` true }
             }
         }
         on("checking two equal byte") {
             it("should pass") {
-                5.toByte() `should not equal to` 20.toByte()
+                5.toByte() `should not be equal to` 20.toByte()
             }
         }
         on("checking two different byte") {
             it("should fail") {
-                assertFails { 5.toByte() `should not equal to` 5.toByte() }
+                assertFails { 5.toByte() `should not be equal to` 5.toByte() }
             }
         }
         on("checking two equal short") {
             it("should pass") {
-                5.toShort() `should not equal to` 20.toShort()
+                5.toShort() `should not be equal to` 20.toShort()
             }
         }
         on("checking two different short") {
             it("should fail") {
-                assertFails { 5.toShort() `should not equal to` 5.toShort() }
+                assertFails { 5.toShort() `should not be equal to` 5.toShort() }
             }
         }
         on("checking two equal int") {
             it("should pass") {
-                5 `should not equal to` 20
+                5 `should not be equal to` 20
             }
         }
         on("checking two different int") {
             it("should fail") {
-                assertFails { 5 `should not equal to` 5 }
+                assertFails { 5 `should not be equal to` 5 }
             }
         }
         on("checking two equal long") {
             it("should pass") {
-                5L `should not equal to` 20L
+                5L `should not be equal to` 20L
             }
         }
         on("checking two different long") {
             it("should fail") {
-                assertFails { 5L `should not equal to` 5L }
+                assertFails { 5L `should not be equal to` 5L }
             }
         }
         on("checking two equal float") {
             it("should pass") {
-                5F `should not equal to` 20F
+                5F `should not be equal to` 20F
             }
         }
         on("checking two different float") {
             it("should fail") {
-                assertFails { 5F `should not equal to` 5F }
+                assertFails { 5F `should not be equal to` 5F }
             }
         }
         on("checking two equal double") {
             it("should pass") {
-                5.0 `should not equal to` 20.0
+                5.0 `should not be equal to` 20.0
             }
         }
         on("checking two different double") {
             it("should fail") {
-                assertFails { 5.0 `should not equal to` 5.0 }
+                assertFails { 5.0 `should not be equal to` 5.0 }
             }
         }
         on("checking two equal string") {
             it("should pass") {
-                "hello world" `should not equal to` "hello"
+                "hello world" `should not be equal to` "hello"
             }
         }
         on("checking two different string") {
             it("should fail") {
-                assertFails { "hello world" `should not equal to` "hello world" }
+                assertFails { "hello world" `should not be equal to` "hello world" }
             }
         }
     }


### PR DESCRIPTION
* Rename `should equal to` to `should be equal to`
* Rename `should be equal to` to `should not be equal to`
* Rename `shouldEqualTo` to `shouldBeEqualTo`
* Rename `shouldNotEqualTo` to `shouldNotBeEqualTo`