### PR TITLE
Kluent should only have an opinion on test runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,19 @@
 
 It uses the [Infix-Notations](https://kotlinlang.org/docs/reference/functions.html#infix-notation "Infix-Notation") and [Extension Functions](https://kotlinlang.org/docs/reference/extensions.html#extension-functions "Extension Functions") of Kotlin to provide a fluent wrapper around the JUnit-Asserts and Mockito.
 
-Kluent 1.x uses JUnit 4 and Kluent 2.x uses JUnit 5. For more, read through the [Changelog and Documentation](https://markusamshove.github.io/Kluent/)
+ [ ![Download](https://api.bintray.com/packages/markusamshove/maven/Kluent/images/download.svg) ](https://bintray.com/markusamshove/maven/Kluent/_latestVersion) [![Build Status](https://travis-ci.org/MarkusAmshove/Kluent.svg?branch=master)](https://travis-ci.org/MarkusAmshove/Kluent)
 
-[![Download](https://api.bintray.com/packages/markusamshove/maven/Kluent/images/download.svg)](https://bintray.com/markusamshove/maven/Kluent/_latestVersion) [![Build Status](https://travis-ci.org/MarkusAmshove/Kluent.svg?branch=master)](https://travis-ci.org/MarkusAmshove/Kluent)
+
+# [Changelog](https://markusamshove.github.io/Kluent/)
+# [Documentation](https://markusamshove.github.io/Kluent/)
 
 ----------
 
-# Usage with dependency managers
+# Include it via gradle/maven
 
-Kluent is hosted [on jCenter](https://bintray.com/markusamshove/maven/Kluent/view# "jCenter")
+Kluent is hosted [here at jcenter](https://bintray.com/markusamshove/maven/Kluent/view# "jCenter")
 
-Kluent-Android is hosted [on jCenter](https://bintray.com/markusamshove/maven/Kluent-Android/view# "jCenter")
+Kluent-Android is hosted [here at jcenter](https://bintray.com/markusamshove/maven/Kluent-Android/view# "jCenter")
 
 ## Gradle
 Replace {version} with the current version
@@ -36,11 +38,12 @@ Replace {version} with the current version
         <type>pom</type>
     </dependency>
 
+
 ----------
 
 # Examples
 
-More examples can be seen on the [site](https://markusamshove.github.io/Kluent/) or in the [tests](https://github.com/MarkusAmshove/Kluent/tree/master/src/test/kotlin/org/amshove/kluent/tests).
+More examples can be seen on the [Site](https://markusamshove.github.io/Kluent/) or in the [tests](https://github.com/MarkusAmshove/Kluent/tree/master/src/test/kotlin/org/amshove/kluent/tests).
 
 ### assertEquals ##
 
@@ -69,5 +72,15 @@ Every method that is included in Kluent also has a "backtick version", to make i
 
 Some examples:
 
-1. assertEquals: ``` "hello" `should equal` "hello" ```
-2. assertNotEquals: ```"hello" `should not equal` "world"```
+### assertEquals ##
+
+    "hello" `should equal` "hello"
+
+### assertNotEquals ##
+
+    "hello" `should not equal` "world"
+
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -4,19 +4,17 @@
 
 It uses the [Infix-Notations](https://kotlinlang.org/docs/reference/functions.html#infix-notation "Infix-Notation") and [Extension Functions](https://kotlinlang.org/docs/reference/extensions.html#extension-functions "Extension Functions") of Kotlin to provide a fluent wrapper around the JUnit-Asserts and Mockito.
 
- [ ![Download](https://api.bintray.com/packages/markusamshove/maven/Kluent/images/download.svg) ](https://bintray.com/markusamshove/maven/Kluent/_latestVersion) [![Build Status](https://travis-ci.org/MarkusAmshove/Kluent.svg?branch=master)](https://travis-ci.org/MarkusAmshove/Kluent)
+Kluent 1.x uses JUnit 4 and Kluent 2.x uses JUnit 5. For more, read through the [Changelog and Documentation](https://markusamshove.github.io/Kluent/)
 
-
-# [Changelog](https://markusamshove.github.io/Kluent/)
-# [Documentation](https://markusamshove.github.io/Kluent/)
+[![Download](https://api.bintray.com/packages/markusamshove/maven/Kluent/images/download.svg)](https://bintray.com/markusamshove/maven/Kluent/_latestVersion) [![Build Status](https://travis-ci.org/MarkusAmshove/Kluent.svg?branch=master)](https://travis-ci.org/MarkusAmshove/Kluent)
 
 ----------
 
-# Include it via gradle/maven
+# Usage with dependency managers
 
-Kluent is hosted [here at jcenter](https://bintray.com/markusamshove/maven/Kluent/view# "jCenter")
+Kluent is hosted [on jCenter](https://bintray.com/markusamshove/maven/Kluent/view# "jCenter")
 
-Kluent-Android is hosted [here at jcenter](https://bintray.com/markusamshove/maven/Kluent-Android/view# "jCenter")
+Kluent-Android is hosted [on jCenter](https://bintray.com/markusamshove/maven/Kluent-Android/view# "jCenter")
 
 ## Gradle
 Replace {version} with the current version
@@ -38,12 +36,11 @@ Replace {version} with the current version
         <type>pom</type>
     </dependency>
 
-
 ----------
 
 # Examples
 
-More examples can be seen on the [Site](https://markusamshove.github.io/Kluent/) or in the [tests](https://github.com/MarkusAmshove/Kluent/tree/master/src/test/kotlin/org/amshove/kluent/tests).
+More examples can be seen on the [site](https://markusamshove.github.io/Kluent/) or in the [tests](https://github.com/MarkusAmshove/Kluent/tree/master/src/test/kotlin/org/amshove/kluent/tests).
 
 ### assertEquals ##
 
@@ -72,15 +69,5 @@ Every method that is included in Kluent also has a "backtick version", to make i
 
 Some examples:
 
-### assertEquals ##
-
-    "hello" `should equal` "hello"
-
-### assertNotEquals ##
-
-    "hello" `should not equal` "world"
-
-
-
-
-
+1. assertEquals: ``` "hello" `should equal` "hello" ```
+2. assertNotEquals: ```"hello" `should not equal` "world"```

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 }
 
 group 'org.amshove.kluent'
-version '1.30'
+version '2.0'
 
 apply plugin: 'kotlin'
 apply plugin: 'idea'
@@ -36,7 +36,9 @@ repositories {
 }
 
 dependencies {
-    compile 'junit:junit:4.12'
+    runtime "org.junit.jupiter:junit-jupiter-engine:5.0.1"
+    compile "org.junit.jupiter:junit-jupiter-api:5.0.1"
+
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "com.nhaarman:mockito-kotlin-kt1.1:$mockito_version"

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ repositories {
 }
 
 dependencies {
-    compile 'org.jetbrains.kotlin:kotlin-test:1.1.51'
+    compile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     compile 'org.opentest4j:opentest4j:1.0.0'
 
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"

--- a/build.gradle
+++ b/build.gradle
@@ -36,12 +36,13 @@ repositories {
 }
 
 dependencies {
-    runtime "org.junit.jupiter:junit-jupiter-engine:5.0.1"
-    compile "org.junit.jupiter:junit-jupiter-api:5.0.1"
+    compile 'org.assertj:assertj-core:3.8.0'
+    compile 'org.opentest4j:opentest4j:1.0.0'
 
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "com.nhaarman:mockito-kotlin-kt1.1:$mockito_version"
+
     testCompile "org.jetbrains.spek:spek:$spek_version"
     testCompile "com.nhaarman:mockito-kotlin-kt1.1:$mockito_version"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,6 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "com.nhaarman:mockito-kotlin-kt1.1:$mockito_version"
-    testCompile 'junit:junit:4.12'
     testCompile "org.jetbrains.spek:spek:$spek_version"
     testCompile "com.nhaarman:mockito-kotlin-kt1.1:$mockito_version"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -37,8 +37,6 @@ repositories {
 
 dependencies {
     compile 'org.jetbrains.kotlin:kotlin-test:1.1.51'
-    // TODO: Remove both of these
-    compile 'org.assertj:assertj-core:3.8.0'
     compile 'org.opentest4j:opentest4j:1.0.0'
 
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,8 @@ repositories {
 }
 
 dependencies {
+    compile 'org.jetbrains.kotlin:kotlin-test:1.1.51'
+    // TODO: Remove both of these
     compile 'org.assertj:assertj-core:3.8.0'
     compile 'org.opentest4j:opentest4j:1.0.0'
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,9 @@ Some examples:
     "hello" `should not equal` "world"
 
 # Changelog
+## 2.0 (WIP)
+* Move to JUnit 5 | [Issue](https://github.com/MarkusAmshove/Kluent/issues/4) | [PR](https://github.com/MarkusAmshove/Kluent/pull/72) | thanks to [@javatarz](https://github.com/javatarz)
+
 # 1.30 (WIP)
 * Allow should(Not)Throw to on functions returning nullables | [Issue](https://github.com/MarkusAmshove/Kluent/issues/63) | [PR](https://github.com/MarkusAmshove/Kluent/pull/64) | thanks to [@gregwoodfill](https://github.com/gregwoodfill)
 * Update mockito-kotlin to kt1.1 | [Issue](https://github.com/MarkusAmshove/Kluent/issues/61)
@@ -147,6 +150,7 @@ Some examples:
 # 1.14
 * Introduce numerical operations | [Issue](https://github.com/MarkusAmshove/Kluent/issues/17) | [PR](https://github.com/MarkusAmshove/Kluent/pull/18)
 
+
     shouldBeGreaterOrEqualTo
 
     shouldBeGreaterThan
@@ -164,6 +168,7 @@ Some examples:
 # 1.13
 * Provide methods to check if an object is a given instance | [PR](https://github.com/MarkusAmshove/Kluent/pull/16) | thanks to [@GAumala](https://github.com/GAumala)
 
+
     shouldBeInstanceOf
 
     shouldNotBeInstanceOf
@@ -174,6 +179,7 @@ Some examples:
 # 1.11
 * Provide methods for common String operations | [Issue](https://github.com/MarkusAmshove/Kluent/issues/12) | [PR](https://github.com/MarkusAmshove/Kluent/pull/13) | thanks to [@goreRatzeze](https://github.com/goreRatzete)
 
+  
     shouldStartWith
 
     shouldNotStartWith
@@ -191,8 +197,8 @@ Some examples:
     shouldNotMatch
 
 # 1.10
-
 * Provide methods to test maps | [Issue](https://github.com/MarkusAmshove/Kluent/issues/10) | [PR](https://github.com/MarkusAmshove/Kluent/pull/11) | thanks to [@goreRatzeze](https://github.com/goreRatzete)
+
 
     shouldHaveKey
     
@@ -208,6 +214,4 @@ Some examples:
 
 
 # 1.9
-
 * Allow subtyping of exceptions | [Issue](https://github.com/MarkusAmshove/Kluent/issues/7) | [PR](https://github.com/MarkusAmshove/Kluent/pull/8) | thanks to [@neyb](https://github.com/neyb)
-

--- a/src/main/kotlin/org/amshove/kluent/Basic.kt
+++ b/src/main/kotlin/org/amshove/kluent/Basic.kt
@@ -1,6 +1,6 @@
 package org.amshove.kluent
 
-import org.junit.Assert.*
+import org.junit.jupiter.api.Assertions.*
 import kotlin.reflect.KClass
 
 infix fun Any?.shouldEqual(theOther: Any?) = assertEquals(theOther, this)
@@ -11,13 +11,13 @@ infix fun Any?.shouldBe(theOther: Any?) = assertSame(theOther, this)
 
 infix fun Any?.shouldNotBe(theOther: Any?) = assertNotSame(theOther, this)
 
-infix fun Any?.shouldBeInstanceOf(className: Class<*>) = assertTrue("Expected $this to be an instance of $className", className.isInstance(this))
+infix fun Any?.shouldBeInstanceOf(className: Class<*>) = assertTrue(className.isInstance(this), "Expected $this to be an instance of $className")
 
-infix fun Any?.shouldBeInstanceOf(className: KClass<*>) = assertTrue("Expected $this to be an instance of $className", className.isInstance(this))
+infix fun Any?.shouldBeInstanceOf(className: KClass<*>) = assertTrue(className.isInstance(this), "Expected $this to be an instance of $className")
 
-infix fun Any?.shouldNotBeInstanceOf(className: Class<*>) = assertFalse("Expected $this to not be an instance of $className", className.isInstance(this))
+infix fun Any?.shouldNotBeInstanceOf(className: Class<*>) = assertFalse(className.isInstance(this), "Expected $this to not be an instance of $className")
 
-infix fun Any?.shouldNotBeInstanceOf(className: KClass<*>) = assertFalse("Expected $this to not be an instance of $className", className.isInstance(this))
+infix fun Any?.shouldNotBeInstanceOf(className: KClass<*>) = assertFalse(className.isInstance(this), "Expected $this to not be an instance of $className")
 
 fun Any?.shouldBeNull() = assertNull(this)
 

--- a/src/main/kotlin/org/amshove/kluent/Basic.kt
+++ b/src/main/kotlin/org/amshove/kluent/Basic.kt
@@ -4,9 +4,9 @@ import kotlin.reflect.KClass
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
-infix fun Any?.shouldEqual(theOther: Any?) = assertEquals(this, theOther)
+infix fun Any?.shouldEqual(theOther: Any?) = assertEquals(theOther, this)
 
-infix fun Any?.shouldNotEqual(theOther: Any?) = assertNotEquals(this, theOther)
+infix fun Any?.shouldNotEqual(theOther: Any?) = assertNotEquals(theOther, this)
 
 infix fun Any?.shouldBe(theOther: Any?) = assert(this === theOther)
 

--- a/src/main/kotlin/org/amshove/kluent/Basic.kt
+++ b/src/main/kotlin/org/amshove/kluent/Basic.kt
@@ -12,13 +12,21 @@ infix fun Any?.shouldBe(theOther: Any?) = assert(this === theOther)
 
 infix fun Any?.shouldNotBe(theOther: Any?) = assert(this !== theOther)
 
-infix fun Any?.shouldBeInstanceOf(className: Class<*>) = assert(className.isInstance(this), { "Expected $this to be an instance of $className" })
+infix fun Any?.shouldBeInstanceOf(className: Class<*>) = assert(className.isInstance(this)) {
+    "Expected $this to be an instance of $className"
+}
 
-infix fun Any?.shouldBeInstanceOf(className: KClass<*>) = assert(className.isInstance(this), { "Expected $this to be an instance of $className" })
+infix fun Any?.shouldBeInstanceOf(className: KClass<*>) = assert(className.isInstance(this)) {
+    "Expected $this to be an instance of $className"
+}
 
-infix fun Any?.shouldNotBeInstanceOf(className: Class<*>) = assert(!className.isInstance(this), { "Expected $this to not be an instance of $className" })
+infix fun Any?.shouldNotBeInstanceOf(className: Class<*>) = assert(!className.isInstance(this)) {
+    "Expected $this to not be an instance of $className"
+}
 
-infix fun Any?.shouldNotBeInstanceOf(className: KClass<*>) = assert(!className.isInstance(this), { "Expected $this to not be an instance of $className" })
+infix fun Any?.shouldNotBeInstanceOf(className: KClass<*>) = assert(!className.isInstance(this)) {
+    "Expected $this to not be an instance of $className"
+}
 
 fun Any?.shouldBeNull() = assert(this === null)
 

--- a/src/main/kotlin/org/amshove/kluent/Basic.kt
+++ b/src/main/kotlin/org/amshove/kluent/Basic.kt
@@ -1,31 +1,32 @@
 package org.amshove.kluent
 
-import org.assertj.core.api.Assertions.assertThat
 import kotlin.reflect.KClass
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 
-infix fun Any?.shouldEqual(theOther: Any?) = assertThat(this).isEqualTo(theOther)
+infix fun Any?.shouldEqual(theOther: Any?) = assertEquals(this, theOther)
 
-infix fun Any?.shouldNotEqual(theOther: Any?) = assertThat(this).isNotEqualTo(theOther)
+infix fun Any?.shouldNotEqual(theOther: Any?) = assertNotEquals(this, theOther)
 
-infix fun Any?.shouldBe(theOther: Any?) = assertThat(this).isSameAs(theOther)
+infix fun Any?.shouldBe(theOther: Any?) = assert(this === theOther)
 
-infix fun Any?.shouldNotBe(theOther: Any?) = assertThat(this).isNotSameAs(theOther)
+infix fun Any?.shouldNotBe(theOther: Any?) = assert(this !== theOther)
 
-infix fun Any?.shouldBeInstanceOf(className: Class<*>) = assertThat(className.isInstance(this)).`as`("Expected $this to be an instance of $className").isTrue()
+infix fun Any?.shouldBeInstanceOf(className: Class<*>) = assert(className.isInstance(this), { "Expected $this to be an instance of $className" })
 
-infix fun Any?.shouldBeInstanceOf(className: KClass<*>) = assertThat(className.isInstance(this)).`as`("Expected $this to be an instance of $className").isTrue()
+infix fun Any?.shouldBeInstanceOf(className: KClass<*>) = assert(className.isInstance(this), { "Expected $this to be an instance of $className" })
 
-infix fun Any?.shouldNotBeInstanceOf(className: Class<*>) = assertThat(className.isInstance(this)).`as`("Expected $this to not be an instance of $className").isFalse()
+infix fun Any?.shouldNotBeInstanceOf(className: Class<*>) = assert(!className.isInstance(this), { "Expected $this to not be an instance of $className" })
 
-infix fun Any?.shouldNotBeInstanceOf(className: KClass<*>) = assertThat(className.isInstance(this)).`as`("Expected $this to not be an instance of $className").isFalse()
+infix fun Any?.shouldNotBeInstanceOf(className: KClass<*>) = assert(!className.isInstance(this), { "Expected $this to not be an instance of $className" })
 
-fun Any?.shouldBeNull() = assertThat(this).isNull()
+fun Any?.shouldBeNull() = assert(this === null)
 
-fun Any?.shouldNotBeNull() = assertThat(this).isNotNull()
+fun Any?.shouldNotBeNull() = assert(this !== null)
 
-fun Boolean.shouldBeTrue() = assertThat(this).isTrue()
+fun Boolean.shouldBeTrue() = assert(this)
 
-fun Boolean.shouldBeFalse() = assertThat(this).isFalse()
+fun Boolean.shouldBeFalse() = assert(!this)
 
 fun Boolean.shouldNotBeTrue() = this.shouldBeFalse()
 

--- a/src/main/kotlin/org/amshove/kluent/Basic.kt
+++ b/src/main/kotlin/org/amshove/kluent/Basic.kt
@@ -1,31 +1,31 @@
 package org.amshove.kluent
 
-import org.junit.jupiter.api.Assertions.*
+import org.assertj.core.api.Assertions.assertThat
 import kotlin.reflect.KClass
 
-infix fun Any?.shouldEqual(theOther: Any?) = assertEquals(theOther, this)
+infix fun Any?.shouldEqual(theOther: Any?) = assertThat(this).isEqualTo(theOther)
 
-infix fun Any?.shouldNotEqual(theOther: Any?) =  assertNotEquals(theOther, this)
+infix fun Any?.shouldNotEqual(theOther: Any?) = assertThat(this).isNotEqualTo(theOther)
 
-infix fun Any?.shouldBe(theOther: Any?) = assertSame(theOther, this)
+infix fun Any?.shouldBe(theOther: Any?) = assertThat(this).isSameAs(theOther)
 
-infix fun Any?.shouldNotBe(theOther: Any?) = assertNotSame(theOther, this)
+infix fun Any?.shouldNotBe(theOther: Any?) = assertThat(this).isNotSameAs(theOther)
 
-infix fun Any?.shouldBeInstanceOf(className: Class<*>) = assertTrue(className.isInstance(this), "Expected $this to be an instance of $className")
+infix fun Any?.shouldBeInstanceOf(className: Class<*>) = assertThat(className.isInstance(this)).`as`("Expected $this to be an instance of $className").isTrue()
 
-infix fun Any?.shouldBeInstanceOf(className: KClass<*>) = assertTrue(className.isInstance(this), "Expected $this to be an instance of $className")
+infix fun Any?.shouldBeInstanceOf(className: KClass<*>) = assertThat(className.isInstance(this)).`as`("Expected $this to be an instance of $className").isTrue()
 
-infix fun Any?.shouldNotBeInstanceOf(className: Class<*>) = assertFalse(className.isInstance(this), "Expected $this to not be an instance of $className")
+infix fun Any?.shouldNotBeInstanceOf(className: Class<*>) = assertThat(className.isInstance(this)).`as`("Expected $this to not be an instance of $className").isFalse()
 
-infix fun Any?.shouldNotBeInstanceOf(className: KClass<*>) = assertFalse(className.isInstance(this), "Expected $this to not be an instance of $className")
+infix fun Any?.shouldNotBeInstanceOf(className: KClass<*>) = assertThat(className.isInstance(this)).`as`("Expected $this to not be an instance of $className").isFalse()
 
-fun Any?.shouldBeNull() = assertNull(this)
+fun Any?.shouldBeNull() = assertThat(this).isNull()
 
-fun Any?.shouldNotBeNull() = assertNotNull(this)
+fun Any?.shouldNotBeNull() = assertThat(this).isNotNull()
 
-fun Boolean.shouldBeTrue() = assertTrue(this)
+fun Boolean.shouldBeTrue() = assertThat(this).isTrue()
 
-fun Boolean.shouldBeFalse() =  assertFalse(this)
+fun Boolean.shouldBeFalse() = assertThat(this).isFalse()
 
 fun Boolean.shouldNotBeTrue() = this.shouldBeFalse()
 

--- a/src/main/kotlin/org/amshove/kluent/CharSequence.kt
+++ b/src/main/kotlin/org/amshove/kluent/CharSequence.kt
@@ -1,55 +1,56 @@
 package org.amshove.kluent
 
-import org.junit.Assert.*
+import org.junit.jupiter.api.Assertions.*
 
-infix fun CharSequence.shouldStartWith(theOther: CharSequence) = assertTrue("Expected the CharSequence $this to start with $theOther", this.startsWith(theOther))
+infix fun CharSequence.shouldStartWith(theOther: CharSequence) = assertTrue(this.startsWith(theOther), "Expected the CharSequence $this to start with $theOther")
 
-infix fun CharSequence.shouldEndWith(theOther: CharSequence) = assertTrue("Expected the CharSequence $this to end with $theOther", this.endsWith(theOther))
+infix fun CharSequence.shouldEndWith(theOther: CharSequence) = assertTrue(this.endsWith(theOther), "Expected the CharSequence $this to end with $theOther")
 
-infix fun CharSequence.shouldContainSome(things: Iterable<CharSequence>) = assertTrue("Expected '$this' to contain at least one of $things", things.any { this.contains(it) })
+infix fun CharSequence.shouldContainSome(things: Iterable<CharSequence>) = assertTrue(things.any { this.contains(it) }, "Expected '$this' to contain at least one of $things")
 
-infix fun CharSequence.shouldContainNone(things: Iterable<CharSequence>) = assertTrue("Expected '$this' to not contain any of $things", things.none { this.contains(it) })
+infix fun CharSequence.shouldContainNone(things: Iterable<CharSequence>) = assertTrue(things.none { this.contains(it) }, "Expected '$this' to not contain any of $things")
 
-infix fun CharSequence.shouldContain(theOther: CharSequence) = assertTrue("Expected the CharSequence $this to contain $theOther", this.contains(theOther))
+infix fun CharSequence.shouldContain(theOther: CharSequence) = assertTrue(this.contains(theOther), "Expected the CharSequence $this to contain $theOther")
 
 infix fun CharSequence.shouldNotContainAny(things: Iterable<CharSequence>) = this shouldContainNone things
 
-infix fun CharSequence.shouldMatch(regex: String) = assertTrue("Expected $this to match $regex", this.matches(Regex(regex)))
+infix fun CharSequence.shouldMatch(regex: String) = assertTrue(this.matches(Regex(regex)), "Expected $this to match $regex")
 
-infix fun CharSequence.shouldMatch(regex: Regex) = assertTrue("Expected $this to match ${regex.pattern}", this.matches(regex))
+infix fun CharSequence.shouldMatch(regex: Regex) = assertTrue(this.matches(regex), "Expected $this to match ${regex.pattern}")
 
-fun CharSequence.shouldBeEmpty() = assertTrue("Expected the CharSequence to be empty, but was $this", this.isEmpty())
+fun CharSequence.shouldBeEmpty() = assertTrue(this.isEmpty(), "Expected the CharSequence to be empty, but was $this")
 
-fun CharSequence?.shouldBeNullOrEmpty() = assertTrue("Expected $this to be null or empty", this == null || this.isEmpty())
+fun CharSequence?.shouldBeNullOrEmpty() = assertTrue(this == null || this.isEmpty(), "Expected $this to be null or empty")
 
-fun CharSequence.shouldBeBlank() = assertTrue("Expected the CharSequence to be blank, but was $this", this.isBlank())
+fun CharSequence.shouldBeBlank() = assertTrue(this.isBlank(), "Expected the CharSequence to be blank, but was $this")
 
-fun CharSequence?.shouldBeNullOrBlank() = assertTrue("Expected $this to be null or blank", this == null || this.isBlank())
+fun CharSequence?.shouldBeNullOrBlank() = assertTrue(this == null || this.isBlank(), "Expected $this to be null or blank")
 
 infix fun String.shouldEqualTo(theOther: String) = assertEquals(theOther, this)
 
 infix fun String.shouldNotEqualTo(theOther: String) = assertNotEquals(theOther, this)
 
-infix fun CharSequence.shouldNotStartWith(theOther: CharSequence) = assertFalse("Expected the CharSequence $this to not start with $theOther", this.startsWith(theOther))
+infix fun CharSequence.shouldNotStartWith(theOther: CharSequence) = assertFalse(this.startsWith(theOther), "Expected the CharSequence $this to not start with $theOther")
 
-infix fun CharSequence.shouldNotEndWith(theOther: CharSequence) = assertFalse("Expected the CharSequence $this to not end with $theOther", this.endsWith(theOther))
+infix fun CharSequence.shouldNotEndWith(theOther: CharSequence) = assertFalse(this.endsWith(theOther), "Expected the CharSequence $this to not end with $theOther")
 
-infix fun CharSequence.shouldNotContain(theOther: CharSequence) = assertFalse("Expected the CharSequence $this to not contain $theOther", this.contains(theOther))
+infix fun CharSequence.shouldNotContain(theOther: CharSequence) = assertFalse(this.contains(theOther), "Expected the CharSequence $this to not contain $theOther")
 
-infix fun CharSequence.shouldNotMatch(regex: String) = assertFalse("Expected $this to not match $regex", this.matches(Regex(regex)))
+infix fun CharSequence.shouldNotMatch(regex: String) = assertFalse(this.matches(Regex(regex)), "Expected $this to not match $regex")
 
-infix fun CharSequence.shouldNotMatch(regex: Regex) = assertFalse("Expected $this to not match ${regex.pattern}", this.matches(regex))
+infix fun CharSequence.shouldNotMatch(regex: Regex) = assertFalse(this.matches(regex), "Expected $this to not match ${regex.pattern}")
 
-fun CharSequence.shouldNotBeEmpty() = assertTrue("Expected the CharSequence to not be empty", this.isNotEmpty())
+fun CharSequence.shouldNotBeEmpty() = assertTrue(this.isNotEmpty(), "Expected the CharSequence to not be empty")
 
 fun CharSequence?.shouldNotBeNullOrEmpty() {
     this.shouldNotBeNull()
     this!!.shouldNotBeEmpty()
 }
 
-fun CharSequence.shouldNotBeBlank() = assertTrue("Expected the CharSequence to not be blank", this.isNotBlank())
+fun CharSequence.shouldNotBeBlank() = assertTrue(this.isNotBlank(), "Expected the CharSequence to not be blank")
 
 fun CharSequence?.shouldNotBeNullOrBlank() {
     this.shouldNotBeNull()
     this!!.shouldNotBeBlank()
 }
+

--- a/src/main/kotlin/org/amshove/kluent/CharSequence.kt
+++ b/src/main/kotlin/org/amshove/kluent/CharSequence.kt
@@ -1,51 +1,87 @@
 package org.amshove.kluent
 
-infix fun CharSequence.shouldStartWith(theOther: CharSequence) = assert(this.startsWith(theOther), {"Expected the CharSequence $this to start with $theOther"})
+infix fun CharSequence.shouldStartWith(theOther: CharSequence) = assert(this.startsWith(theOther)) {
+    "Expected the CharSequence $this to start with $theOther"
+}
 
-infix fun CharSequence.shouldEndWith(theOther: CharSequence) = assert(this.endsWith(theOther), {"Expected the CharSequence $this to end with $theOther`"})
+infix fun CharSequence.shouldEndWith(theOther: CharSequence) = assert(this.endsWith(theOther)) {
+    "Expected the CharSequence $this to end with $theOther`"
+}
 
-infix fun CharSequence.shouldContainSome(things: Iterable<CharSequence>) = assert(things.any { this.contains(it) }, {"Expected '$this' to contain at least one of $things`"})
+infix fun CharSequence.shouldContainSome(things: Iterable<CharSequence>) = assert(things.any { this.contains(it) }) {
+    "Expected '$this' to contain at least one of $things`"
+}
 
-infix fun CharSequence.shouldContainNone(things: Iterable<CharSequence>) = assert(things.none { this.contains(it) }, {"Expected '$this' to not contain any of $things`"})
+infix fun CharSequence.shouldContainNone(things: Iterable<CharSequence>) = assert(things.none { this.contains(it) }) {
+    "Expected '$this' to not contain any of $things`"
+}
 
-infix fun CharSequence.shouldContain(theOther: CharSequence) = assert(this.contains(theOther), {"Expected the CharSequence $this to contain $theOther`"})
+infix fun CharSequence.shouldContain(theOther: CharSequence) = assert(this.contains(theOther)) {
+    "Expected the CharSequence $this to contain $theOther`"
+}
 
 infix fun CharSequence.shouldNotContainAny(things: Iterable<CharSequence>) = this shouldContainNone things
 
-infix fun CharSequence.shouldMatch(regex: String) = assert(this.matches(Regex(regex)), {"Expected $this to match $regex`"})
+infix fun CharSequence.shouldMatch(regex: String) = assert(this.matches(Regex(regex))) {
+    "Expected $this to match $regex`"
+}
 
-infix fun CharSequence.shouldMatch(regex: Regex) = assert(this.matches(regex), {"Expected $this to match ${regex.pattern}`"})
+infix fun CharSequence.shouldMatch(regex: Regex) = assert(this.matches(regex)) {
+    "Expected $this to match ${regex.pattern}`"
+}
 
-fun CharSequence.shouldBeEmpty() = assert(this.isEmpty(), {"Expected the CharSequence to be empty, but was $this"})
+fun CharSequence.shouldBeEmpty() = assert(this.isEmpty()) {
+    "Expected the CharSequence to be empty, but was $this"
+}
 
-fun CharSequence?.shouldBeNullOrEmpty() = assert(this == null || this.isEmpty(), {"Expected $this to be null or empty"})
+fun CharSequence?.shouldBeNullOrEmpty() = assert(this == null || this.isEmpty()) {
+    "Expected $this to be null or empty"
+}
 
-fun CharSequence.shouldBeBlank() = assert(this.isBlank(), {"Expected the CharSequence to be blank, but was $this"})
+fun CharSequence.shouldBeBlank() = assert(this.isBlank()) {
+    "Expected the CharSequence to be blank, but was $this"
+}
 
-fun CharSequence?.shouldBeNullOrBlank() = assert(this == null || this.isBlank(), {"Expected $this to be null or blank"})
+fun CharSequence?.shouldBeNullOrBlank() = assert(this == null || this.isBlank()) {
+    "Expected $this to be null or blank"
+}
 
 infix fun String.shouldEqualTo(theOther: String) = assert(this == theOther)
 
 infix fun String.shouldNotEqualTo(theOther: String) = assert(this != theOther)
 
-infix fun CharSequence.shouldNotStartWith(theOther: CharSequence) = assert(!this.startsWith(theOther), {"Expected the CharSequence $this to not start with $theOther"})
+infix fun CharSequence.shouldNotStartWith(theOther: CharSequence) = assert(!this.startsWith(theOther)) {
+    "Expected the CharSequence $this to not start with $theOther"
+}
 
-infix fun CharSequence.shouldNotEndWith(theOther: CharSequence) = assert(!this.endsWith(theOther), {"Expected the CharSequence $this to not end with $theOther"})
+infix fun CharSequence.shouldNotEndWith(theOther: CharSequence) = assert(!this.endsWith(theOther)) {
+    "Expected the CharSequence $this to not end with $theOther"
+}
 
-infix fun CharSequence.shouldNotContain(theOther: CharSequence) = assert(!this.contains(theOther), {"Expected the CharSequence $this to not contain $theOther"})
+infix fun CharSequence.shouldNotContain(theOther: CharSequence) = assert(!this.contains(theOther)) {
+    "Expected the CharSequence $this to not contain $theOther"
+}
 
-infix fun CharSequence.shouldNotMatch(regex: String) = assert(!this.matches(Regex(regex)), {"Expected $this to not match $regex"})
+infix fun CharSequence.shouldNotMatch(regex: String) = assert(!this.matches(Regex(regex))) {
+    "Expected $this to not match $regex"
+}
 
-infix fun CharSequence.shouldNotMatch(regex: Regex) = assert(!this.matches(regex), {"Expected $this to not match ${regex.pattern}"})
+infix fun CharSequence.shouldNotMatch(regex: Regex) = assert(!this.matches(regex)) {
+    "Expected $this to not match ${regex.pattern}"
+}
 
-fun CharSequence.shouldNotBeEmpty() = assert(this.isNotEmpty(), {"Expected the CharSequence to not be empty"})
+fun CharSequence.shouldNotBeEmpty() = assert(this.isNotEmpty()) {
+    "Expected the CharSequence to not be empty"
+}
 
 fun CharSequence?.shouldNotBeNullOrEmpty() {
     this.shouldNotBeNull()
     this!!.shouldNotBeEmpty()
 }
 
-fun CharSequence.shouldNotBeBlank() = assert(this.isNotBlank(), {"Expected the CharSequence to not be blank"})
+fun CharSequence.shouldNotBeBlank() = assert(this.isNotBlank()) {
+    "Expected the CharSequence to not be blank"
+}
 
 fun CharSequence?.shouldNotBeNullOrBlank() {
     this.shouldNotBeNull()

--- a/src/main/kotlin/org/amshove/kluent/CharSequence.kt
+++ b/src/main/kotlin/org/amshove/kluent/CharSequence.kt
@@ -1,53 +1,51 @@
 package org.amshove.kluent
 
-import org.assertj.core.api.Assertions.assertThat
+infix fun CharSequence.shouldStartWith(theOther: CharSequence) = assert(this.startsWith(theOther), {"Expected the CharSequence $this to start with $theOther"})
 
-infix fun CharSequence.shouldStartWith(theOther: CharSequence) = assertThat(this.startsWith(theOther)).`as`("Expected the CharSequence $this to start with $theOther").isTrue()
+infix fun CharSequence.shouldEndWith(theOther: CharSequence) = assert(this.endsWith(theOther), {"Expected the CharSequence $this to end with $theOther`"})
 
-infix fun CharSequence.shouldEndWith(theOther: CharSequence) = assertThat(this.endsWith(theOther)).`as`("Expected the CharSequence $this to end with $theOther").isTrue()
+infix fun CharSequence.shouldContainSome(things: Iterable<CharSequence>) = assert(things.any { this.contains(it) }, {"Expected '$this' to contain at least one of $things`"})
 
-infix fun CharSequence.shouldContainSome(things: Iterable<CharSequence>) = assertThat(things.any { this.contains(it) }).`as`("Expected '$this' to contain at least one of $things").isTrue()
+infix fun CharSequence.shouldContainNone(things: Iterable<CharSequence>) = assert(things.none { this.contains(it) }, {"Expected '$this' to not contain any of $things`"})
 
-infix fun CharSequence.shouldContainNone(things: Iterable<CharSequence>) = assertThat(things.none { this.contains(it) }).`as`("Expected '$this' to not contain any of $things").isTrue()
-
-infix fun CharSequence.shouldContain(theOther: CharSequence) = assertThat(this.contains(theOther)).`as`("Expected the CharSequence $this to contain $theOther").isTrue()
+infix fun CharSequence.shouldContain(theOther: CharSequence) = assert(this.contains(theOther), {"Expected the CharSequence $this to contain $theOther`"})
 
 infix fun CharSequence.shouldNotContainAny(things: Iterable<CharSequence>) = this shouldContainNone things
 
-infix fun CharSequence.shouldMatch(regex: String) = assertThat(this.matches(Regex(regex))).`as`("Expected $this to match $regex").isTrue()
+infix fun CharSequence.shouldMatch(regex: String) = assert(this.matches(Regex(regex)), {"Expected $this to match $regex`"})
 
-infix fun CharSequence.shouldMatch(regex: Regex) = assertThat(this.matches(regex)).`as`("Expected $this to match ${regex.pattern}").isTrue()
+infix fun CharSequence.shouldMatch(regex: Regex) = assert(this.matches(regex), {"Expected $this to match ${regex.pattern}`"})
 
-fun CharSequence.shouldBeEmpty() = assertThat(this.isEmpty()).`as`("Expected the CharSequence to be empty, but was $this").isTrue()
+fun CharSequence.shouldBeEmpty() = assert(this.isEmpty(), {"Expected the CharSequence to be empty, but was $this"})
 
-fun CharSequence?.shouldBeNullOrEmpty() = assertThat(this == null || this.isEmpty()).`as`("Expected $this to be null or empty").isTrue()
+fun CharSequence?.shouldBeNullOrEmpty() = assert(this == null || this.isEmpty(), {"Expected $this to be null or empty"})
 
-fun CharSequence.shouldBeBlank() = assertThat(this.isBlank()).`as`("Expected the CharSequence to be blank, but was $this").isTrue()
+fun CharSequence.shouldBeBlank() = assert(this.isBlank(), {"Expected the CharSequence to be blank, but was $this"})
 
-fun CharSequence?.shouldBeNullOrBlank() = assertThat(this == null || this.isBlank()).`as`("Expected $this to be null or blank").isTrue()
+fun CharSequence?.shouldBeNullOrBlank() = assert(this == null || this.isBlank(), {"Expected $this to be null or blank"})
 
-infix fun String.shouldEqualTo(theOther: String) = assertThat(this).isEqualTo(theOther)
+infix fun String.shouldEqualTo(theOther: String) = assert(this == theOther)
 
-infix fun String.shouldNotEqualTo(theOther: String) = assertThat(this).isNotEqualTo(theOther)
+infix fun String.shouldNotEqualTo(theOther: String) = assert(this != theOther)
 
-infix fun CharSequence.shouldNotStartWith(theOther: CharSequence) = assertThat(this.startsWith(theOther)).`as`("Expected the CharSequence $this to not start with $theOther").isFalse()
+infix fun CharSequence.shouldNotStartWith(theOther: CharSequence) = assert(!this.startsWith(theOther), {"Expected the CharSequence $this to not start with $theOther"})
 
-infix fun CharSequence.shouldNotEndWith(theOther: CharSequence) = assertThat(this.endsWith(theOther)).`as`("Expected the CharSequence $this to not end with $theOther").isFalse()
+infix fun CharSequence.shouldNotEndWith(theOther: CharSequence) = assert(!this.endsWith(theOther), {"Expected the CharSequence $this to not end with $theOther"})
 
-infix fun CharSequence.shouldNotContain(theOther: CharSequence) = assertThat(this.contains(theOther)).`as`("Expected the CharSequence $this to not contain $theOther").isFalse()
+infix fun CharSequence.shouldNotContain(theOther: CharSequence) = assert(!this.contains(theOther), {"Expected the CharSequence $this to not contain $theOther"})
 
-infix fun CharSequence.shouldNotMatch(regex: String) = assertThat(this.matches(Regex(regex))).`as`("Expected $this to not match $regex").isFalse()
+infix fun CharSequence.shouldNotMatch(regex: String) = assert(!this.matches(Regex(regex)), {"Expected $this to not match $regex"})
 
-infix fun CharSequence.shouldNotMatch(regex: Regex) = assertThat(this.matches(regex)).`as`("Expected $this to not match ${regex.pattern}").isFalse()
+infix fun CharSequence.shouldNotMatch(regex: Regex) = assert(!this.matches(regex), {"Expected $this to not match ${regex.pattern}"})
 
-fun CharSequence.shouldNotBeEmpty() = assertThat(this.isNotEmpty()).`as`("Expected the CharSequence to not be empty").isTrue()
+fun CharSequence.shouldNotBeEmpty() = assert(this.isNotEmpty(), {"Expected the CharSequence to not be empty"})
 
 fun CharSequence?.shouldNotBeNullOrEmpty() {
     this.shouldNotBeNull()
     this!!.shouldNotBeEmpty()
 }
 
-fun CharSequence.shouldNotBeBlank() = assertThat(this.isNotBlank()).`as`("Expected the CharSequence to not be blank").isTrue()
+fun CharSequence.shouldNotBeBlank() = assert(this.isNotBlank(), {"Expected the CharSequence to not be blank"})
 
 fun CharSequence?.shouldNotBeNullOrBlank() {
     this.shouldNotBeNull()

--- a/src/main/kotlin/org/amshove/kluent/CharSequence.kt
+++ b/src/main/kotlin/org/amshove/kluent/CharSequence.kt
@@ -1,53 +1,53 @@
 package org.amshove.kluent
 
-import org.junit.jupiter.api.Assertions.*
+import org.assertj.core.api.Assertions.assertThat
 
-infix fun CharSequence.shouldStartWith(theOther: CharSequence) = assertTrue(this.startsWith(theOther), "Expected the CharSequence $this to start with $theOther")
+infix fun CharSequence.shouldStartWith(theOther: CharSequence) = assertThat(this.startsWith(theOther)).`as`("Expected the CharSequence $this to start with $theOther").isTrue()
 
-infix fun CharSequence.shouldEndWith(theOther: CharSequence) = assertTrue(this.endsWith(theOther), "Expected the CharSequence $this to end with $theOther")
+infix fun CharSequence.shouldEndWith(theOther: CharSequence) = assertThat(this.endsWith(theOther)).`as`("Expected the CharSequence $this to end with $theOther").isTrue()
 
-infix fun CharSequence.shouldContainSome(things: Iterable<CharSequence>) = assertTrue(things.any { this.contains(it) }, "Expected '$this' to contain at least one of $things")
+infix fun CharSequence.shouldContainSome(things: Iterable<CharSequence>) = assertThat(things.any { this.contains(it) }).`as`("Expected '$this' to contain at least one of $things").isTrue()
 
-infix fun CharSequence.shouldContainNone(things: Iterable<CharSequence>) = assertTrue(things.none { this.contains(it) }, "Expected '$this' to not contain any of $things")
+infix fun CharSequence.shouldContainNone(things: Iterable<CharSequence>) = assertThat(things.none { this.contains(it) }).`as`("Expected '$this' to not contain any of $things").isTrue()
 
-infix fun CharSequence.shouldContain(theOther: CharSequence) = assertTrue(this.contains(theOther), "Expected the CharSequence $this to contain $theOther")
+infix fun CharSequence.shouldContain(theOther: CharSequence) = assertThat(this.contains(theOther)).`as`("Expected the CharSequence $this to contain $theOther").isTrue()
 
 infix fun CharSequence.shouldNotContainAny(things: Iterable<CharSequence>) = this shouldContainNone things
 
-infix fun CharSequence.shouldMatch(regex: String) = assertTrue(this.matches(Regex(regex)), "Expected $this to match $regex")
+infix fun CharSequence.shouldMatch(regex: String) = assertThat(this.matches(Regex(regex))).`as`("Expected $this to match $regex").isTrue()
 
-infix fun CharSequence.shouldMatch(regex: Regex) = assertTrue(this.matches(regex), "Expected $this to match ${regex.pattern}")
+infix fun CharSequence.shouldMatch(regex: Regex) = assertThat(this.matches(regex)).`as`("Expected $this to match ${regex.pattern}").isTrue()
 
-fun CharSequence.shouldBeEmpty() = assertTrue(this.isEmpty(), "Expected the CharSequence to be empty, but was $this")
+fun CharSequence.shouldBeEmpty() = assertThat(this.isEmpty()).`as`("Expected the CharSequence to be empty, but was $this").isTrue()
 
-fun CharSequence?.shouldBeNullOrEmpty() = assertTrue(this == null || this.isEmpty(), "Expected $this to be null or empty")
+fun CharSequence?.shouldBeNullOrEmpty() = assertThat(this == null || this.isEmpty()).`as`("Expected $this to be null or empty").isTrue()
 
-fun CharSequence.shouldBeBlank() = assertTrue(this.isBlank(), "Expected the CharSequence to be blank, but was $this")
+fun CharSequence.shouldBeBlank() = assertThat(this.isBlank()).`as`("Expected the CharSequence to be blank, but was $this").isTrue()
 
-fun CharSequence?.shouldBeNullOrBlank() = assertTrue(this == null || this.isBlank(), "Expected $this to be null or blank")
+fun CharSequence?.shouldBeNullOrBlank() = assertThat(this == null || this.isBlank()).`as`("Expected $this to be null or blank").isTrue()
 
-infix fun String.shouldEqualTo(theOther: String) = assertEquals(theOther, this)
+infix fun String.shouldEqualTo(theOther: String) = assertThat(this).isEqualTo(theOther)
 
-infix fun String.shouldNotEqualTo(theOther: String) = assertNotEquals(theOther, this)
+infix fun String.shouldNotEqualTo(theOther: String) = assertThat(this).isNotEqualTo(theOther)
 
-infix fun CharSequence.shouldNotStartWith(theOther: CharSequence) = assertFalse(this.startsWith(theOther), "Expected the CharSequence $this to not start with $theOther")
+infix fun CharSequence.shouldNotStartWith(theOther: CharSequence) = assertThat(this.startsWith(theOther)).`as`("Expected the CharSequence $this to not start with $theOther").isFalse()
 
-infix fun CharSequence.shouldNotEndWith(theOther: CharSequence) = assertFalse(this.endsWith(theOther), "Expected the CharSequence $this to not end with $theOther")
+infix fun CharSequence.shouldNotEndWith(theOther: CharSequence) = assertThat(this.endsWith(theOther)).`as`("Expected the CharSequence $this to not end with $theOther").isFalse()
 
-infix fun CharSequence.shouldNotContain(theOther: CharSequence) = assertFalse(this.contains(theOther), "Expected the CharSequence $this to not contain $theOther")
+infix fun CharSequence.shouldNotContain(theOther: CharSequence) = assertThat(this.contains(theOther)).`as`("Expected the CharSequence $this to not contain $theOther").isFalse()
 
-infix fun CharSequence.shouldNotMatch(regex: String) = assertFalse(this.matches(Regex(regex)), "Expected $this to not match $regex")
+infix fun CharSequence.shouldNotMatch(regex: String) = assertThat(this.matches(Regex(regex))).`as`("Expected $this to not match $regex").isFalse()
 
-infix fun CharSequence.shouldNotMatch(regex: Regex) = assertFalse(this.matches(regex), "Expected $this to not match ${regex.pattern}")
+infix fun CharSequence.shouldNotMatch(regex: Regex) = assertThat(this.matches(regex)).`as`("Expected $this to not match ${regex.pattern}").isFalse()
 
-fun CharSequence.shouldNotBeEmpty() = assertTrue(this.isNotEmpty(), "Expected the CharSequence to not be empty")
+fun CharSequence.shouldNotBeEmpty() = assertThat(this.isNotEmpty()).`as`("Expected the CharSequence to not be empty").isTrue()
 
 fun CharSequence?.shouldNotBeNullOrEmpty() {
     this.shouldNotBeNull()
     this!!.shouldNotBeEmpty()
 }
 
-fun CharSequence.shouldNotBeBlank() = assertTrue(this.isNotBlank(), "Expected the CharSequence to not be blank")
+fun CharSequence.shouldNotBeBlank() = assertThat(this.isNotBlank()).`as`("Expected the CharSequence to not be blank").isTrue()
 
 fun CharSequence?.shouldNotBeNullOrBlank() {
     this.shouldNotBeNull()

--- a/src/main/kotlin/org/amshove/kluent/Collections.kt
+++ b/src/main/kotlin/org/amshove/kluent/Collections.kt
@@ -1,12 +1,12 @@
 package org.amshove.kluent
 
-import org.junit.Assert.*
+import org.junit.jupiter.api.Assertions.*
 
 infix fun <T> Array<T>.shouldContain(theThing: T) = if (this.contains(theThing)) Unit else fail("$this should contain $theThing", "$theThing", join(this))
 
-infix fun <T> Array<T>.shouldContainSome(things: Array<T>) = assertTrue("Expected $this to contain at least one of $things", this.any { things.contains(it) })
+infix fun <T> Array<T>.shouldContainSome(things: Array<T>) = assertTrue(this.any { things.contains(it) }, "Expected $this to contain at least one of $things")
 
-infix fun <T> Array<T>.shouldContainNone(things: Array<T>) = assertTrue("Expected $this to contain none of $things", this.none { things.contains(it) })
+infix fun <T> Array<T>.shouldContainNone(things: Array<T>) = assertTrue(this.none { things.contains(it) }, "Expected $this to contain none of $things")
 
 infix fun <T> Array<T>.shouldContainAll(things: Array<T>) = things.forEach { shouldContain(it) }
 
@@ -200,9 +200,9 @@ infix fun Short.shouldNotBeIn(theArray: ShortArray) = this shouldNotBeIn theArra
 
 infix fun <T> Iterable<T>.shouldContain(theThing: T) = if (this.contains(theThing)) Unit else fail("$this should contain $theThing", "$theThing", join(this))
 
-infix fun <T> Iterable<T>.shouldContainSome(things: Iterable<T>) = assertTrue("Expected $this to contain at least one of $things", this.any { things.contains(it) })
+infix fun <T> Iterable<T>.shouldContainSome(things: Iterable<T>) = assertTrue(this.any { things.contains(it) }, "Expected $this to contain at least one of $things")
 
-infix fun <T> Iterable<T>.shouldContainNone(things: Iterable<T>) = assertTrue("Expected $this to contain none of $things", this.none { things.contains(it) })
+infix fun <T> Iterable<T>.shouldContainNone(things: Iterable<T>) = assertTrue(this.none { things.contains(it) }, "Expected $this to contain none of $things")
 
 infix fun <T> Iterable<T>.shouldContainAll(things: Iterable<T>) = things.forEach { shouldContain(it) }
 
@@ -244,5 +244,5 @@ infix fun <T> Any?.shouldNotBeIn(iterable: Iterable<T>) = if (!iterable.contains
 
 infix fun <T> Any?.shouldBeIn(array: Array<T>) = if (array.contains(this)) Unit else fail("$this should be in $array", "$this", join(array))
 
-internal fun <T> assertEmpty(iterable: Iterable<T>, collectionType: String) = assertTrue("Expected the $collectionType to be empty, but has ${iterable.count()} elements", iterable.count() == 0)
-internal fun <T> assertNotEmpty(iterable: Iterable<T>, collectionType: String) = assertTrue("Expected the $collectionType to contain elements, but is empty", iterable.count() > 0)
+internal fun <T> assertEmpty(iterable: Iterable<T>, collectionType: String) = assertTrue(iterable.count() == 0, "Expected the $collectionType to be empty, but has ${iterable.count()} elements")
+internal fun <T> assertNotEmpty(iterable: Iterable<T>, collectionType: String) = assertTrue(iterable.count() > 0, "Expected the $collectionType to contain elements, but is empty")

--- a/src/main/kotlin/org/amshove/kluent/Collections.kt
+++ b/src/main/kotlin/org/amshove/kluent/Collections.kt
@@ -1,12 +1,12 @@
 package org.amshove.kluent
 
-import org.assertj.core.api.Assertions.assertThat
+import java.util.*
 
 infix fun <T> Array<T>.shouldContain(theThing: T) = if (this.contains(theThing)) Unit else fail("$this should contain $theThing", "$theThing", join(this))
 
-infix fun <T> Array<T>.shouldContainSome(things: Array<T>) = assertThat(this.any { things.contains(it) }).`as`("Expected $this to contain at least one of $things").isTrue()
+infix fun <T> Array<T>.shouldContainSome(things: Array<T>) = assert(this.any { things.contains(it) }, {"Expected $this to contain at least one of $things"})
 
-infix fun <T> Array<T>.shouldContainNone(things: Array<T>) = assertThat(this.none { things.contains(it) }).`as`("Expected $this to contain none of $things").isTrue()
+infix fun <T> Array<T>.shouldContainNone(things: Array<T>) = assert(this.none { things.contains(it) }, {"Expected $this to contain none of $things"})
 
 infix fun <T> Array<T>.shouldContainAll(things: Array<T>) = things.forEach { shouldContain(it) }
 
@@ -14,13 +14,13 @@ infix fun <T> Array<T>.shouldNotContain(theThing: T) = if (!this.contains(theThi
 
 infix fun <T> Array<T>.shouldNotContainAny(things: Array<T>) = things.forEach { shouldNotContain(it) }
 
-infix fun <T> Array<T>?.shouldEqual(theOther: Array<T>?) = assertThat(this).isEqualTo(theOther)
+infix fun <T> Array<T>?.shouldEqual(theOther: Array<T>?) = assert(Arrays.equals(this, theOther))
 
 fun <T> Array<T>.shouldBeEmpty() = assertEmpty(this.toList(), "Array")
 
 fun <T> Array<T>.shouldNotBeEmpty() = assertNotEmpty(this.toList(), "Array")
 
-infix fun IntArray.shouldEqual(theOther: IntArray) = assertThat(theOther).isEqualTo(this)
+infix fun IntArray.shouldEqual(theOther: IntArray) = assert(Arrays.equals(this, theOther))
 
 fun IntArray.shouldBeEmpty() = this.toTypedArray().shouldBeEmpty()
 
@@ -42,7 +42,7 @@ infix fun Int.shouldBeIn(theArray: IntArray) = this shouldBeIn theArray.toTypedA
 
 infix fun Int.shouldNotBeIn(theArray: IntArray) = this shouldNotBeIn theArray.toTypedArray()
 
-infix fun BooleanArray.shouldEqual(theOther: BooleanArray) = assertThat(theOther).isEqualTo(this)
+infix fun BooleanArray.shouldEqual(theOther: BooleanArray) = assert(Arrays.equals(this, theOther))
 
 fun BooleanArray.shouldBeEmpty() = this.toTypedArray().shouldBeEmpty()
 
@@ -64,7 +64,7 @@ infix fun Boolean.shouldBeIn(theArray: BooleanArray) = this shouldBeIn theArray.
 
 infix fun Boolean.shouldNotBeIn(theArray: BooleanArray) = this shouldNotBeIn theArray.toTypedArray()
 
-infix fun ByteArray.shouldEqual(theOther: ByteArray) = assertThat(theOther).isEqualTo(this)
+infix fun ByteArray.shouldEqual(theOther: ByteArray) = assert(Arrays.equals(this, theOther))
 
 fun ByteArray.shouldBeEmpty() = this.toTypedArray().shouldBeEmpty()
 
@@ -86,7 +86,7 @@ infix fun Byte.shouldBeIn(theArray: ByteArray) = this shouldBeIn theArray.toType
 
 infix fun Byte.shouldNotBeIn(theArray: ByteArray) = this shouldNotBeIn theArray.toTypedArray()
 
-infix fun CharArray.shouldEqual(theOther: CharArray) = assertThat(theOther).isEqualTo(this)
+infix fun CharArray.shouldEqual(theOther: CharArray) = assert(Arrays.equals(this, theOther))
 
 infix fun CharArray.shouldNotEqual(theOther: CharArray) = this.toTypedArray() shouldNotEqual theOther.toTypedArray()
 
@@ -110,7 +110,7 @@ infix fun Char.shouldBeIn(theArray: CharArray) = this shouldBeIn theArray.toType
 
 infix fun Char.shouldNotBeIn(theArray: CharArray) = this shouldNotBeIn theArray.toTypedArray()
 
-infix fun DoubleArray.shouldEqual(theOther: DoubleArray) = assertThat(theOther.toTypedArray()).isEqualTo(this.toTypedArray())
+infix fun DoubleArray.shouldEqual(theOther: DoubleArray) = assert(Arrays.equals(this.toTypedArray(), theOther.toTypedArray()))
 
 fun DoubleArray.shouldBeEmpty() = this.toTypedArray().shouldBeEmpty()
 
@@ -132,7 +132,7 @@ infix fun Double.shouldBeIn(theArray: DoubleArray) = this shouldBeIn theArray.to
 
 infix fun Double.shouldNotBeIn(theArray: DoubleArray) = this shouldNotBeIn theArray.toTypedArray()
 
-infix fun FloatArray.shouldEqual(theOther: FloatArray) = assertThat(theOther.toTypedArray()).isEqualTo(this.toTypedArray())
+infix fun FloatArray.shouldEqual(theOther: FloatArray) = assert(Arrays.equals(this.toTypedArray(), theOther.toTypedArray()))
 
 fun FloatArray.shouldBeEmpty() = this.toTypedArray().shouldBeEmpty()
 
@@ -154,7 +154,7 @@ infix fun Float.shouldBeIn(theArray: FloatArray) = this shouldBeIn theArray.toTy
 
 infix fun Float.shouldNotBeIn(theArray: FloatArray) = this shouldNotBeIn theArray.toTypedArray()
 
-infix fun LongArray.shouldEqual(theOther: LongArray) = assertThat(theOther).isEqualTo(this)
+infix fun LongArray.shouldEqual(theOther: LongArray) = assert(Arrays.equals(this, theOther))
 
 fun LongArray.shouldBeEmpty() = this.toTypedArray().shouldBeEmpty()
 
@@ -176,7 +176,7 @@ infix fun Long.shouldBeIn(theArray: LongArray) = this shouldBeIn theArray.toType
 
 infix fun Long.shouldNotBeIn(theArray: LongArray) = this shouldNotBeIn theArray.toTypedArray()
 
-infix fun ShortArray.shouldEqual(theOther: ShortArray) = assertThat(theOther).isEqualTo(this)
+infix fun ShortArray.shouldEqual(theOther: ShortArray) = assert(Arrays.equals(this, theOther))
 
 fun ShortArray.shouldBeEmpty() = this.toTypedArray().shouldBeEmpty()
 
@@ -200,9 +200,9 @@ infix fun Short.shouldNotBeIn(theArray: ShortArray) = this shouldNotBeIn theArra
 
 infix fun <T> Iterable<T>.shouldContain(theThing: T) = if (this.contains(theThing)) Unit else fail("$this should contain $theThing", "$theThing", join(this))
 
-infix fun <T> Iterable<T>.shouldContainSome(things: Iterable<T>) = assertThat(this.any { things.contains(it) }).`as`("Expected $this to contain at least one of $things").isTrue()
+infix fun <T> Iterable<T>.shouldContainSome(things: Iterable<T>) = assert(this.any { things.contains(it) }, {"Expected $this to contain at least one of $things"})
 
-infix fun <T> Iterable<T>.shouldContainNone(things: Iterable<T>) = assertThat(this.none { things.contains(it) }).`as`("Expected $this to contain none of $things").isTrue()
+infix fun <T> Iterable<T>.shouldContainNone(things: Iterable<T>) = assert(this.none { things.contains(it) }, {"Expected $this to contain none of $things"})
 
 infix fun <T> Iterable<T>.shouldContainAll(things: Iterable<T>) = things.forEach { shouldContain(it) }
 
@@ -210,7 +210,7 @@ infix fun <T> Iterable<T>.shouldNotContain(theThing: T) = if (!this.contains(the
 
 infix fun <T> Iterable<T>.shouldNotContainAny(things: Iterable<T>) = things.forEach { shouldNotContain(it) }
 
-infix fun <T> Iterable<T>?.shouldEqual(theOther: Iterable<T>?) = assertThat(this).isEqualTo(theOther)
+infix fun <T> Iterable<T>?.shouldEqual(theOther: Iterable<T>?) = assert(this == theOther)
 
 fun <T> Iterable<T>.shouldBeEmpty() = assertEmpty(this, "Iterable")
 
@@ -244,6 +244,6 @@ infix fun <T> Any?.shouldNotBeIn(iterable: Iterable<T>) = if (!iterable.contains
 
 infix fun <T> Any?.shouldBeIn(array: Array<T>) = if (array.contains(this)) Unit else fail("$this should be in $array", "$this", join(array))
 
-internal fun <T> assertEmpty(iterable: Iterable<T>, collectionType: String) = assertThat(iterable.count() == 0).`as`("Expected the $collectionType to be empty, but has ${iterable.count()} elements").isTrue()
+internal fun <T> assertEmpty(iterable: Iterable<T>, collectionType: String) = assert(iterable.count() == 0, {"Expected the $collectionType to be empty, but has ${iterable.count()} elements"})
 
-internal fun <T> assertNotEmpty(iterable: Iterable<T>, collectionType: String) = assertThat(iterable.count() > 0).`as`("Expected the $collectionType to contain elements, but is empty").isTrue()
+internal fun <T> assertNotEmpty(iterable: Iterable<T>, collectionType: String) = assert(iterable.count() > 0, {"Expected the $collectionType to contain elements, but is empty"})

--- a/src/main/kotlin/org/amshove/kluent/Collections.kt
+++ b/src/main/kotlin/org/amshove/kluent/Collections.kt
@@ -1,12 +1,12 @@
 package org.amshove.kluent
 
-import org.junit.jupiter.api.Assertions.*
+import org.assertj.core.api.Assertions.assertThat
 
 infix fun <T> Array<T>.shouldContain(theThing: T) = if (this.contains(theThing)) Unit else fail("$this should contain $theThing", "$theThing", join(this))
 
-infix fun <T> Array<T>.shouldContainSome(things: Array<T>) = assertTrue(this.any { things.contains(it) }, "Expected $this to contain at least one of $things")
+infix fun <T> Array<T>.shouldContainSome(things: Array<T>) = assertThat(this.any { things.contains(it) }).`as`("Expected $this to contain at least one of $things").isTrue()
 
-infix fun <T> Array<T>.shouldContainNone(things: Array<T>) = assertTrue(this.none { things.contains(it) }, "Expected $this to contain none of $things")
+infix fun <T> Array<T>.shouldContainNone(things: Array<T>) = assertThat(this.none { things.contains(it) }).`as`("Expected $this to contain none of $things").isTrue()
 
 infix fun <T> Array<T>.shouldContainAll(things: Array<T>) = things.forEach { shouldContain(it) }
 
@@ -14,13 +14,13 @@ infix fun <T> Array<T>.shouldNotContain(theThing: T) = if (!this.contains(theThi
 
 infix fun <T> Array<T>.shouldNotContainAny(things: Array<T>) = things.forEach { shouldNotContain(it) }
 
-infix fun <T> Array<T>?.shouldEqual(theOther: Array<T>?) = assertArrayEquals(theOther, this)
+infix fun <T> Array<T>?.shouldEqual(theOther: Array<T>?) = assertThat(this).isEqualTo(theOther)
 
 fun <T> Array<T>.shouldBeEmpty() = assertEmpty(this.toList(), "Array")
 
 fun <T> Array<T>.shouldNotBeEmpty() = assertNotEmpty(this.toList(), "Array")
 
-infix fun IntArray.shouldEqual(theOther: IntArray) = assertArrayEquals(this, theOther)
+infix fun IntArray.shouldEqual(theOther: IntArray) = assertThat(theOther).isEqualTo(this)
 
 fun IntArray.shouldBeEmpty() = this.toTypedArray().shouldBeEmpty()
 
@@ -42,7 +42,7 @@ infix fun Int.shouldBeIn(theArray: IntArray) = this shouldBeIn theArray.toTypedA
 
 infix fun Int.shouldNotBeIn(theArray: IntArray) = this shouldNotBeIn theArray.toTypedArray()
 
-infix fun BooleanArray.shouldEqual(theOther: BooleanArray) = assertArrayEquals(this, theOther)
+infix fun BooleanArray.shouldEqual(theOther: BooleanArray) = assertThat(theOther).isEqualTo(this)
 
 fun BooleanArray.shouldBeEmpty() = this.toTypedArray().shouldBeEmpty()
 
@@ -64,7 +64,7 @@ infix fun Boolean.shouldBeIn(theArray: BooleanArray) = this shouldBeIn theArray.
 
 infix fun Boolean.shouldNotBeIn(theArray: BooleanArray) = this shouldNotBeIn theArray.toTypedArray()
 
-infix fun ByteArray.shouldEqual(theOther: ByteArray) = assertArrayEquals(this, theOther)
+infix fun ByteArray.shouldEqual(theOther: ByteArray) = assertThat(theOther).isEqualTo(this)
 
 fun ByteArray.shouldBeEmpty() = this.toTypedArray().shouldBeEmpty()
 
@@ -86,7 +86,7 @@ infix fun Byte.shouldBeIn(theArray: ByteArray) = this shouldBeIn theArray.toType
 
 infix fun Byte.shouldNotBeIn(theArray: ByteArray) = this shouldNotBeIn theArray.toTypedArray()
 
-infix fun CharArray.shouldEqual(theOther: CharArray) = assertArrayEquals(this, theOther)
+infix fun CharArray.shouldEqual(theOther: CharArray) = assertThat(theOther).isEqualTo(this)
 
 infix fun CharArray.shouldNotEqual(theOther: CharArray) = this.toTypedArray() shouldNotEqual theOther.toTypedArray()
 
@@ -110,7 +110,7 @@ infix fun Char.shouldBeIn(theArray: CharArray) = this shouldBeIn theArray.toType
 
 infix fun Char.shouldNotBeIn(theArray: CharArray) = this shouldNotBeIn theArray.toTypedArray()
 
-infix fun DoubleArray.shouldEqual(theOther: DoubleArray) = assertArrayEquals(this.toTypedArray(), theOther.toTypedArray())
+infix fun DoubleArray.shouldEqual(theOther: DoubleArray) = assertThat(theOther.toTypedArray()).isEqualTo(this.toTypedArray())
 
 fun DoubleArray.shouldBeEmpty() = this.toTypedArray().shouldBeEmpty()
 
@@ -132,7 +132,7 @@ infix fun Double.shouldBeIn(theArray: DoubleArray) = this shouldBeIn theArray.to
 
 infix fun Double.shouldNotBeIn(theArray: DoubleArray) = this shouldNotBeIn theArray.toTypedArray()
 
-infix fun FloatArray.shouldEqual(theOther: FloatArray) = assertArrayEquals(this.toTypedArray(), theOther.toTypedArray())
+infix fun FloatArray.shouldEqual(theOther: FloatArray) = assertThat(theOther.toTypedArray()).isEqualTo(this.toTypedArray())
 
 fun FloatArray.shouldBeEmpty() = this.toTypedArray().shouldBeEmpty()
 
@@ -154,7 +154,7 @@ infix fun Float.shouldBeIn(theArray: FloatArray) = this shouldBeIn theArray.toTy
 
 infix fun Float.shouldNotBeIn(theArray: FloatArray) = this shouldNotBeIn theArray.toTypedArray()
 
-infix fun LongArray.shouldEqual(theOther: LongArray) = assertArrayEquals(this, theOther)
+infix fun LongArray.shouldEqual(theOther: LongArray) = assertThat(theOther).isEqualTo(this)
 
 fun LongArray.shouldBeEmpty() = this.toTypedArray().shouldBeEmpty()
 
@@ -176,7 +176,7 @@ infix fun Long.shouldBeIn(theArray: LongArray) = this shouldBeIn theArray.toType
 
 infix fun Long.shouldNotBeIn(theArray: LongArray) = this shouldNotBeIn theArray.toTypedArray()
 
-infix fun ShortArray.shouldEqual(theOther: ShortArray) = assertArrayEquals(this, theOther)
+infix fun ShortArray.shouldEqual(theOther: ShortArray) = assertThat(theOther).isEqualTo(this)
 
 fun ShortArray.shouldBeEmpty() = this.toTypedArray().shouldBeEmpty()
 
@@ -200,9 +200,9 @@ infix fun Short.shouldNotBeIn(theArray: ShortArray) = this shouldNotBeIn theArra
 
 infix fun <T> Iterable<T>.shouldContain(theThing: T) = if (this.contains(theThing)) Unit else fail("$this should contain $theThing", "$theThing", join(this))
 
-infix fun <T> Iterable<T>.shouldContainSome(things: Iterable<T>) = assertTrue(this.any { things.contains(it) }, "Expected $this to contain at least one of $things")
+infix fun <T> Iterable<T>.shouldContainSome(things: Iterable<T>) = assertThat(this.any { things.contains(it) }).`as`("Expected $this to contain at least one of $things").isTrue()
 
-infix fun <T> Iterable<T>.shouldContainNone(things: Iterable<T>) = assertTrue(this.none { things.contains(it) }, "Expected $this to contain none of $things")
+infix fun <T> Iterable<T>.shouldContainNone(things: Iterable<T>) = assertThat(this.none { things.contains(it) }).`as`("Expected $this to contain none of $things").isTrue()
 
 infix fun <T> Iterable<T>.shouldContainAll(things: Iterable<T>) = things.forEach { shouldContain(it) }
 
@@ -210,7 +210,7 @@ infix fun <T> Iterable<T>.shouldNotContain(theThing: T) = if (!this.contains(the
 
 infix fun <T> Iterable<T>.shouldNotContainAny(things: Iterable<T>) = things.forEach { shouldNotContain(it) }
 
-infix fun <T> Iterable<T>?.shouldEqual(theOther: Iterable<T>?) = assertEquals(theOther, this)
+infix fun <T> Iterable<T>?.shouldEqual(theOther: Iterable<T>?) = assertThat(this).isEqualTo(theOther)
 
 fun <T> Iterable<T>.shouldBeEmpty() = assertEmpty(this, "Iterable")
 
@@ -244,5 +244,6 @@ infix fun <T> Any?.shouldNotBeIn(iterable: Iterable<T>) = if (!iterable.contains
 
 infix fun <T> Any?.shouldBeIn(array: Array<T>) = if (array.contains(this)) Unit else fail("$this should be in $array", "$this", join(array))
 
-internal fun <T> assertEmpty(iterable: Iterable<T>, collectionType: String) = assertTrue(iterable.count() == 0, "Expected the $collectionType to be empty, but has ${iterable.count()} elements")
-internal fun <T> assertNotEmpty(iterable: Iterable<T>, collectionType: String) = assertTrue(iterable.count() > 0, "Expected the $collectionType to contain elements, but is empty")
+internal fun <T> assertEmpty(iterable: Iterable<T>, collectionType: String) = assertThat(iterable.count() == 0).`as`("Expected the $collectionType to be empty, but has ${iterable.count()} elements").isTrue()
+
+internal fun <T> assertNotEmpty(iterable: Iterable<T>, collectionType: String) = assertThat(iterable.count() > 0).`as`("Expected the $collectionType to contain elements, but is empty").isTrue()

--- a/src/main/kotlin/org/amshove/kluent/Collections.kt
+++ b/src/main/kotlin/org/amshove/kluent/Collections.kt
@@ -4,9 +4,13 @@ import java.util.*
 
 infix fun <T> Array<T>.shouldContain(theThing: T) = if (this.contains(theThing)) Unit else fail("$this should contain $theThing", "$theThing", join(this))
 
-infix fun <T> Array<T>.shouldContainSome(things: Array<T>) = assert(this.any { things.contains(it) }, {"Expected $this to contain at least one of $things"})
+infix fun <T> Array<T>.shouldContainSome(things: Array<T>) = assert(this.any { things.contains(it) }) {
+    "Expected $this to contain at least one of $things"
+}
 
-infix fun <T> Array<T>.shouldContainNone(things: Array<T>) = assert(this.none { things.contains(it) }, {"Expected $this to contain none of $things"})
+infix fun <T> Array<T>.shouldContainNone(things: Array<T>) = assert(this.none { things.contains(it) }) {
+    "Expected $this to contain none of $things"
+}
 
 infix fun <T> Array<T>.shouldContainAll(things: Array<T>) = things.forEach { shouldContain(it) }
 
@@ -200,9 +204,13 @@ infix fun Short.shouldNotBeIn(theArray: ShortArray) = this shouldNotBeIn theArra
 
 infix fun <T> Iterable<T>.shouldContain(theThing: T) = if (this.contains(theThing)) Unit else fail("$this should contain $theThing", "$theThing", join(this))
 
-infix fun <T> Iterable<T>.shouldContainSome(things: Iterable<T>) = assert(this.any { things.contains(it) }, {"Expected $this to contain at least one of $things"})
+infix fun <T> Iterable<T>.shouldContainSome(things: Iterable<T>) = assert(this.any { things.contains(it) }) {
+    "Expected $this to contain at least one of $things"
+}
 
-infix fun <T> Iterable<T>.shouldContainNone(things: Iterable<T>) = assert(this.none { things.contains(it) }, {"Expected $this to contain none of $things"})
+infix fun <T> Iterable<T>.shouldContainNone(things: Iterable<T>) = assert(this.none { things.contains(it) }) {
+    "Expected $this to contain none of $things"
+}
 
 infix fun <T> Iterable<T>.shouldContainAll(things: Iterable<T>) = things.forEach { shouldContain(it) }
 
@@ -244,6 +252,10 @@ infix fun <T> Any?.shouldNotBeIn(iterable: Iterable<T>) = if (!iterable.contains
 
 infix fun <T> Any?.shouldBeIn(array: Array<T>) = if (array.contains(this)) Unit else fail("$this should be in $array", "$this", join(array))
 
-internal fun <T> assertEmpty(iterable: Iterable<T>, collectionType: String) = assert(iterable.count() == 0, {"Expected the $collectionType to be empty, but has ${iterable.count()} elements"})
+internal fun <T> assertEmpty(iterable: Iterable<T>, collectionType: String) = assert(iterable.count() == 0) {
+    "Expected the $collectionType to be empty, but has ${iterable.count()} elements"
+}
 
-internal fun <T> assertNotEmpty(iterable: Iterable<T>, collectionType: String) = assert(iterable.count() > 0, {"Expected the $collectionType to contain elements, but is empty"})
+internal fun <T> assertNotEmpty(iterable: Iterable<T>, collectionType: String) = assert(iterable.count() > 0) {
+    "Expected the $collectionType to contain elements, but is empty"
+}

--- a/src/main/kotlin/org/amshove/kluent/Collections.kt
+++ b/src/main/kotlin/org/amshove/kluent/Collections.kt
@@ -1,5 +1,7 @@
 package org.amshove.kluent
 
+import java.util.*
+
 infix fun <T> Array<T>.shouldContain(theThing: T) = if (this.contains(theThing)) Unit else fail("$this should contain $theThing", "$theThing", join(this))
 
 infix fun <T> Array<T>.shouldContainSome(things: Array<T>) = assert(this.any { things.contains(it) }) {
@@ -16,15 +18,7 @@ infix fun <T> Array<T>.shouldNotContain(theThing: T) = if (!this.contains(theThi
 
 infix fun <T> Array<T>.shouldNotContainAny(things: Array<T>) = things.forEach { shouldNotContain(it) }
 
-infix fun <T> Array<T>?.shouldEqual(theOther: Array<T>?) = assert(arraysEqual(this, theOther))
-
-private fun <T> arraysEqual(a1: Array<T>?, a2: Array<T>?): Boolean {
-    return when {
-        a1 == null && a2 == null -> true
-        a1 == null || a2 == null -> false
-        else -> a1 contentEquals a2
-    }
-}
+infix fun <T> Array<T>?.shouldEqual(theOther: Array<T>?) = assert(Arrays.equals(this, theOther))
 
 fun <T> Array<T>.shouldBeEmpty() = assertEmpty(this.toList(), "Array")
 

--- a/src/main/kotlin/org/amshove/kluent/Collections.kt
+++ b/src/main/kotlin/org/amshove/kluent/Collections.kt
@@ -1,7 +1,5 @@
 package org.amshove.kluent
 
-import java.util.*
-
 infix fun <T> Array<T>.shouldContain(theThing: T) = if (this.contains(theThing)) Unit else fail("$this should contain $theThing", "$theThing", join(this))
 
 infix fun <T> Array<T>.shouldContainSome(things: Array<T>) = assert(this.any { things.contains(it) }) {
@@ -18,13 +16,21 @@ infix fun <T> Array<T>.shouldNotContain(theThing: T) = if (!this.contains(theThi
 
 infix fun <T> Array<T>.shouldNotContainAny(things: Array<T>) = things.forEach { shouldNotContain(it) }
 
-infix fun <T> Array<T>?.shouldEqual(theOther: Array<T>?) = assert(Arrays.equals(this, theOther))
+infix fun <T> Array<T>?.shouldEqual(theOther: Array<T>?) = assert(arraysEqual(this, theOther))
+
+private fun <T> arraysEqual(a1: Array<T>?, a2: Array<T>?): Boolean {
+    return when {
+        a1 == null && a2 == null -> true
+        a1 == null || a2 == null -> false
+        else -> a1 contentEquals a2
+    }
+}
 
 fun <T> Array<T>.shouldBeEmpty() = assertEmpty(this.toList(), "Array")
 
 fun <T> Array<T>.shouldNotBeEmpty() = assertNotEmpty(this.toList(), "Array")
 
-infix fun IntArray.shouldEqual(theOther: IntArray) = assert(Arrays.equals(this, theOther))
+infix fun IntArray.shouldEqual(theOther: IntArray) = assert(this contentEquals theOther)
 
 fun IntArray.shouldBeEmpty() = this.toTypedArray().shouldBeEmpty()
 
@@ -46,7 +52,7 @@ infix fun Int.shouldBeIn(theArray: IntArray) = this shouldBeIn theArray.toTypedA
 
 infix fun Int.shouldNotBeIn(theArray: IntArray) = this shouldNotBeIn theArray.toTypedArray()
 
-infix fun BooleanArray.shouldEqual(theOther: BooleanArray) = assert(Arrays.equals(this, theOther))
+infix fun BooleanArray.shouldEqual(theOther: BooleanArray) = assert(this contentEquals theOther)
 
 fun BooleanArray.shouldBeEmpty() = this.toTypedArray().shouldBeEmpty()
 
@@ -68,7 +74,7 @@ infix fun Boolean.shouldBeIn(theArray: BooleanArray) = this shouldBeIn theArray.
 
 infix fun Boolean.shouldNotBeIn(theArray: BooleanArray) = this shouldNotBeIn theArray.toTypedArray()
 
-infix fun ByteArray.shouldEqual(theOther: ByteArray) = assert(Arrays.equals(this, theOther))
+infix fun ByteArray.shouldEqual(theOther: ByteArray) = assert(this contentEquals theOther)
 
 fun ByteArray.shouldBeEmpty() = this.toTypedArray().shouldBeEmpty()
 
@@ -90,7 +96,7 @@ infix fun Byte.shouldBeIn(theArray: ByteArray) = this shouldBeIn theArray.toType
 
 infix fun Byte.shouldNotBeIn(theArray: ByteArray) = this shouldNotBeIn theArray.toTypedArray()
 
-infix fun CharArray.shouldEqual(theOther: CharArray) = assert(Arrays.equals(this, theOther))
+infix fun CharArray.shouldEqual(theOther: CharArray) = assert(this contentEquals theOther)
 
 infix fun CharArray.shouldNotEqual(theOther: CharArray) = this.toTypedArray() shouldNotEqual theOther.toTypedArray()
 
@@ -114,7 +120,7 @@ infix fun Char.shouldBeIn(theArray: CharArray) = this shouldBeIn theArray.toType
 
 infix fun Char.shouldNotBeIn(theArray: CharArray) = this shouldNotBeIn theArray.toTypedArray()
 
-infix fun DoubleArray.shouldEqual(theOther: DoubleArray) = assert(Arrays.equals(this.toTypedArray(), theOther.toTypedArray()))
+infix fun DoubleArray.shouldEqual(theOther: DoubleArray) = assert(this.toTypedArray() contentEquals theOther.toTypedArray())
 
 fun DoubleArray.shouldBeEmpty() = this.toTypedArray().shouldBeEmpty()
 
@@ -136,7 +142,7 @@ infix fun Double.shouldBeIn(theArray: DoubleArray) = this shouldBeIn theArray.to
 
 infix fun Double.shouldNotBeIn(theArray: DoubleArray) = this shouldNotBeIn theArray.toTypedArray()
 
-infix fun FloatArray.shouldEqual(theOther: FloatArray) = assert(Arrays.equals(this.toTypedArray(), theOther.toTypedArray()))
+infix fun FloatArray.shouldEqual(theOther: FloatArray) = assert(this.toTypedArray() contentEquals theOther.toTypedArray())
 
 fun FloatArray.shouldBeEmpty() = this.toTypedArray().shouldBeEmpty()
 
@@ -158,7 +164,7 @@ infix fun Float.shouldBeIn(theArray: FloatArray) = this shouldBeIn theArray.toTy
 
 infix fun Float.shouldNotBeIn(theArray: FloatArray) = this shouldNotBeIn theArray.toTypedArray()
 
-infix fun LongArray.shouldEqual(theOther: LongArray) = assert(Arrays.equals(this, theOther))
+infix fun LongArray.shouldEqual(theOther: LongArray) = assert(this contentEquals theOther)
 
 fun LongArray.shouldBeEmpty() = this.toTypedArray().shouldBeEmpty()
 
@@ -180,7 +186,7 @@ infix fun Long.shouldBeIn(theArray: LongArray) = this shouldBeIn theArray.toType
 
 infix fun Long.shouldNotBeIn(theArray: LongArray) = this shouldNotBeIn theArray.toTypedArray()
 
-infix fun ShortArray.shouldEqual(theOther: ShortArray) = assert(Arrays.equals(this, theOther))
+infix fun ShortArray.shouldEqual(theOther: ShortArray) = assert(this contentEquals theOther)
 
 fun ShortArray.shouldBeEmpty() = this.toTypedArray().shouldBeEmpty()
 

--- a/src/main/kotlin/org/amshove/kluent/DateTime.kt
+++ b/src/main/kotlin/org/amshove/kluent/DateTime.kt
@@ -1,15 +1,15 @@
 package org.amshove.kluent
 
-import org.junit.Assert.assertTrue
+import org.junit.jupiter.api.Assertions.assertTrue
 import java.time.*
 
-infix fun LocalDateTime.shouldBeAfter(theOther: LocalDateTime) = assertTrue("Expected $this to be after $theOther", this > theOther)
+infix fun LocalDateTime.shouldBeAfter(theOther: LocalDateTime) = assertTrue(this > theOther, "Expected $this to be after $theOther")
 
-infix fun LocalDateTime.shouldBeAfter(theTime: LocalTime) = assertTrue("Expected $this to be after $theTime", this.toLocalTime() > theTime)
+infix fun LocalDateTime.shouldBeAfter(theTime: LocalTime) = assertTrue(this.toLocalTime() > theTime, "Expected $this to be after $theTime")
 
-infix fun LocalDateTime.shouldBeBefore(theOther: LocalDateTime) = assertTrue("Expected $this to be before $theOther", this < theOther)
+infix fun LocalDateTime.shouldBeBefore(theOther: LocalDateTime) = assertTrue(this < theOther, "Expected $this to be before $theOther")
 
-infix fun LocalDateTime.shouldBeBefore(theTime: LocalTime) = assertTrue("Expected $this to be before $theTime", this.toLocalTime() < theTime)
+infix fun LocalDateTime.shouldBeBefore(theTime: LocalTime) = assertTrue(this.toLocalTime() < theTime, "Expected $this to be before $theTime")
 
 infix fun LocalDateTime.shouldBeInHour(theHour: Int) = this.toLocalTime() shouldBeInHour theHour
 
@@ -23,41 +23,41 @@ infix fun LocalDateTime.shouldBeInSecond(theSecond: Int) = this.toLocalTime() sh
 
 infix fun LocalDateTime.shouldNotBeInSecond(theSecond: Int) = this.toLocalTime() shouldNotBeInSecond theSecond
 
-infix fun LocalDateTime.shouldBeOnOrAfter(theDate: LocalDateTime) = assertTrue("Expected $this to be on or after $theDate", this >= theDate)
+infix fun LocalDateTime.shouldBeOnOrAfter(theDate: LocalDateTime) = assertTrue(this >= theDate, "Expected $this to be on or after $theDate")
 
-infix fun LocalDateTime.shouldBeOnOrBefore(theDate: LocalDateTime) = assertTrue("Expected $this to be on or before $theDate", this <= theDate)
+infix fun LocalDateTime.shouldBeOnOrBefore(theDate: LocalDateTime) = assertTrue(this <= theDate, "Expected $this to be on or before $theDate")
 
-infix fun LocalDateTime.shouldBeOn(theDay: DayOfWeek) = assertTrue("Expected $this to be a $theDay, but was ${this.dayOfWeek}", this.dayOfWeek == theDay)
+infix fun LocalDateTime.shouldBeOn(theDay: DayOfWeek) = assertTrue(this.dayOfWeek == theDay, "Expected $this to be a $theDay, but was ${this.dayOfWeek}")
 
 infix fun LocalDateTime.shouldNotBeOn(theDay: DayOfWeek) = this.toLocalDate() shouldNotBeOn theDay
 
-infix fun LocalDateTime.shouldBeIn(theMonth: Month) = assertTrue("Expected $this to be in $theMonth, but was ${this.month}", this.month == theMonth)
+infix fun LocalDateTime.shouldBeIn(theMonth: Month) = assertTrue(this.month == theMonth, "Expected $this to be in $theMonth, but was ${this.month}")
 
 infix fun LocalDateTime.shouldNotBeIn(theMonth: Month) = this.toLocalDate() shouldNotBeIn theMonth
 
-infix fun LocalDateTime.shouldBeInYear(theYear: Int) = assertTrue("Expected $this to be in $theYear, but was ${this.year}", this.year == theYear)
+infix fun LocalDateTime.shouldBeInYear(theYear: Int) = assertTrue(this.year == theYear, "Expected $this to be in $theYear, but was ${this.year}")
 
 infix fun LocalDateTime.shouldNotBeInYear(theYear: Int) = this.toLocalDate() shouldNotBeInYear theYear
 
-infix fun LocalDate.shouldBeAfter(theOther: LocalDate) = assertTrue("Expected $this to be after $theOther", this > theOther)
+infix fun LocalDate.shouldBeAfter(theOther: LocalDate) = assertTrue(this > theOther, "Expected $this to be after $theOther")
 
-infix fun LocalDate.shouldBeBefore(theOther: LocalDate) = assertTrue("Expected $this to be before $theOther", this < theOther)
+infix fun LocalDate.shouldBeBefore(theOther: LocalDate) = assertTrue(this < theOther, "Expected $this to be before $theOther")
 
-infix fun LocalDate.shouldBeOnOrAfter(theDate: LocalDate) = assertTrue("Expected $this to be on or after $theDate", this >= theDate)
+infix fun LocalDate.shouldBeOnOrAfter(theDate: LocalDate) = assertTrue(this >= theDate, "Expected $this to be on or after $theDate")
 
-infix fun LocalDate.shouldBeOnOrBefore(theDate: LocalDate) = assertTrue("Expected $this to be on or before $theDate", this <= theDate)
+infix fun LocalDate.shouldBeOnOrBefore(theDate: LocalDate) = assertTrue(this <= theDate, "Expected $this to be on or before $theDate")
 
-infix fun LocalDate.shouldBeOn(theDay: DayOfWeek) = assertTrue("Expected $this to be a $theDay, but was ${this.dayOfWeek}", this.dayOfWeek == theDay)
+infix fun LocalDate.shouldBeOn(theDay: DayOfWeek) = assertTrue(this.dayOfWeek == theDay, "Expected $this to be a $theDay, but was ${this.dayOfWeek}")
 
-infix fun LocalDate.shouldNotBeOn(theDay: DayOfWeek) = assertTrue("Expected $this to not be a $theDay, but was ${this.dayOfWeek}", this.dayOfWeek != theDay)
+infix fun LocalDate.shouldNotBeOn(theDay: DayOfWeek) = assertTrue(this.dayOfWeek != theDay, "Expected $this to not be a $theDay, but was ${this.dayOfWeek}")
 
-infix fun LocalDate.shouldBeIn(theMonth: Month) = assertTrue("Expected $this to be in $theMonth, but was ${this.month}", this.month == theMonth)
+infix fun LocalDate.shouldBeIn(theMonth: Month) = assertTrue(this.month == theMonth, "Expected $this to be in $theMonth, but was ${this.month}")
 
-infix fun LocalDate.shouldNotBeIn(theMonth: Month) = assertTrue("Expected $this to not be in $theMonth, but was ${this.month}", this.month != theMonth)
+infix fun LocalDate.shouldNotBeIn(theMonth: Month) = assertTrue(this.month != theMonth, "Expected $this to not be in $theMonth, but was ${this.month}")
 
-infix fun LocalDate.shouldBeInYear(theYear: Int) = assertTrue("Expected $this to be in $theYear, but was ${this.year}", this.year == theYear)
+infix fun LocalDate.shouldBeInYear(theYear: Int) = assertTrue(this.year == theYear, "Expected $this to be in $theYear, but was ${this.year}")
 
-infix fun LocalDate.shouldNotBeInYear(theYear: Int) = assertTrue("Expected $this to not be in $theYear, but was ${this.year}", this.year != theYear)
+infix fun LocalDate.shouldNotBeInYear(theYear: Int) = assertTrue(this.year != theYear, "Expected $this to not be in $theYear, but was ${this.year}")
 
 fun Int.hours() = TimeComparator(addedHours = this)
 fun Int.minutes() = TimeComparator(addedMinutes = this)
@@ -72,17 +72,17 @@ infix fun LocalTime.shouldBeAtLeast(timeComparator: TimeComparator) = timeCompar
 
 infix fun LocalTime.shouldBeAtMost(timeComparator: TimeComparator) = timeComparator.withStartValue(this).withComparatorType(ComparatorType.AtMost)
 
-infix fun LocalTime.shouldBeInHour(theHour: Int) = assertTrue("Expected $this to be in hour $theHour", this.hour == theHour)
+infix fun LocalTime.shouldBeInHour(theHour: Int) = assertTrue(this.hour == theHour, "Expected $this to be in hour $theHour")
 
-infix fun LocalTime.shouldNotBeInHour(theHour: Int) = assertTrue("Expected $this to not be in hour $theHour", this.hour != theHour)
+infix fun LocalTime.shouldNotBeInHour(theHour: Int) = assertTrue(this.hour != theHour, "Expected $this to not be in hour $theHour")
 
-infix fun LocalTime.shouldBeInMinute(theMinute: Int) = assertTrue("Expected $this to be in minute $theMinute", this.minute == theMinute)
+infix fun LocalTime.shouldBeInMinute(theMinute: Int) = assertTrue(this.minute == theMinute, "Expected $this to be in minute $theMinute")
 
-infix fun LocalTime.shouldNotBeInMinute(theMinute: Int) = assertTrue("Expected $this to not be in minute $theMinute", this.minute != theMinute)
+infix fun LocalTime.shouldNotBeInMinute(theMinute: Int) = assertTrue(this.minute != theMinute, "Expected $this to not be in minute $theMinute")
 
-infix fun LocalTime.shouldBeInSecond(theSecond: Int) = assertTrue("Expected $this to be in second $theSecond", this.second == theSecond)
+infix fun LocalTime.shouldBeInSecond(theSecond: Int) = assertTrue(this.second == theSecond, "Expected $this to be in second $theSecond")
 
-infix fun LocalTime.shouldNotBeInSecond(theSecond: Int) = assertTrue("Expected $this to not be in second $theSecond", this.second != theSecond)
+infix fun LocalTime.shouldNotBeInSecond(theSecond: Int) = assertTrue(this.second != theSecond, "Expected $this to not be in second $theSecond")
 
 infix fun LocalDate.shouldBe(dateComparator: DateComparator) = dateComparator.withStartValue(this)
 

--- a/src/main/kotlin/org/amshove/kluent/DateTime.kt
+++ b/src/main/kotlin/org/amshove/kluent/DateTime.kt
@@ -1,15 +1,14 @@
 package org.amshove.kluent
 
-import org.assertj.core.api.Assertions.assertThat
 import java.time.*
 
-infix fun LocalDateTime.shouldBeAfter(theOther: LocalDateTime) = assertThat(this > theOther).`as`("Expected $this to be after $theOther").isTrue()
+infix fun LocalDateTime.shouldBeAfter(theOther: LocalDateTime) = assert(this > theOther, {"Expected $this to be after $theOther"})
 
-infix fun LocalDateTime.shouldBeAfter(theTime: LocalTime) = assertThat(this.toLocalTime() > theTime).`as`("Expected $this to be after $theTime").isTrue()
+infix fun LocalDateTime.shouldBeAfter(theTime: LocalTime) = assert(this.toLocalTime() > theTime, {"Expected $this to be after $theTime"})
 
-infix fun LocalDateTime.shouldBeBefore(theOther: LocalDateTime) = assertThat(this < theOther).`as`("Expected $this to be before $theOther").isTrue()
+infix fun LocalDateTime.shouldBeBefore(theOther: LocalDateTime) = assert(this < theOther, {"Expected $this to be before $theOther"})
 
-infix fun LocalDateTime.shouldBeBefore(theTime: LocalTime) = assertThat(this.toLocalTime() < theTime).`as`("Expected $this to be before $theTime").isTrue()
+infix fun LocalDateTime.shouldBeBefore(theTime: LocalTime) = assert(this.toLocalTime() < theTime, {"Expected $this to be before $theTime"})
 
 infix fun LocalDateTime.shouldBeInHour(theHour: Int) = this.toLocalTime() shouldBeInHour theHour
 
@@ -23,41 +22,41 @@ infix fun LocalDateTime.shouldBeInSecond(theSecond: Int) = this.toLocalTime() sh
 
 infix fun LocalDateTime.shouldNotBeInSecond(theSecond: Int) = this.toLocalTime() shouldNotBeInSecond theSecond
 
-infix fun LocalDateTime.shouldBeOnOrAfter(theDate: LocalDateTime) = assertThat(this >= theDate).`as`("Expected $this to be on or after $theDate").isTrue()
+infix fun LocalDateTime.shouldBeOnOrAfter(theDate: LocalDateTime) = assert(this >= theDate, {"Expected $this to be on or after $theDate"})
 
-infix fun LocalDateTime.shouldBeOnOrBefore(theDate: LocalDateTime) = assertThat(this <= theDate).`as`("Expected $this to be on or before $theDate").isTrue()
+infix fun LocalDateTime.shouldBeOnOrBefore(theDate: LocalDateTime) = assert(this <= theDate, {"Expected $this to be on or before $theDate"})
 
-infix fun LocalDateTime.shouldBeOn(theDay: DayOfWeek) = assertThat(this.dayOfWeek == theDay).`as`("Expected $this to be a $theDay, but was ${this.dayOfWeek}").isTrue()
+infix fun LocalDateTime.shouldBeOn(theDay: DayOfWeek) = assert(this.dayOfWeek == theDay, {"Expected $this to be a $theDay, but was ${this.dayOfWeek}"})
 
 infix fun LocalDateTime.shouldNotBeOn(theDay: DayOfWeek) = this.toLocalDate() shouldNotBeOn theDay
 
-infix fun LocalDateTime.shouldBeIn(theMonth: Month) = assertThat(this.month == theMonth).`as`("Expected $this to be in $theMonth, but was ${this.month}").isTrue()
+infix fun LocalDateTime.shouldBeIn(theMonth: Month) = assert(this.month == theMonth, {"Expected $this to be in $theMonth, but was ${this.month}"})
 
 infix fun LocalDateTime.shouldNotBeIn(theMonth: Month) = this.toLocalDate() shouldNotBeIn theMonth
 
-infix fun LocalDateTime.shouldBeInYear(theYear: Int) = assertThat(this.year == theYear).`as`("Expected $this to be in $theYear, but was ${this.year}").isTrue()
+infix fun LocalDateTime.shouldBeInYear(theYear: Int) = assert(this.year == theYear, {"Expected $this to be in $theYear, but was ${this.year}"})
 
 infix fun LocalDateTime.shouldNotBeInYear(theYear: Int) = this.toLocalDate() shouldNotBeInYear theYear
 
-infix fun LocalDate.shouldBeAfter(theOther: LocalDate) = assertThat(this > theOther).`as`("Expected $this to be after $theOther").isTrue()
+infix fun LocalDate.shouldBeAfter(theOther: LocalDate) = assert(this > theOther, {"Expected $this to be after $theOther"})
 
-infix fun LocalDate.shouldBeBefore(theOther: LocalDate) = assertThat(this < theOther).`as`("Expected $this to be before $theOther").isTrue()
+infix fun LocalDate.shouldBeBefore(theOther: LocalDate) = assert(this < theOther, {"Expected $this to be before $theOther"})
 
-infix fun LocalDate.shouldBeOnOrAfter(theDate: LocalDate) = assertThat(this >= theDate).`as`("Expected $this to be on or after $theDate").isTrue()
+infix fun LocalDate.shouldBeOnOrAfter(theDate: LocalDate) = assert(this >= theDate, {"Expected $this to be on or after $theDate"})
 
-infix fun LocalDate.shouldBeOnOrBefore(theDate: LocalDate) = assertThat(this <= theDate).`as`("Expected $this to be on or before $theDate").isTrue()
+infix fun LocalDate.shouldBeOnOrBefore(theDate: LocalDate) = assert(this <= theDate, {"Expected $this to be on or before $theDate"})
 
-infix fun LocalDate.shouldBeOn(theDay: DayOfWeek) = assertThat(this.dayOfWeek == theDay).`as`("Expected $this to be a $theDay, but was ${this.dayOfWeek}").isTrue()
+infix fun LocalDate.shouldBeOn(theDay: DayOfWeek) = assert(this.dayOfWeek == theDay, {"Expected $this to be a $theDay, but was ${this.dayOfWeek}"})
 
-infix fun LocalDate.shouldNotBeOn(theDay: DayOfWeek) = assertThat(this.dayOfWeek != theDay).`as`("Expected $this to not be a $theDay, but was ${this.dayOfWeek}").isTrue()
+infix fun LocalDate.shouldNotBeOn(theDay: DayOfWeek) = assert(this.dayOfWeek != theDay, {"Expected $this to not be a $theDay, but was ${this.dayOfWeek}"})
 
-infix fun LocalDate.shouldBeIn(theMonth: Month) = assertThat(this.month == theMonth).`as`("Expected $this to be in $theMonth, but was ${this.month}").isTrue()
+infix fun LocalDate.shouldBeIn(theMonth: Month) = assert(this.month == theMonth, {"Expected $this to be in $theMonth, but was ${this.month}"})
 
-infix fun LocalDate.shouldNotBeIn(theMonth: Month) = assertThat(this.month != theMonth).`as`("Expected $this to not be in $theMonth, but was ${this.month}").isTrue()
+infix fun LocalDate.shouldNotBeIn(theMonth: Month) = assert(this.month != theMonth, {"Expected $this to not be in $theMonth, but was ${this.month}"})
 
-infix fun LocalDate.shouldBeInYear(theYear: Int) = assertThat(this.year == theYear).`as`("Expected $this to be in $theYear, but was ${this.year}").isTrue()
+infix fun LocalDate.shouldBeInYear(theYear: Int) = assert(this.year == theYear, {"Expected $this to be in $theYear, but was ${this.year}"})
 
-infix fun LocalDate.shouldNotBeInYear(theYear: Int) = assertThat(this.year != theYear).`as`("Expected $this to not be in $theYear, but was ${this.year}").isTrue()
+infix fun LocalDate.shouldNotBeInYear(theYear: Int) = assert(this.year != theYear, {"Expected $this to not be in $theYear, but was ${this.year}"})
 
 fun Int.hours() = TimeComparator(addedHours = this)
 fun Int.minutes() = TimeComparator(addedMinutes = this)
@@ -72,17 +71,17 @@ infix fun LocalTime.shouldBeAtLeast(timeComparator: TimeComparator) = timeCompar
 
 infix fun LocalTime.shouldBeAtMost(timeComparator: TimeComparator) = timeComparator.withStartValue(this).withComparatorType(ComparatorType.AtMost)
 
-infix fun LocalTime.shouldBeInHour(theHour: Int) = assertThat(this.hour == theHour).`as`("Expected $this to be in hour $theHour").isTrue()
+infix fun LocalTime.shouldBeInHour(theHour: Int) = assert(this.hour == theHour, {"Expected $this to be in hour $theHour"})
 
-infix fun LocalTime.shouldNotBeInHour(theHour: Int) = assertThat(this.hour != theHour).`as`("Expected $this to not be in hour $theHour").isTrue()
+infix fun LocalTime.shouldNotBeInHour(theHour: Int) = assert(this.hour != theHour, {"Expected $this to not be in hour $theHour"})
 
-infix fun LocalTime.shouldBeInMinute(theMinute: Int) = assertThat(this.minute == theMinute).`as`("Expected $this to be in minute $theMinute").isTrue()
+infix fun LocalTime.shouldBeInMinute(theMinute: Int) = assert(this.minute == theMinute, {"Expected $this to be in minute $theMinute"})
 
-infix fun LocalTime.shouldNotBeInMinute(theMinute: Int) = assertThat(this.minute != theMinute).`as`("Expected $this to not be in minute $theMinute").isTrue()
+infix fun LocalTime.shouldNotBeInMinute(theMinute: Int) = assert(this.minute != theMinute, {"Expected $this to not be in minute $theMinute"})
 
-infix fun LocalTime.shouldBeInSecond(theSecond: Int) = assertThat(this.second == theSecond).`as`("Expected $this to be in second $theSecond").isTrue()
+infix fun LocalTime.shouldBeInSecond(theSecond: Int) = assert(this.second == theSecond, {"Expected $this to be in second $theSecond"})
 
-infix fun LocalTime.shouldNotBeInSecond(theSecond: Int) = assertThat(this.second != theSecond).`as`("Expected $this to not be in second $theSecond").isTrue()
+infix fun LocalTime.shouldNotBeInSecond(theSecond: Int) = assert(this.second != theSecond, {"Expected $this to not be in second $theSecond"})
 
 infix fun LocalDate.shouldBe(dateComparator: DateComparator) = dateComparator.withStartValue(this)
 

--- a/src/main/kotlin/org/amshove/kluent/DateTime.kt
+++ b/src/main/kotlin/org/amshove/kluent/DateTime.kt
@@ -2,13 +2,21 @@ package org.amshove.kluent
 
 import java.time.*
 
-infix fun LocalDateTime.shouldBeAfter(theOther: LocalDateTime) = assert(this > theOther, {"Expected $this to be after $theOther"})
+infix fun LocalDateTime.shouldBeAfter(theOther: LocalDateTime) = assert(this > theOther) {
+    "Expected $this to be after $theOther"
+}
 
-infix fun LocalDateTime.shouldBeAfter(theTime: LocalTime) = assert(this.toLocalTime() > theTime, {"Expected $this to be after $theTime"})
+infix fun LocalDateTime.shouldBeAfter(theTime: LocalTime) = assert(this.toLocalTime() > theTime) {
+    "Expected $this to be after $theTime"
+}
 
-infix fun LocalDateTime.shouldBeBefore(theOther: LocalDateTime) = assert(this < theOther, {"Expected $this to be before $theOther"})
+infix fun LocalDateTime.shouldBeBefore(theOther: LocalDateTime) = assert(this < theOther) {
+    "Expected $this to be before $theOther"
+}
 
-infix fun LocalDateTime.shouldBeBefore(theTime: LocalTime) = assert(this.toLocalTime() < theTime, {"Expected $this to be before $theTime"})
+infix fun LocalDateTime.shouldBeBefore(theTime: LocalTime) = assert(this.toLocalTime() < theTime) {
+    "Expected $this to be before $theTime"
+}
 
 infix fun LocalDateTime.shouldBeInHour(theHour: Int) = this.toLocalTime() shouldBeInHour theHour
 
@@ -22,41 +30,71 @@ infix fun LocalDateTime.shouldBeInSecond(theSecond: Int) = this.toLocalTime() sh
 
 infix fun LocalDateTime.shouldNotBeInSecond(theSecond: Int) = this.toLocalTime() shouldNotBeInSecond theSecond
 
-infix fun LocalDateTime.shouldBeOnOrAfter(theDate: LocalDateTime) = assert(this >= theDate, {"Expected $this to be on or after $theDate"})
+infix fun LocalDateTime.shouldBeOnOrAfter(theDate: LocalDateTime) = assert(this >= theDate) {
+    "Expected $this to be on or after $theDate"
+}
 
-infix fun LocalDateTime.shouldBeOnOrBefore(theDate: LocalDateTime) = assert(this <= theDate, {"Expected $this to be on or before $theDate"})
+infix fun LocalDateTime.shouldBeOnOrBefore(theDate: LocalDateTime) = assert(this <= theDate) {
+    "Expected $this to be on or before $theDate"
+}
 
-infix fun LocalDateTime.shouldBeOn(theDay: DayOfWeek) = assert(this.dayOfWeek == theDay, {"Expected $this to be a $theDay, but was ${this.dayOfWeek}"})
+infix fun LocalDateTime.shouldBeOn(theDay: DayOfWeek) = assert(this.dayOfWeek == theDay) {
+    "Expected $this to be a $theDay, but was ${this.dayOfWeek}"
+}
 
 infix fun LocalDateTime.shouldNotBeOn(theDay: DayOfWeek) = this.toLocalDate() shouldNotBeOn theDay
 
-infix fun LocalDateTime.shouldBeIn(theMonth: Month) = assert(this.month == theMonth, {"Expected $this to be in $theMonth, but was ${this.month}"})
+infix fun LocalDateTime.shouldBeIn(theMonth: Month) = assert(this.month == theMonth) {
+    "Expected $this to be in $theMonth, but was ${this.month}"
+}
 
 infix fun LocalDateTime.shouldNotBeIn(theMonth: Month) = this.toLocalDate() shouldNotBeIn theMonth
 
-infix fun LocalDateTime.shouldBeInYear(theYear: Int) = assert(this.year == theYear, {"Expected $this to be in $theYear, but was ${this.year}"})
+infix fun LocalDateTime.shouldBeInYear(theYear: Int) = assert(this.year == theYear) {
+    "Expected $this to be in $theYear, but was ${this.year}"
+}
 
 infix fun LocalDateTime.shouldNotBeInYear(theYear: Int) = this.toLocalDate() shouldNotBeInYear theYear
 
-infix fun LocalDate.shouldBeAfter(theOther: LocalDate) = assert(this > theOther, {"Expected $this to be after $theOther"})
+infix fun LocalDate.shouldBeAfter(theOther: LocalDate) = assert(this > theOther) {
+    "Expected $this to be after $theOther"
+}
 
-infix fun LocalDate.shouldBeBefore(theOther: LocalDate) = assert(this < theOther, {"Expected $this to be before $theOther"})
+infix fun LocalDate.shouldBeBefore(theOther: LocalDate) = assert(this < theOther) {
+    "Expected $this to be before $theOther"
+}
 
-infix fun LocalDate.shouldBeOnOrAfter(theDate: LocalDate) = assert(this >= theDate, {"Expected $this to be on or after $theDate"})
+infix fun LocalDate.shouldBeOnOrAfter(theDate: LocalDate) = assert(this >= theDate) {
+    "Expected $this to be on or after $theDate"
+}
 
-infix fun LocalDate.shouldBeOnOrBefore(theDate: LocalDate) = assert(this <= theDate, {"Expected $this to be on or before $theDate"})
+infix fun LocalDate.shouldBeOnOrBefore(theDate: LocalDate) = assert(this <= theDate) {
+    "Expected $this to be on or before $theDate"
+}
 
-infix fun LocalDate.shouldBeOn(theDay: DayOfWeek) = assert(this.dayOfWeek == theDay, {"Expected $this to be a $theDay, but was ${this.dayOfWeek}"})
+infix fun LocalDate.shouldBeOn(theDay: DayOfWeek) = assert(this.dayOfWeek == theDay) {
+    "Expected $this to be a $theDay, but was ${this.dayOfWeek}"
+}
 
-infix fun LocalDate.shouldNotBeOn(theDay: DayOfWeek) = assert(this.dayOfWeek != theDay, {"Expected $this to not be a $theDay, but was ${this.dayOfWeek}"})
+infix fun LocalDate.shouldNotBeOn(theDay: DayOfWeek) = assert(this.dayOfWeek != theDay) {
+    "Expected $this to not be a $theDay, but was ${this.dayOfWeek}"
+}
 
-infix fun LocalDate.shouldBeIn(theMonth: Month) = assert(this.month == theMonth, {"Expected $this to be in $theMonth, but was ${this.month}"})
+infix fun LocalDate.shouldBeIn(theMonth: Month) = assert(this.month == theMonth) {
+    "Expected $this to be in $theMonth, but was ${this.month}"
+}
 
-infix fun LocalDate.shouldNotBeIn(theMonth: Month) = assert(this.month != theMonth, {"Expected $this to not be in $theMonth, but was ${this.month}"})
+infix fun LocalDate.shouldNotBeIn(theMonth: Month) = assert(this.month != theMonth) {
+    "Expected $this to not be in $theMonth, but was ${this.month}"
+}
 
-infix fun LocalDate.shouldBeInYear(theYear: Int) = assert(this.year == theYear, {"Expected $this to be in $theYear, but was ${this.year}"})
+infix fun LocalDate.shouldBeInYear(theYear: Int) = assert(this.year == theYear) {
+    "Expected $this to be in $theYear, but was ${this.year}"
+}
 
-infix fun LocalDate.shouldNotBeInYear(theYear: Int) = assert(this.year != theYear, {"Expected $this to not be in $theYear, but was ${this.year}"})
+infix fun LocalDate.shouldNotBeInYear(theYear: Int) = assert(this.year != theYear) {
+    "Expected $this to not be in $theYear, but was ${this.year}"
+}
 
 fun Int.hours() = TimeComparator(addedHours = this)
 fun Int.minutes() = TimeComparator(addedMinutes = this)
@@ -71,17 +109,29 @@ infix fun LocalTime.shouldBeAtLeast(timeComparator: TimeComparator) = timeCompar
 
 infix fun LocalTime.shouldBeAtMost(timeComparator: TimeComparator) = timeComparator.withStartValue(this).withComparatorType(ComparatorType.AtMost)
 
-infix fun LocalTime.shouldBeInHour(theHour: Int) = assert(this.hour == theHour, {"Expected $this to be in hour $theHour"})
+infix fun LocalTime.shouldBeInHour(theHour: Int) = assert(this.hour == theHour) {
+    "Expected $this to be in hour $theHour"
+}
 
-infix fun LocalTime.shouldNotBeInHour(theHour: Int) = assert(this.hour != theHour, {"Expected $this to not be in hour $theHour"})
+infix fun LocalTime.shouldNotBeInHour(theHour: Int) = assert(this.hour != theHour) {
+    "Expected $this to not be in hour $theHour"
+}
 
-infix fun LocalTime.shouldBeInMinute(theMinute: Int) = assert(this.minute == theMinute, {"Expected $this to be in minute $theMinute"})
+infix fun LocalTime.shouldBeInMinute(theMinute: Int) = assert(this.minute == theMinute) {
+    "Expected $this to be in minute $theMinute"
+}
 
-infix fun LocalTime.shouldNotBeInMinute(theMinute: Int) = assert(this.minute != theMinute, {"Expected $this to not be in minute $theMinute"})
+infix fun LocalTime.shouldNotBeInMinute(theMinute: Int) = assert(this.minute != theMinute) {
+    "Expected $this to not be in minute $theMinute"
+}
 
-infix fun LocalTime.shouldBeInSecond(theSecond: Int) = assert(this.second == theSecond, {"Expected $this to be in second $theSecond"})
+infix fun LocalTime.shouldBeInSecond(theSecond: Int) = assert(this.second == theSecond) {
+    "Expected $this to be in second $theSecond"
+}
 
-infix fun LocalTime.shouldNotBeInSecond(theSecond: Int) = assert(this.second != theSecond, {"Expected $this to not be in second $theSecond"})
+infix fun LocalTime.shouldNotBeInSecond(theSecond: Int) = assert(this.second != theSecond) {
+    "Expected $this to not be in second $theSecond"
+}
 
 infix fun LocalDate.shouldBe(dateComparator: DateComparator) = dateComparator.withStartValue(this)
 

--- a/src/main/kotlin/org/amshove/kluent/DateTime.kt
+++ b/src/main/kotlin/org/amshove/kluent/DateTime.kt
@@ -1,15 +1,15 @@
 package org.amshove.kluent
 
-import org.junit.jupiter.api.Assertions.assertTrue
+import org.assertj.core.api.Assertions.assertThat
 import java.time.*
 
-infix fun LocalDateTime.shouldBeAfter(theOther: LocalDateTime) = assertTrue(this > theOther, "Expected $this to be after $theOther")
+infix fun LocalDateTime.shouldBeAfter(theOther: LocalDateTime) = assertThat(this > theOther).`as`("Expected $this to be after $theOther").isTrue()
 
-infix fun LocalDateTime.shouldBeAfter(theTime: LocalTime) = assertTrue(this.toLocalTime() > theTime, "Expected $this to be after $theTime")
+infix fun LocalDateTime.shouldBeAfter(theTime: LocalTime) = assertThat(this.toLocalTime() > theTime).`as`("Expected $this to be after $theTime").isTrue()
 
-infix fun LocalDateTime.shouldBeBefore(theOther: LocalDateTime) = assertTrue(this < theOther, "Expected $this to be before $theOther")
+infix fun LocalDateTime.shouldBeBefore(theOther: LocalDateTime) = assertThat(this < theOther).`as`("Expected $this to be before $theOther").isTrue()
 
-infix fun LocalDateTime.shouldBeBefore(theTime: LocalTime) = assertTrue(this.toLocalTime() < theTime, "Expected $this to be before $theTime")
+infix fun LocalDateTime.shouldBeBefore(theTime: LocalTime) = assertThat(this.toLocalTime() < theTime).`as`("Expected $this to be before $theTime").isTrue()
 
 infix fun LocalDateTime.shouldBeInHour(theHour: Int) = this.toLocalTime() shouldBeInHour theHour
 
@@ -23,41 +23,41 @@ infix fun LocalDateTime.shouldBeInSecond(theSecond: Int) = this.toLocalTime() sh
 
 infix fun LocalDateTime.shouldNotBeInSecond(theSecond: Int) = this.toLocalTime() shouldNotBeInSecond theSecond
 
-infix fun LocalDateTime.shouldBeOnOrAfter(theDate: LocalDateTime) = assertTrue(this >= theDate, "Expected $this to be on or after $theDate")
+infix fun LocalDateTime.shouldBeOnOrAfter(theDate: LocalDateTime) = assertThat(this >= theDate).`as`("Expected $this to be on or after $theDate").isTrue()
 
-infix fun LocalDateTime.shouldBeOnOrBefore(theDate: LocalDateTime) = assertTrue(this <= theDate, "Expected $this to be on or before $theDate")
+infix fun LocalDateTime.shouldBeOnOrBefore(theDate: LocalDateTime) = assertThat(this <= theDate).`as`("Expected $this to be on or before $theDate").isTrue()
 
-infix fun LocalDateTime.shouldBeOn(theDay: DayOfWeek) = assertTrue(this.dayOfWeek == theDay, "Expected $this to be a $theDay, but was ${this.dayOfWeek}")
+infix fun LocalDateTime.shouldBeOn(theDay: DayOfWeek) = assertThat(this.dayOfWeek == theDay).`as`("Expected $this to be a $theDay, but was ${this.dayOfWeek}").isTrue()
 
 infix fun LocalDateTime.shouldNotBeOn(theDay: DayOfWeek) = this.toLocalDate() shouldNotBeOn theDay
 
-infix fun LocalDateTime.shouldBeIn(theMonth: Month) = assertTrue(this.month == theMonth, "Expected $this to be in $theMonth, but was ${this.month}")
+infix fun LocalDateTime.shouldBeIn(theMonth: Month) = assertThat(this.month == theMonth).`as`("Expected $this to be in $theMonth, but was ${this.month}").isTrue()
 
 infix fun LocalDateTime.shouldNotBeIn(theMonth: Month) = this.toLocalDate() shouldNotBeIn theMonth
 
-infix fun LocalDateTime.shouldBeInYear(theYear: Int) = assertTrue(this.year == theYear, "Expected $this to be in $theYear, but was ${this.year}")
+infix fun LocalDateTime.shouldBeInYear(theYear: Int) = assertThat(this.year == theYear).`as`("Expected $this to be in $theYear, but was ${this.year}").isTrue()
 
 infix fun LocalDateTime.shouldNotBeInYear(theYear: Int) = this.toLocalDate() shouldNotBeInYear theYear
 
-infix fun LocalDate.shouldBeAfter(theOther: LocalDate) = assertTrue(this > theOther, "Expected $this to be after $theOther")
+infix fun LocalDate.shouldBeAfter(theOther: LocalDate) = assertThat(this > theOther).`as`("Expected $this to be after $theOther").isTrue()
 
-infix fun LocalDate.shouldBeBefore(theOther: LocalDate) = assertTrue(this < theOther, "Expected $this to be before $theOther")
+infix fun LocalDate.shouldBeBefore(theOther: LocalDate) = assertThat(this < theOther).`as`("Expected $this to be before $theOther").isTrue()
 
-infix fun LocalDate.shouldBeOnOrAfter(theDate: LocalDate) = assertTrue(this >= theDate, "Expected $this to be on or after $theDate")
+infix fun LocalDate.shouldBeOnOrAfter(theDate: LocalDate) = assertThat(this >= theDate).`as`("Expected $this to be on or after $theDate").isTrue()
 
-infix fun LocalDate.shouldBeOnOrBefore(theDate: LocalDate) = assertTrue(this <= theDate, "Expected $this to be on or before $theDate")
+infix fun LocalDate.shouldBeOnOrBefore(theDate: LocalDate) = assertThat(this <= theDate).`as`("Expected $this to be on or before $theDate").isTrue()
 
-infix fun LocalDate.shouldBeOn(theDay: DayOfWeek) = assertTrue(this.dayOfWeek == theDay, "Expected $this to be a $theDay, but was ${this.dayOfWeek}")
+infix fun LocalDate.shouldBeOn(theDay: DayOfWeek) = assertThat(this.dayOfWeek == theDay).`as`("Expected $this to be a $theDay, but was ${this.dayOfWeek}").isTrue()
 
-infix fun LocalDate.shouldNotBeOn(theDay: DayOfWeek) = assertTrue(this.dayOfWeek != theDay, "Expected $this to not be a $theDay, but was ${this.dayOfWeek}")
+infix fun LocalDate.shouldNotBeOn(theDay: DayOfWeek) = assertThat(this.dayOfWeek != theDay).`as`("Expected $this to not be a $theDay, but was ${this.dayOfWeek}").isTrue()
 
-infix fun LocalDate.shouldBeIn(theMonth: Month) = assertTrue(this.month == theMonth, "Expected $this to be in $theMonth, but was ${this.month}")
+infix fun LocalDate.shouldBeIn(theMonth: Month) = assertThat(this.month == theMonth).`as`("Expected $this to be in $theMonth, but was ${this.month}").isTrue()
 
-infix fun LocalDate.shouldNotBeIn(theMonth: Month) = assertTrue(this.month != theMonth, "Expected $this to not be in $theMonth, but was ${this.month}")
+infix fun LocalDate.shouldNotBeIn(theMonth: Month) = assertThat(this.month != theMonth).`as`("Expected $this to not be in $theMonth, but was ${this.month}").isTrue()
 
-infix fun LocalDate.shouldBeInYear(theYear: Int) = assertTrue(this.year == theYear, "Expected $this to be in $theYear, but was ${this.year}")
+infix fun LocalDate.shouldBeInYear(theYear: Int) = assertThat(this.year == theYear).`as`("Expected $this to be in $theYear, but was ${this.year}").isTrue()
 
-infix fun LocalDate.shouldNotBeInYear(theYear: Int) = assertTrue(this.year != theYear, "Expected $this to not be in $theYear, but was ${this.year}")
+infix fun LocalDate.shouldNotBeInYear(theYear: Int) = assertThat(this.year != theYear).`as`("Expected $this to not be in $theYear, but was ${this.year}").isTrue()
 
 fun Int.hours() = TimeComparator(addedHours = this)
 fun Int.minutes() = TimeComparator(addedMinutes = this)
@@ -72,17 +72,17 @@ infix fun LocalTime.shouldBeAtLeast(timeComparator: TimeComparator) = timeCompar
 
 infix fun LocalTime.shouldBeAtMost(timeComparator: TimeComparator) = timeComparator.withStartValue(this).withComparatorType(ComparatorType.AtMost)
 
-infix fun LocalTime.shouldBeInHour(theHour: Int) = assertTrue(this.hour == theHour, "Expected $this to be in hour $theHour")
+infix fun LocalTime.shouldBeInHour(theHour: Int) = assertThat(this.hour == theHour).`as`("Expected $this to be in hour $theHour").isTrue()
 
-infix fun LocalTime.shouldNotBeInHour(theHour: Int) = assertTrue(this.hour != theHour, "Expected $this to not be in hour $theHour")
+infix fun LocalTime.shouldNotBeInHour(theHour: Int) = assertThat(this.hour != theHour).`as`("Expected $this to not be in hour $theHour").isTrue()
 
-infix fun LocalTime.shouldBeInMinute(theMinute: Int) = assertTrue(this.minute == theMinute, "Expected $this to be in minute $theMinute")
+infix fun LocalTime.shouldBeInMinute(theMinute: Int) = assertThat(this.minute == theMinute).`as`("Expected $this to be in minute $theMinute").isTrue()
 
-infix fun LocalTime.shouldNotBeInMinute(theMinute: Int) = assertTrue(this.minute != theMinute, "Expected $this to not be in minute $theMinute")
+infix fun LocalTime.shouldNotBeInMinute(theMinute: Int) = assertThat(this.minute != theMinute).`as`("Expected $this to not be in minute $theMinute").isTrue()
 
-infix fun LocalTime.shouldBeInSecond(theSecond: Int) = assertTrue(this.second == theSecond, "Expected $this to be in second $theSecond")
+infix fun LocalTime.shouldBeInSecond(theSecond: Int) = assertThat(this.second == theSecond).`as`("Expected $this to be in second $theSecond").isTrue()
 
-infix fun LocalTime.shouldNotBeInSecond(theSecond: Int) = assertTrue(this.second != theSecond, "Expected $this to not be in second $theSecond")
+infix fun LocalTime.shouldNotBeInSecond(theSecond: Int) = assertThat(this.second != theSecond).`as`("Expected $this to not be in second $theSecond").isTrue()
 
 infix fun LocalDate.shouldBe(dateComparator: DateComparator) = dateComparator.withStartValue(this)
 

--- a/src/main/kotlin/org/amshove/kluent/Exceptions.kt
+++ b/src/main/kotlin/org/amshove/kluent/Exceptions.kt
@@ -10,7 +10,7 @@ infix fun <T : Throwable> (() -> Any?).shouldThrow(expectedException: KClass<T>)
     } catch (e: Throwable) {
         @Suppress("UNCHECKED_CAST")
         return when {
-            e.isA(AssertionFailedError::class) -> throw e
+            e.isA(AssertionError::class) -> throw e
             e.isA(expectedException) -> ExceptionResult(e as T)
             else -> throw AssertionFailedError("Expected ${expectedException.javaObjectType} to be thrown", "${expectedException.javaObjectType}", "${e.javaClass}")
         }

--- a/src/main/kotlin/org/amshove/kluent/Exceptions.kt
+++ b/src/main/kotlin/org/amshove/kluent/Exceptions.kt
@@ -12,7 +12,7 @@ infix fun <T : Throwable> (() -> Any?).shouldThrow(expectedException: KClass<T>)
         return when {
             e.isA(AssertionError::class) -> throw e
             e.isA(expectedException) -> ExceptionResult(e as T)
-            else -> throw AssertionFailedError("Expected ${expectedException.javaObjectType} to be thrown", "${expectedException.javaObjectType}", "${e.javaClass}")
+            else -> fail("Expected ${expectedException.javaObjectType} to be thrown", "${expectedException.javaObjectType}", "${e.javaClass}")
         }
     }
 }

--- a/src/main/kotlin/org/amshove/kluent/File.kt
+++ b/src/main/kotlin/org/amshove/kluent/File.kt
@@ -1,17 +1,17 @@
 package org.amshove.kluent
 
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import java.io.File
 
-fun File.shouldExist() = assertTrue("The file does not exist", this.exists())
-fun File.shouldNotExist() = assertFalse("The file exists", this.exists())
+fun File.shouldExist() = assertTrue(this.exists(), "The file does not exist")
+fun File.shouldNotExist() = assertFalse(this.exists(), "The file exists")
 
-fun File.shouldBeDir() = assertTrue("The file is not a directory", this.isDirectory)
-fun File.shouldNotBeDir() = assertFalse("The file is a directory", this.isDirectory)
+fun File.shouldBeDir() = assertTrue(this.isDirectory, "The file is not a directory")
+fun File.shouldNotBeDir() = assertFalse(this.isDirectory, "The file is a directory")
 
-fun File.shouldBeFile() = assertTrue("The file is not a file", this.isFile)
-fun File.shouldNotBeFile() = assertFalse("The file is a file", this.isFile)
+fun File.shouldBeFile() = assertTrue(this.isFile, "The file is not a file")
+fun File.shouldNotBeFile() = assertFalse(this.isFile, "The file is a file")
 
 infix fun File.shouldHaveExtension(other: String) = this.extension shouldEqualTo other
 infix fun File.shouldNotHaveExtension(other: String) = this.extension shouldNotEqualTo other

--- a/src/main/kotlin/org/amshove/kluent/File.kt
+++ b/src/main/kotlin/org/amshove/kluent/File.kt
@@ -1,17 +1,16 @@
 package org.amshove.kluent
 
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
+import org.assertj.core.api.Assertions.assertThat
 import java.io.File
 
-fun File.shouldExist() = assertTrue(this.exists(), "The file does not exist")
-fun File.shouldNotExist() = assertFalse(this.exists(), "The file exists")
+fun File.shouldExist() = assertThat(this.exists()).`as`("The file does not exist").isTrue()
+fun File.shouldNotExist() = assertThat(this.exists()).`as`("The file exists").isFalse()
 
-fun File.shouldBeDir() = assertTrue(this.isDirectory, "The file is not a directory")
-fun File.shouldNotBeDir() = assertFalse(this.isDirectory, "The file is a directory")
+fun File.shouldBeDir() = assertThat(this.isDirectory).`as`("The file is not a directory").isTrue()
+fun File.shouldNotBeDir() = assertThat(this.isDirectory).`as`("The file is a directory").isFalse()
 
-fun File.shouldBeFile() = assertTrue(this.isFile, "The file is not a file")
-fun File.shouldNotBeFile() = assertFalse(this.isFile, "The file is a file")
+fun File.shouldBeFile() = assertThat(this.isFile).`as`("The file is not a file").isTrue()
+fun File.shouldNotBeFile() = assertThat(this.isFile).`as`("The file is a file").isFalse()
 
 infix fun File.shouldHaveExtension(other: String) = this.extension shouldEqualTo other
 infix fun File.shouldNotHaveExtension(other: String) = this.extension shouldNotEqualTo other

--- a/src/main/kotlin/org/amshove/kluent/File.kt
+++ b/src/main/kotlin/org/amshove/kluent/File.kt
@@ -1,16 +1,15 @@
 package org.amshove.kluent
 
-import org.assertj.core.api.Assertions.assertThat
 import java.io.File
 
-fun File.shouldExist() = assertThat(this.exists()).`as`("The file does not exist").isTrue()
-fun File.shouldNotExist() = assertThat(this.exists()).`as`("The file exists").isFalse()
+fun File.shouldExist() = assert(this.exists(), {"The file does not exist"})
+fun File.shouldNotExist() = assert(!this.exists(), {"The file exists"})
 
-fun File.shouldBeDir() = assertThat(this.isDirectory).`as`("The file is not a directory").isTrue()
-fun File.shouldNotBeDir() = assertThat(this.isDirectory).`as`("The file is a directory").isFalse()
+fun File.shouldBeDir() = assert(this.isDirectory, {"The file is not a directory"})
+fun File.shouldNotBeDir() = assert(!this.isDirectory, {"The file is a directory"})
 
-fun File.shouldBeFile() = assertThat(this.isFile).`as`("The file is not a file").isTrue()
-fun File.shouldNotBeFile() = assertThat(this.isFile).`as`("The file is a file").isFalse()
+fun File.shouldBeFile() = assert(this.isFile, {"The file is not a file"})
+fun File.shouldNotBeFile() = assert(!this.isFile, {"The file is a file"})
 
 infix fun File.shouldHaveExtension(other: String) = this.extension shouldEqualTo other
 infix fun File.shouldNotHaveExtension(other: String) = this.extension shouldNotEqualTo other

--- a/src/main/kotlin/org/amshove/kluent/File.kt
+++ b/src/main/kotlin/org/amshove/kluent/File.kt
@@ -2,14 +2,29 @@ package org.amshove.kluent
 
 import java.io.File
 
-fun File.shouldExist() = assert(this.exists(), {"The file does not exist"})
-fun File.shouldNotExist() = assert(!this.exists(), {"The file exists"})
+fun File.shouldExist() = assert(this.exists()) {
+    "The file does not exist"
+}
 
-fun File.shouldBeDir() = assert(this.isDirectory, {"The file is not a directory"})
-fun File.shouldNotBeDir() = assert(!this.isDirectory, {"The file is a directory"})
+fun File.shouldNotExist() = assert(!this.exists()) {
+    "The file exists"
+}
 
-fun File.shouldBeFile() = assert(this.isFile, {"The file is not a file"})
-fun File.shouldNotBeFile() = assert(!this.isFile, {"The file is a file"})
+fun File.shouldBeDir() = assert(this.isDirectory) {
+    "The file is not a directory"
+}
+
+fun File.shouldNotBeDir() = assert(!this.isDirectory) {
+    "The file is a directory"
+}
+
+fun File.shouldBeFile() = assert(this.isFile) {
+    "The file is not a file"
+}
+
+fun File.shouldNotBeFile() = assert(!this.isFile) {
+    "The file is a file"
+}
 
 infix fun File.shouldHaveExtension(other: String) = this.extension shouldEqualTo other
 infix fun File.shouldNotHaveExtension(other: String) = this.extension shouldNotEqualTo other

--- a/src/main/kotlin/org/amshove/kluent/JavaTimeComparators.kt
+++ b/src/main/kotlin/org/amshove/kluent/JavaTimeComparators.kt
@@ -1,6 +1,6 @@
 package org.amshove.kluent
 
-import org.junit.Assert.assertTrue
+import org.junit.jupiter.api.Assertions
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -34,27 +34,27 @@ abstract class AbstractJavaTimeComparator<T> where T : Comparable<T> {
     }
 
     protected fun assertAtLeastAfter(theOther: T) {
-        assertTrue("Expected $startValue to be at least { ${getExpectedOffset()} } after $theOther", startValue >= theOther)
+        Assertions.assertTrue(startValue >= theOther, "Expected $startValue to be at least { ${getExpectedOffset()} } after $theOther")
     }
 
     protected fun assertAtMostAfter(theOther: T) {
-        assertTrue("Expected $startValue to be at most { ${getExpectedOffset()} } after $theOther", startValue <= theOther)
+        Assertions.assertTrue(startValue <= theOther, "Expected $startValue to be at most { ${getExpectedOffset()} } after $theOther")
     }
 
     protected fun assertExactlyAfter(theOther: T) {
-        assertTrue("Expected $startValue to be { ${getExpectedOffset()} } after $theOther", startValue == theOther)
+        Assertions.assertTrue(startValue == theOther, "Expected $startValue to be { ${getExpectedOffset()} } after $theOther")
     }
 
     protected fun assertExactlyBefore(theOther: T) {
-        assertTrue("Expected $startValue to be { ${getExpectedOffset()} } before $theOther", startValue == theOther)
+        Assertions.assertTrue(startValue == theOther, "Expected $startValue to be { ${getExpectedOffset()} } before $theOther")
     }
 
     protected fun assertAtLeastBefore(theOther: T) {
-        assertTrue("Expected $startValue to be at least { ${getExpectedOffset()} } before $theOther", startValue <= theOther)
+        Assertions.assertTrue(startValue <= theOther, "Expected $startValue to be at least { ${getExpectedOffset()} } before $theOther")
     }
 
     protected fun assertAtMostBefore(theOther: T) {
-        assertTrue("Expected $startValue to be at most { ${getExpectedOffset()} } before $theOther", startValue >= theOther)
+        Assertions.assertTrue(startValue >= theOther, "Expected $startValue to be at most { ${getExpectedOffset()} } before $theOther")
     }
 
     protected abstract fun calculateComparedValue(currentValue: T, multiplier: Int = 1): T

--- a/src/main/kotlin/org/amshove/kluent/JavaTimeComparators.kt
+++ b/src/main/kotlin/org/amshove/kluent/JavaTimeComparators.kt
@@ -1,6 +1,6 @@
 package org.amshove.kluent
 
-import org.junit.jupiter.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -34,27 +34,27 @@ abstract class AbstractJavaTimeComparator<T> where T : Comparable<T> {
     }
 
     protected fun assertAtLeastAfter(theOther: T) {
-        Assertions.assertTrue(startValue >= theOther, "Expected $startValue to be at least { ${getExpectedOffset()} } after $theOther")
+        assertThat(startValue >= theOther).`as`("Expected $startValue to be at least { ${getExpectedOffset()} } after $theOther").isTrue()
     }
 
     protected fun assertAtMostAfter(theOther: T) {
-        Assertions.assertTrue(startValue <= theOther, "Expected $startValue to be at most { ${getExpectedOffset()} } after $theOther")
+        assertThat(startValue <= theOther).`as`("Expected $startValue to be at most { ${getExpectedOffset()} } after $theOther").isTrue()
     }
 
     protected fun assertExactlyAfter(theOther: T) {
-        Assertions.assertTrue(startValue == theOther, "Expected $startValue to be { ${getExpectedOffset()} } after $theOther")
+        assertThat(startValue == theOther).`as`("Expected $startValue to be { ${getExpectedOffset()} } after $theOther").isTrue()
     }
 
     protected fun assertExactlyBefore(theOther: T) {
-        Assertions.assertTrue(startValue == theOther, "Expected $startValue to be { ${getExpectedOffset()} } before $theOther")
+        assertThat(startValue == theOther).`as`("Expected $startValue to be { ${getExpectedOffset()} } before $theOther").isTrue()
     }
 
     protected fun assertAtLeastBefore(theOther: T) {
-        Assertions.assertTrue(startValue <= theOther, "Expected $startValue to be at least { ${getExpectedOffset()} } before $theOther")
+        assertThat(startValue <= theOther).`as`("Expected $startValue to be at least { ${getExpectedOffset()} } before $theOther").isTrue()
     }
 
     protected fun assertAtMostBefore(theOther: T) {
-        Assertions.assertTrue(startValue >= theOther, "Expected $startValue to be at most { ${getExpectedOffset()} } before $theOther")
+        assertThat(startValue >= theOther).`as`("Expected $startValue to be at most { ${getExpectedOffset()} } before $theOther").isTrue()
     }
 
     protected abstract fun calculateComparedValue(currentValue: T, multiplier: Int = 1): T

--- a/src/main/kotlin/org/amshove/kluent/JavaTimeComparators.kt
+++ b/src/main/kotlin/org/amshove/kluent/JavaTimeComparators.kt
@@ -1,6 +1,5 @@
 package org.amshove.kluent
 
-import org.assertj.core.api.Assertions.assertThat
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -34,27 +33,27 @@ abstract class AbstractJavaTimeComparator<T> where T : Comparable<T> {
     }
 
     protected fun assertAtLeastAfter(theOther: T) {
-        assertThat(startValue >= theOther).`as`("Expected $startValue to be at least { ${getExpectedOffset()} } after $theOther").isTrue()
+        assert(startValue >= theOther, { "Expected $startValue to be at least { ${getExpectedOffset()} } after $theOther" })
     }
 
     protected fun assertAtMostAfter(theOther: T) {
-        assertThat(startValue <= theOther).`as`("Expected $startValue to be at most { ${getExpectedOffset()} } after $theOther").isTrue()
+        assert(startValue <= theOther, { "Expected $startValue to be at most { ${getExpectedOffset()} } after $theOther" })
     }
 
     protected fun assertExactlyAfter(theOther: T) {
-        assertThat(startValue == theOther).`as`("Expected $startValue to be { ${getExpectedOffset()} } after $theOther").isTrue()
+        assert(startValue == theOther, { "Expected $startValue to be { ${getExpectedOffset()} } after $theOther" })
     }
 
     protected fun assertExactlyBefore(theOther: T) {
-        assertThat(startValue == theOther).`as`("Expected $startValue to be { ${getExpectedOffset()} } before $theOther").isTrue()
+        assert(startValue == theOther, { "Expected $startValue to be { ${getExpectedOffset()} } before $theOther" })
     }
 
     protected fun assertAtLeastBefore(theOther: T) {
-        assertThat(startValue <= theOther).`as`("Expected $startValue to be at least { ${getExpectedOffset()} } before $theOther").isTrue()
+        assert(startValue <= theOther, { "Expected $startValue to be at least { ${getExpectedOffset()} } before $theOther" })
     }
 
     protected fun assertAtMostBefore(theOther: T) {
-        assertThat(startValue >= theOther).`as`("Expected $startValue to be at most { ${getExpectedOffset()} } before $theOther").isTrue()
+        assert(startValue >= theOther, { "Expected $startValue to be at most { ${getExpectedOffset()} } before $theOther" })
     }
 
     protected abstract fun calculateComparedValue(currentValue: T, multiplier: Int = 1): T

--- a/src/main/kotlin/org/amshove/kluent/JavaTimeComparators.kt
+++ b/src/main/kotlin/org/amshove/kluent/JavaTimeComparators.kt
@@ -33,27 +33,39 @@ abstract class AbstractJavaTimeComparator<T> where T : Comparable<T> {
     }
 
     protected fun assertAtLeastAfter(theOther: T) {
-        assert(startValue >= theOther, { "Expected $startValue to be at least { ${getExpectedOffset()} } after $theOther" })
+        assert(startValue >= theOther) {
+            "Expected $startValue to be at least { ${getExpectedOffset()} } after $theOther"
+        }
     }
 
     protected fun assertAtMostAfter(theOther: T) {
-        assert(startValue <= theOther, { "Expected $startValue to be at most { ${getExpectedOffset()} } after $theOther" })
+        assert(startValue <= theOther) {
+            "Expected $startValue to be at most { ${getExpectedOffset()} } after $theOther"
+        }
     }
 
     protected fun assertExactlyAfter(theOther: T) {
-        assert(startValue == theOther, { "Expected $startValue to be { ${getExpectedOffset()} } after $theOther" })
+        assert(startValue == theOther) {
+            "Expected $startValue to be { ${getExpectedOffset()} } after $theOther"
+        }
     }
 
     protected fun assertExactlyBefore(theOther: T) {
-        assert(startValue == theOther, { "Expected $startValue to be { ${getExpectedOffset()} } before $theOther" })
+        assert(startValue == theOther) {
+            "Expected $startValue to be { ${getExpectedOffset()} } before $theOther"
+        }
     }
 
     protected fun assertAtLeastBefore(theOther: T) {
-        assert(startValue <= theOther, { "Expected $startValue to be at least { ${getExpectedOffset()} } before $theOther" })
+        assert(startValue <= theOther) {
+            "Expected $startValue to be at least { ${getExpectedOffset()} } before $theOther"
+        }
     }
 
     protected fun assertAtMostBefore(theOther: T) {
-        assert(startValue >= theOther, { "Expected $startValue to be at most { ${getExpectedOffset()} } before $theOther" })
+        assert(startValue >= theOther) {
+            "Expected $startValue to be at most { ${getExpectedOffset()} } before $theOther"
+        }
     }
 
     protected abstract fun calculateComparedValue(currentValue: T, multiplier: Int = 1): T

--- a/src/main/kotlin/org/amshove/kluent/Numerical.kt
+++ b/src/main/kotlin/org/amshove/kluent/Numerical.kt
@@ -1,6 +1,6 @@
 package org.amshove.kluent
 
-import org.junit.Assert.*
+import org.junit.jupiter.api.Assertions.*
 
 infix fun Boolean.shouldEqualTo(theOther: Boolean) = assertEquals(theOther, this)
 
@@ -12,9 +12,9 @@ infix fun Int.shouldEqualTo(theOther: Int) = assertEquals(theOther, this)
 
 infix fun Long.shouldEqualTo(theOther: Long) = assertEquals(theOther, this)
 
-infix fun Float.shouldEqualTo(theOther: Float) = assertEquals(theOther, this, 0f)
+infix fun Float.shouldEqualTo(theOther: Float) = assertEquals(theOther, this)
 
-infix fun Double.shouldEqualTo(theOther: Double) = assertEquals(theOther, this, 0.0)
+infix fun Double.shouldEqualTo(theOther: Double) = assertEquals(theOther, this)
 
 infix fun Boolean.shouldNotEqualTo(theOther: Boolean) = assertNotEquals(theOther, this)
 
@@ -30,149 +30,149 @@ infix fun Float.shouldNotEqualTo(theOther: Float) = assertNotEquals(theOther, th
 
 infix fun Double.shouldNotEqualTo(theOther: Double) = assertNotEquals(theOther, this)
 
-infix fun Byte.shouldBeGreaterThan(theOther: Byte) = assertTrue("Expected $this to be greater than $theOther", this > theOther)
+infix fun Byte.shouldBeGreaterThan(theOther: Byte) = assertTrue(this > theOther, "Expected $this to be greater than $theOther")
 
-infix fun Short.shouldBeGreaterThan(theOther: Short) = assertTrue("Expected $this to be greater than $theOther", this > theOther)
+infix fun Short.shouldBeGreaterThan(theOther: Short) = assertTrue(this > theOther, "Expected $this to be greater than $theOther")
 
-infix fun Int.shouldBeGreaterThan(theOther: Int) = assertTrue("Expected $this to be greater than $theOther", this > theOther)
+infix fun Int.shouldBeGreaterThan(theOther: Int) = assertTrue(this > theOther, "Expected $this to be greater than $theOther")
 
-infix fun Long.shouldBeGreaterThan(theOther: Long) = assertTrue("Expected $this to be greater than $theOther", this > theOther)
+infix fun Long.shouldBeGreaterThan(theOther: Long) = assertTrue(this > theOther, "Expected $this to be greater than $theOther")
 
-infix fun Float.shouldBeGreaterThan(theOther: Float) = assertTrue("Expected $this to be greater than $theOther", this > theOther)
+infix fun Float.shouldBeGreaterThan(theOther: Float) = assertTrue(this > theOther, "Expected $this to be greater than $theOther")
 
-infix fun Double.shouldBeGreaterThan(theOther: Double) = assertTrue("Expected $this to be greater than $theOther", this > theOther)
+infix fun Double.shouldBeGreaterThan(theOther: Double) = assertTrue(this > theOther, "Expected $this to be greater than $theOther")
 
-infix fun Byte.shouldNotBeGreaterThan(theOther: Byte) = assertTrue("Expected $this to not be greater than $theOther", this <= theOther)
+infix fun Byte.shouldNotBeGreaterThan(theOther: Byte) = assertTrue(this <= theOther, "Expected $this to not be greater than $theOther")
 
-infix fun Short.shouldNotBeGreaterThan(theOther: Short) = assertTrue("Expected $this to not be greater than $theOther", this <= theOther)
+infix fun Short.shouldNotBeGreaterThan(theOther: Short) = assertTrue(this <= theOther, "Expected $this to not be greater than $theOther")
 
-infix fun Int.shouldNotBeGreaterThan(theOther: Int) = assertTrue("Expected $this to not be greater than $theOther", this <= theOther)
+infix fun Int.shouldNotBeGreaterThan(theOther: Int) = assertTrue(this <= theOther, "Expected $this to not be greater than $theOther")
 
-infix fun Long.shouldNotBeGreaterThan(theOther: Long) = assertTrue("Expected $this to not be greater than $theOther", this <= theOther)
+infix fun Long.shouldNotBeGreaterThan(theOther: Long) = assertTrue(this <= theOther, "Expected $this to not be greater than $theOther")
 
-infix fun Float.shouldNotBeGreaterThan(theOther: Float) = assertTrue("Expected $this to not be greater than $theOther", this <= theOther)
+infix fun Float.shouldNotBeGreaterThan(theOther: Float) = assertTrue(this <= theOther, "Expected $this to not be greater than $theOther")
 
-infix fun Double.shouldNotBeGreaterThan(theOther: Double) = assertTrue("Expected $this to not be greater than $theOther", this <= theOther)
+infix fun Double.shouldNotBeGreaterThan(theOther: Double) = assertTrue(this <= theOther, "Expected $this to not be greater than $theOther")
 
-infix fun Byte.shouldBeGreaterOrEqualTo(theOther: Byte) = assertTrue("Expected $this to be greater or equal to $theOther", this >= theOther)
+infix fun Byte.shouldBeGreaterOrEqualTo(theOther: Byte) = assertTrue(this >= theOther, "Expected $this to be greater or equal to $theOther")
 
-infix fun Short.shouldBeGreaterOrEqualTo(theOther: Short) = assertTrue("Expected $this to be greater or equal to $theOther", this >= theOther)
+infix fun Short.shouldBeGreaterOrEqualTo(theOther: Short) = assertTrue(this >= theOther, "Expected $this to be greater or equal to $theOther")
 
-infix fun Int.shouldBeGreaterOrEqualTo(theOther: Int) = assertTrue("Expected $this to be greater or equal to $theOther", this >= theOther)
+infix fun Int.shouldBeGreaterOrEqualTo(theOther: Int) = assertTrue(this >= theOther, "Expected $this to be greater or equal to $theOther")
 
-infix fun Long.shouldBeGreaterOrEqualTo(theOther: Long) = assertTrue("Expected $this to be greater or equal to $theOther", this >= theOther)
+infix fun Long.shouldBeGreaterOrEqualTo(theOther: Long) = assertTrue(this >= theOther, "Expected $this to be greater or equal to $theOther")
 
-infix fun Float.shouldBeGreaterOrEqualTo(theOther: Float) = assertTrue("Expected $this to be greater or equal to $theOther", this >= theOther)
+infix fun Float.shouldBeGreaterOrEqualTo(theOther: Float) = assertTrue(this >= theOther, "Expected $this to be greater or equal to $theOther")
 
-infix fun Double.shouldBeGreaterOrEqualTo(theOther: Double) = assertTrue("Expected $this to be greater or equal to $theOther", this >= theOther)
+infix fun Double.shouldBeGreaterOrEqualTo(theOther: Double) = assertTrue(this >= theOther, "Expected $this to be greater or equal to $theOther")
 
-infix fun Byte.shouldNotBeGreaterOrEqualTo(theOther: Byte) = assertTrue("Expected $this to be not be greater or equal to $theOther", this < theOther)
+infix fun Byte.shouldNotBeGreaterOrEqualTo(theOther: Byte) = assertTrue(this < theOther, "Expected $this to be not be greater or equal to $theOther")
 
-infix fun Short.shouldNotBeGreaterOrEqualTo(theOther: Short) = assertTrue("Expected $this to not be greater or equal to $theOther", this < theOther)
+infix fun Short.shouldNotBeGreaterOrEqualTo(theOther: Short) = assertTrue(this < theOther, "Expected $this to not be greater or equal to $theOther")
 
-infix fun Int.shouldNotBeGreaterOrEqualTo(theOther: Int) = assertTrue("Expected $this to not be greater or equal to $theOther", this < theOther)
+infix fun Int.shouldNotBeGreaterOrEqualTo(theOther: Int) = assertTrue(this < theOther, "Expected $this to not be greater or equal to $theOther")
 
-infix fun Long.shouldNotBeGreaterOrEqualTo(theOther: Long) = assertTrue("Expected $this to not be greater or equal to $theOther", this < theOther)
+infix fun Long.shouldNotBeGreaterOrEqualTo(theOther: Long) = assertTrue(this < theOther, "Expected $this to not be greater or equal to $theOther")
 
-infix fun Float.shouldNotBeGreaterOrEqualTo(theOther: Float) = assertTrue("Expected $this to not be greater or equal to $theOther", this < theOther)
+infix fun Float.shouldNotBeGreaterOrEqualTo(theOther: Float) = assertTrue(this < theOther, "Expected $this to not be greater or equal to $theOther")
 
-infix fun Double.shouldNotBeGreaterOrEqualTo(theOther: Double) = assertTrue("Expected $this to not be greater or equal to $theOther", this < theOther)
+infix fun Double.shouldNotBeGreaterOrEqualTo(theOther: Double) = assertTrue(this < theOther, "Expected $this to not be greater or equal to $theOther")
 
-infix fun Byte.shouldBeLessThan(theOther: Byte) = assertTrue("Expected $this to be less than $theOther", this < theOther)
+infix fun Byte.shouldBeLessThan(theOther: Byte) = assertTrue(this < theOther, "Expected $this to be less than $theOther")
 
-infix fun Short.shouldBeLessThan(theOther: Short) = assertTrue("Expected $this to be less than $theOther", this < theOther)
+infix fun Short.shouldBeLessThan(theOther: Short) = assertTrue(this < theOther, "Expected $this to be less than $theOther")
 
-infix fun Int.shouldBeLessThan(theOther: Int) = assertTrue("Expected $this to be less than $theOther", this < theOther)
+infix fun Int.shouldBeLessThan(theOther: Int) = assertTrue(this < theOther, "Expected $this to be less than $theOther")
 
-infix fun Long.shouldBeLessThan(theOther: Long) = assertTrue("Expected $this to be less than $theOther", this < theOther)
+infix fun Long.shouldBeLessThan(theOther: Long) = assertTrue(this < theOther, "Expected $this to be less than $theOther")
 
-infix fun Float.shouldBeLessThan(theOther: Float) = assertTrue("Expected $this to be less than $theOther", this < theOther)
+infix fun Float.shouldBeLessThan(theOther: Float) = assertTrue(this < theOther, "Expected $this to be less than $theOther")
 
-infix fun Double.shouldBeLessThan(theOther: Double) = assertTrue("Expected $this to be less than $theOther", this < theOther)
+infix fun Double.shouldBeLessThan(theOther: Double) = assertTrue(this < theOther, "Expected $this to be less than $theOther")
 
-infix fun Byte.shouldNotBeLessThan(theOther: Byte) = assertTrue("Expected $this to not be less than $theOther", this >= theOther)
+infix fun Byte.shouldNotBeLessThan(theOther: Byte) = assertTrue(this >= theOther, "Expected $this to not be less than $theOther")
 
-infix fun Short.shouldNotBeLessThan(theOther: Short) = assertTrue("Expected $this to not be less than $theOther", this >= theOther)
+infix fun Short.shouldNotBeLessThan(theOther: Short) = assertTrue(this >= theOther, "Expected $this to not be less than $theOther")
 
-infix fun Int.shouldNotBeLessThan(theOther: Int) = assertTrue("Expected $this to not be less than $theOther", this >= theOther)
+infix fun Int.shouldNotBeLessThan(theOther: Int) = assertTrue(this >= theOther, "Expected $this to not be less than $theOther")
 
-infix fun Long.shouldNotBeLessThan(theOther: Long) = assertTrue("Expected $this to not be less than $theOther", this >= theOther)
+infix fun Long.shouldNotBeLessThan(theOther: Long) = assertTrue(this >= theOther, "Expected $this to not be less than $theOther")
 
-infix fun Float.shouldNotBeLessThan(theOther: Float) = assertTrue("Expected $this to not be less than $theOther", this >= theOther)
+infix fun Float.shouldNotBeLessThan(theOther: Float) = assertTrue(this >= theOther, "Expected $this to not be less than $theOther")
 
-infix fun Double.shouldNotBeLessThan(theOther: Double) = assertTrue("Expected $this to not be less than $theOther", this >= theOther)
+infix fun Double.shouldNotBeLessThan(theOther: Double) = assertTrue(this >= theOther, "Expected $this to not be less than $theOther")
 
-infix fun Byte.shouldBeLessOrEqualTo(theOther: Byte) = assertTrue("Expected $this to be less or equal to $theOther", this <= theOther)
+infix fun Byte.shouldBeLessOrEqualTo(theOther: Byte) = assertTrue(this <= theOther, "Expected $this to be less or equal to $theOther")
 
-infix fun Short.shouldBeLessOrEqualTo(theOther: Short) = assertTrue("Expected $this to be less or equal to $theOther", this <= theOther)
+infix fun Short.shouldBeLessOrEqualTo(theOther: Short) = assertTrue(this <= theOther, "Expected $this to be less or equal to $theOther")
 
-infix fun Int.shouldBeLessOrEqualTo(theOther: Int) = assertTrue("Expected $this to be less or equal to $theOther", this <= theOther)
+infix fun Int.shouldBeLessOrEqualTo(theOther: Int) = assertTrue(this <= theOther, "Expected $this to be less or equal to $theOther")
 
-infix fun Long.shouldBeLessOrEqualTo(theOther: Long) = assertTrue("Expected $this to be less or equal to $theOther", this <= theOther)
+infix fun Long.shouldBeLessOrEqualTo(theOther: Long) = assertTrue(this <= theOther, "Expected $this to be less or equal to $theOther")
 
-infix fun Float.shouldBeLessOrEqualTo(theOther: Float) = assertTrue("Expected $this to be less or equal to $theOther", this <= theOther)
+infix fun Float.shouldBeLessOrEqualTo(theOther: Float) = assertTrue(this <= theOther, "Expected $this to be less or equal to $theOther")
 
-infix fun Double.shouldBeLessOrEqualTo(theOther: Double) = assertTrue("Expected $this to be less or equal to $theOther", this <= theOther)
+infix fun Double.shouldBeLessOrEqualTo(theOther: Double) = assertTrue(this <= theOther, "Expected $this to be less or equal to $theOther")
 
-infix fun Byte.shouldNotBeLessOrEqualTo(theOther: Byte) = assertTrue("Expected $this to not be less or equal to $theOther", this > theOther)
+infix fun Byte.shouldNotBeLessOrEqualTo(theOther: Byte) = assertTrue(this > theOther, "Expected $this to not be less or equal to $theOther")
 
-infix fun Short.shouldNotBeLessOrEqualTo(theOther: Short) = assertTrue("Expected $this to not be less or equal to $theOther", this > theOther)
+infix fun Short.shouldNotBeLessOrEqualTo(theOther: Short) = assertTrue(this > theOther, "Expected $this to not be less or equal to $theOther")
 
-infix fun Int.shouldNotBeLessOrEqualTo(theOther: Int) = assertTrue("Expected $this to not be less or equal to $theOther", this > theOther)
+infix fun Int.shouldNotBeLessOrEqualTo(theOther: Int) = assertTrue(this > theOther, "Expected $this to not be less or equal to $theOther")
 
-infix fun Long.shouldNotBeLessOrEqualTo(theOther: Long) = assertTrue("Expected $this to not be less or equal to $theOther", this > theOther)
+infix fun Long.shouldNotBeLessOrEqualTo(theOther: Long) = assertTrue(this > theOther, "Expected $this to not be less or equal to $theOther")
 
-infix fun Float.shouldNotBeLessOrEqualTo(theOther: Float) = assertTrue("Expected $this to not be less or equal to $theOther", this > theOther)
+infix fun Float.shouldNotBeLessOrEqualTo(theOther: Float) = assertTrue(this > theOther, "Expected $this to not be less or equal to $theOther")
 
-infix fun Double.shouldNotBeLessOrEqualTo(theOther: Double) = assertTrue("Expected $this to not be less or equal to $theOther", this > theOther)
+infix fun Double.shouldNotBeLessOrEqualTo(theOther: Double) = assertTrue(this > theOther, "Expected $this to not be less or equal to $theOther")
 
-fun Byte.shouldBePositive() = assertTrue("Expected $this to be positive", this > 0)
+fun Byte.shouldBePositive() = assertTrue(this > 0, "Expected $this to be positive")
 
-fun Short.shouldBePositive() = assertTrue("Expected $this to be positive", this > 0)
+fun Short.shouldBePositive() = assertTrue(this > 0, "Expected $this to be positive")
 
-fun Int.shouldBePositive() = assertTrue("Expected $this to be positive", this > 0)
+fun Int.shouldBePositive() = assertTrue(this > 0, "Expected $this to be positive")
 
-fun Long.shouldBePositive() = assertTrue("Expected $this to be positive", this > 0)
+fun Long.shouldBePositive() = assertTrue(this > 0, "Expected $this to be positive")
 
-fun Float.shouldBePositive() = assertTrue("Expected $this to be positive", this > 0)
+fun Float.shouldBePositive() = assertTrue(this > 0, "Expected $this to be positive")
 
-fun Double.shouldBePositive() = assertTrue("Expected $this to be positive", this > 0)
+fun Double.shouldBePositive() = assertTrue(this > 0, "Expected $this to be positive")
 
-fun Byte.shouldBeNegative() = assertTrue("Expected $this to be negative", this < 0)
+fun Byte.shouldBeNegative() = assertTrue(this < 0, "Expected $this to be negative")
 
-fun Short.shouldBeNegative() = assertTrue("Expected $this to be negative", this < 0)
+fun Short.shouldBeNegative() = assertTrue(this < 0, "Expected $this to be negative")
 
-fun Int.shouldBeNegative() = assertTrue("Expected $this to be negative", this < 0)
+fun Int.shouldBeNegative() = assertTrue(this < 0, "Expected $this to be negative")
 
-fun Long.shouldBeNegative() = assertTrue("Expected $this to be negative", this < 0)
+fun Long.shouldBeNegative() = assertTrue(this < 0, "Expected $this to be negative")
 
-fun Float.shouldBeNegative() = assertTrue("Expected $this to be negative", this < 0)
+fun Float.shouldBeNegative() = assertTrue(this < 0, "Expected $this to be negative")
 
-fun Double.shouldBeNegative() = assertTrue("Expected $this to be negative", this < 0)
+fun Double.shouldBeNegative() = assertTrue(this < 0, "Expected $this to be negative")
 
-fun Byte.shouldBeInRange(lowerBound: Byte, upperBound: Byte) = assertTrue("Expected $this to be between (and including) $lowerBound and $upperBound", this >= lowerBound && this <= upperBound)
+fun Byte.shouldBeInRange(lowerBound: Byte, upperBound: Byte) = assertTrue(this >= lowerBound && this <= upperBound, "Expected $this to be between (and including) $lowerBound and $upperBound")
 
-fun Short.shouldBeInRange(lowerBound: Short, upperBound: Short) = assertTrue("Expected $this to be between (and including) $lowerBound and $upperBound", this >= lowerBound && this <= upperBound)
+fun Short.shouldBeInRange(lowerBound: Short, upperBound: Short) = assertTrue(this >= lowerBound && this <= upperBound, "Expected $this to be between (and including) $lowerBound and $upperBound")
 
-fun Int.shouldBeInRange(lowerBound: Int, upperBound: Int) = assertTrue("Expected $this to be between (and including) $lowerBound and $upperBound", this >= lowerBound && this <= upperBound)
+fun Int.shouldBeInRange(lowerBound: Int, upperBound: Int) = assertTrue(this >= lowerBound && this <= upperBound, "Expected $this to be between (and including) $lowerBound and $upperBound")
 
-fun Long.shouldBeInRange(lowerBound: Long, upperBound: Long) = assertTrue("Expected $this to be between (and including) $lowerBound and $upperBound", this >= lowerBound && this <= upperBound)
+fun Long.shouldBeInRange(lowerBound: Long, upperBound: Long) = assertTrue(this >= lowerBound && this <= upperBound, "Expected $this to be between (and including) $lowerBound and $upperBound")
 
-fun Float.shouldBeInRange(lowerBound: Float, upperBound: Float) = assertTrue("Expected $this to be between (and including) $lowerBound and $upperBound", this >= lowerBound && this <= upperBound)
+fun Float.shouldBeInRange(lowerBound: Float, upperBound: Float) = assertTrue(this >= lowerBound && this <= upperBound, "Expected $this to be between (and including) $lowerBound and $upperBound")
 
-fun Double.shouldBeInRange(lowerBound: Double, upperBound: Double) = assertTrue("Expected $this to be between (and including) $lowerBound and $upperBound", this >= lowerBound && this <= upperBound)
+fun Double.shouldBeInRange(lowerBound: Double, upperBound: Double) = assertTrue(this >= lowerBound && this <= upperBound, "Expected $this to be between (and including) $lowerBound and $upperBound")
 
-fun Byte.shouldNotBeInRange(lowerBound: Byte, upperBound: Byte) = assertTrue("Expected $this to not be between (and including) $lowerBound and $upperBound", this < lowerBound || this > upperBound)
+fun Byte.shouldNotBeInRange(lowerBound: Byte, upperBound: Byte) = assertTrue(this < lowerBound || this > upperBound, "Expected $this to not be between (and including) $lowerBound and $upperBound")
 
-fun Short.shouldNotBeInRange(lowerBound: Short, upperBound: Short) = assertTrue("Expected $this to not be between (and including) $lowerBound and $upperBound", this < lowerBound || this > upperBound)
+fun Short.shouldNotBeInRange(lowerBound: Short, upperBound: Short) = assertTrue(this < lowerBound || this > upperBound, "Expected $this to not be between (and including) $lowerBound and $upperBound")
 
-fun Int.shouldNotBeInRange(lowerBound: Int, upperBound: Int) = assertTrue("Expected $this to not be between (and including) $lowerBound and $upperBound", this < lowerBound || this > upperBound)
+fun Int.shouldNotBeInRange(lowerBound: Int, upperBound: Int) = assertTrue(this < lowerBound || this > upperBound, "Expected $this to not be between (and including) $lowerBound and $upperBound")
 
-fun Long.shouldNotBeInRange(lowerBound: Long, upperBound: Long) = assertTrue("Expected $this to not be between (and including) $lowerBound and $upperBound", this < lowerBound || this > upperBound)
+fun Long.shouldNotBeInRange(lowerBound: Long, upperBound: Long) = assertTrue(this < lowerBound || this > upperBound, "Expected $this to not be between (and including) $lowerBound and $upperBound")
 
-fun Float.shouldNotBeInRange(lowerBound: Float, upperBound: Float) = assertTrue("Expected $this to not be between (and including) $lowerBound and $upperBound", this < lowerBound || this > upperBound)
+fun Float.shouldNotBeInRange(lowerBound: Float, upperBound: Float) = assertTrue(this < lowerBound || this > upperBound, "Expected $this to not be between (and including) $lowerBound and $upperBound")
 
-fun Double.shouldNotBeInRange(lowerBound: Double, upperBound: Double) = assertTrue("Expected $this to not be between (and including) $lowerBound and $upperBound", this < lowerBound || this > upperBound)
+fun Double.shouldNotBeInRange(lowerBound: Double, upperBound: Double) = assertTrue(this < lowerBound || this > upperBound, "Expected $this to not be between (and including) $lowerBound and $upperBound")
 
 infix fun Byte.shouldBeInRange(range: IntRange) = (this.toInt()).shouldBeInRange(range)
 

--- a/src/main/kotlin/org/amshove/kluent/Numerical.kt
+++ b/src/main/kotlin/org/amshove/kluent/Numerical.kt
@@ -1,178 +1,176 @@
 package org.amshove.kluent
 
-import org.assertj.core.api.Assertions.assertThat
+infix fun Boolean.shouldEqualTo(theOther: Boolean) = assert(this == theOther)
 
-infix fun Boolean.shouldEqualTo(theOther: Boolean) = assertThat(this).isEqualTo(theOther)
+infix fun Byte.shouldEqualTo(theOther: Byte) = assert(this == theOther)
 
-infix fun Byte.shouldEqualTo(theOther: Byte) = assertThat(this).isEqualTo(theOther)
+infix fun Short.shouldEqualTo(theOther: Short) = assert(this == theOther)
 
-infix fun Short.shouldEqualTo(theOther: Short) = assertThat(this).isEqualTo(theOther)
+infix fun Int.shouldEqualTo(theOther: Int) = assert(this == theOther)
 
-infix fun Int.shouldEqualTo(theOther: Int) = assertThat(this).isEqualTo(theOther)
+infix fun Long.shouldEqualTo(theOther: Long) = assert(this == theOther)
 
-infix fun Long.shouldEqualTo(theOther: Long) = assertThat(this).isEqualTo(theOther)
+infix fun Float.shouldEqualTo(theOther: Float) = assert(this == theOther)
 
-infix fun Float.shouldEqualTo(theOther: Float) = assertThat(this).isEqualTo(theOther)
+infix fun Double.shouldEqualTo(theOther: Double) = assert(this == theOther)
 
-infix fun Double.shouldEqualTo(theOther: Double) = assertThat(this).isEqualTo(theOther)
+infix fun Boolean.shouldNotEqualTo(theOther: Boolean) = assert(this != theOther)
 
-infix fun Boolean.shouldNotEqualTo(theOther: Boolean) = assertThat(this).isNotEqualTo(theOther)
+infix fun Byte.shouldNotEqualTo(theOther: Byte) = assert(this != theOther)
 
-infix fun Byte.shouldNotEqualTo(theOther: Byte) = assertThat(this).isNotEqualTo(theOther)
+infix fun Short.shouldNotEqualTo(theOther: Short) = assert(this != theOther)
 
-infix fun Short.shouldNotEqualTo(theOther: Short) = assertThat(this).isNotEqualTo(theOther)
+infix fun Int.shouldNotEqualTo(theOther: Int) = assert(this != theOther)
 
-infix fun Int.shouldNotEqualTo(theOther: Int) = assertThat(this).isNotEqualTo(theOther)
+infix fun Long.shouldNotEqualTo(theOther: Long) = assert(this != theOther)
 
-infix fun Long.shouldNotEqualTo(theOther: Long) = assertThat(this).isNotEqualTo(theOther)
+infix fun Float.shouldNotEqualTo(theOther: Float) = assert(this != theOther)
 
-infix fun Float.shouldNotEqualTo(theOther: Float) = assertThat(this).isNotEqualTo(theOther)
+infix fun Double.shouldNotEqualTo(theOther: Double) = assert(this != theOther)
 
-infix fun Double.shouldNotEqualTo(theOther: Double) = assertThat(this).isNotEqualTo(theOther)
+infix fun Byte.shouldBeGreaterThan(theOther: Byte) = assert(this > theOther, { "Expected $this to be greater than $theOther" })
 
-infix fun Byte.shouldBeGreaterThan(theOther: Byte) = assertThat(this > theOther).`as`("Expected $this to be greater than $theOther").isTrue()
+infix fun Short.shouldBeGreaterThan(theOther: Short) = assert(this > theOther, { "Expected $this to be greater than $theOther" })
 
-infix fun Short.shouldBeGreaterThan(theOther: Short) = assertThat(this > theOther).`as`("Expected $this to be greater than $theOther").isTrue()
+infix fun Int.shouldBeGreaterThan(theOther: Int) = assert(this > theOther, { "Expected $this to be greater than $theOther" })
 
-infix fun Int.shouldBeGreaterThan(theOther: Int) = assertThat(this > theOther).`as`("Expected $this to be greater than $theOther").isTrue()
+infix fun Long.shouldBeGreaterThan(theOther: Long) = assert(this > theOther, { "Expected $this to be greater than $theOther" })
 
-infix fun Long.shouldBeGreaterThan(theOther: Long) = assertThat(this > theOther).`as`("Expected $this to be greater than $theOther").isTrue()
+infix fun Float.shouldBeGreaterThan(theOther: Float) = assert(this > theOther, { "Expected $this to be greater than $theOther" })
 
-infix fun Float.shouldBeGreaterThan(theOther: Float) = assertThat(this > theOther).`as`("Expected $this to be greater than $theOther").isTrue()
+infix fun Double.shouldBeGreaterThan(theOther: Double) = assert(this > theOther, { "Expected $this to be greater than $theOther" })
 
-infix fun Double.shouldBeGreaterThan(theOther: Double) = assertThat(this > theOther).`as`("Expected $this to be greater than $theOther").isTrue()
+infix fun Byte.shouldNotBeGreaterThan(theOther: Byte) = assert(this <= theOther, { "Expected $this to not be greater than $theOther" })
 
-infix fun Byte.shouldNotBeGreaterThan(theOther: Byte) = assertThat(this <= theOther).`as`("Expected $this to not be greater than $theOther").isTrue()
+infix fun Short.shouldNotBeGreaterThan(theOther: Short) = assert(this <= theOther, { "Expected $this to not be greater than $theOther" })
 
-infix fun Short.shouldNotBeGreaterThan(theOther: Short) = assertThat(this <= theOther).`as`("Expected $this to not be greater than $theOther").isTrue()
+infix fun Int.shouldNotBeGreaterThan(theOther: Int) = assert(this <= theOther, { "Expected $this to not be greater than $theOther" })
 
-infix fun Int.shouldNotBeGreaterThan(theOther: Int) = assertThat(this <= theOther).`as`("Expected $this to not be greater than $theOther").isTrue()
+infix fun Long.shouldNotBeGreaterThan(theOther: Long) = assert(this <= theOther, { "Expected $this to not be greater than $theOther" })
 
-infix fun Long.shouldNotBeGreaterThan(theOther: Long) = assertThat(this <= theOther).`as`("Expected $this to not be greater than $theOther").isTrue()
+infix fun Float.shouldNotBeGreaterThan(theOther: Float) = assert(this <= theOther, { "Expected $this to not be greater than $theOther" })
 
-infix fun Float.shouldNotBeGreaterThan(theOther: Float) = assertThat(this <= theOther).`as`("Expected $this to not be greater than $theOther").isTrue()
+infix fun Double.shouldNotBeGreaterThan(theOther: Double) = assert(this <= theOther, { "Expected $this to not be greater than $theOther" })
 
-infix fun Double.shouldNotBeGreaterThan(theOther: Double) = assertThat(this <= theOther).`as`("Expected $this to not be greater than $theOther").isTrue()
+infix fun Byte.shouldBeGreaterOrEqualTo(theOther: Byte) = assert(this >= theOther, { "Expected $this to be greater or equal to $theOther" })
 
-infix fun Byte.shouldBeGreaterOrEqualTo(theOther: Byte) = assertThat(this >= theOther).`as`("Expected $this to be greater or equal to $theOther").isTrue()
+infix fun Short.shouldBeGreaterOrEqualTo(theOther: Short) = assert(this >= theOther, { "Expected $this to be greater or equal to $theOther" })
 
-infix fun Short.shouldBeGreaterOrEqualTo(theOther: Short) = assertThat(this >= theOther).`as`("Expected $this to be greater or equal to $theOther").isTrue()
+infix fun Int.shouldBeGreaterOrEqualTo(theOther: Int) = assert(this >= theOther, { "Expected $this to be greater or equal to $theOther" })
 
-infix fun Int.shouldBeGreaterOrEqualTo(theOther: Int) = assertThat(this >= theOther).`as`("Expected $this to be greater or equal to $theOther").isTrue()
+infix fun Long.shouldBeGreaterOrEqualTo(theOther: Long) = assert(this >= theOther, { "Expected $this to be greater or equal to $theOther" })
 
-infix fun Long.shouldBeGreaterOrEqualTo(theOther: Long) = assertThat(this >= theOther).`as`("Expected $this to be greater or equal to $theOther").isTrue()
+infix fun Float.shouldBeGreaterOrEqualTo(theOther: Float) = assert(this >= theOther, { "Expected $this to be greater or equal to $theOther" })
 
-infix fun Float.shouldBeGreaterOrEqualTo(theOther: Float) = assertThat(this >= theOther).`as`("Expected $this to be greater or equal to $theOther").isTrue()
+infix fun Double.shouldBeGreaterOrEqualTo(theOther: Double) = assert(this >= theOther, { "Expected $this to be greater or equal to $theOther" })
 
-infix fun Double.shouldBeGreaterOrEqualTo(theOther: Double) = assertThat(this >= theOther).`as`("Expected $this to be greater or equal to $theOther").isTrue()
+infix fun Byte.shouldNotBeGreaterOrEqualTo(theOther: Byte) = assert(this < theOther, { "Expected $this to be not be greater or equal to $theOther" })
 
-infix fun Byte.shouldNotBeGreaterOrEqualTo(theOther: Byte) = assertThat(this < theOther).`as`("Expected $this to be not be greater or equal to $theOther").isTrue()
+infix fun Short.shouldNotBeGreaterOrEqualTo(theOther: Short) = assert(this < theOther, { "Expected $this to not be greater or equal to $theOther" })
 
-infix fun Short.shouldNotBeGreaterOrEqualTo(theOther: Short) = assertThat(this < theOther).`as`("Expected $this to not be greater or equal to $theOther").isTrue()
+infix fun Int.shouldNotBeGreaterOrEqualTo(theOther: Int) = assert(this < theOther, { "Expected $this to not be greater or equal to $theOther" })
 
-infix fun Int.shouldNotBeGreaterOrEqualTo(theOther: Int) = assertThat(this < theOther).`as`("Expected $this to not be greater or equal to $theOther").isTrue()
+infix fun Long.shouldNotBeGreaterOrEqualTo(theOther: Long) = assert(this < theOther, { "Expected $this to not be greater or equal to $theOther" })
 
-infix fun Long.shouldNotBeGreaterOrEqualTo(theOther: Long) = assertThat(this < theOther).`as`("Expected $this to not be greater or equal to $theOther").isTrue()
+infix fun Float.shouldNotBeGreaterOrEqualTo(theOther: Float) = assert(this < theOther, { "Expected $this to not be greater or equal to $theOther" })
 
-infix fun Float.shouldNotBeGreaterOrEqualTo(theOther: Float) = assertThat(this < theOther).`as`("Expected $this to not be greater or equal to $theOther").isTrue()
+infix fun Double.shouldNotBeGreaterOrEqualTo(theOther: Double) = assert(this < theOther, { "Expected $this to not be greater or equal to $theOther" })
 
-infix fun Double.shouldNotBeGreaterOrEqualTo(theOther: Double) = assertThat(this < theOther).`as`("Expected $this to not be greater or equal to $theOther").isTrue()
+infix fun Byte.shouldBeLessThan(theOther: Byte) = assert(this < theOther, { "Expected $this to be less than $theOther" })
 
-infix fun Byte.shouldBeLessThan(theOther: Byte) = assertThat(this < theOther).`as`("Expected $this to be less than $theOther").isTrue()
+infix fun Short.shouldBeLessThan(theOther: Short) = assert(this < theOther, { "Expected $this to be less than $theOther" })
 
-infix fun Short.shouldBeLessThan(theOther: Short) = assertThat(this < theOther).`as`("Expected $this to be less than $theOther").isTrue()
+infix fun Int.shouldBeLessThan(theOther: Int) = assert(this < theOther, { "Expected $this to be less than $theOther" })
 
-infix fun Int.shouldBeLessThan(theOther: Int) = assertThat(this < theOther).`as`("Expected $this to be less than $theOther").isTrue()
+infix fun Long.shouldBeLessThan(theOther: Long) = assert(this < theOther, { "Expected $this to be less than $theOther" })
 
-infix fun Long.shouldBeLessThan(theOther: Long) = assertThat(this < theOther).`as`("Expected $this to be less than $theOther").isTrue()
+infix fun Float.shouldBeLessThan(theOther: Float) = assert(this < theOther, { "Expected $this to be less than $theOther" })
 
-infix fun Float.shouldBeLessThan(theOther: Float) = assertThat(this < theOther).`as`("Expected $this to be less than $theOther").isTrue()
+infix fun Double.shouldBeLessThan(theOther: Double) = assert(this < theOther, { "Expected $this to be less than $theOther" })
 
-infix fun Double.shouldBeLessThan(theOther: Double) = assertThat(this < theOther).`as`("Expected $this to be less than $theOther").isTrue()
+infix fun Byte.shouldNotBeLessThan(theOther: Byte) = assert(this >= theOther, { "Expected $this to not be less than $theOther" })
 
-infix fun Byte.shouldNotBeLessThan(theOther: Byte) = assertThat(this >= theOther).`as`("Expected $this to not be less than $theOther").isTrue()
+infix fun Short.shouldNotBeLessThan(theOther: Short) = assert(this >= theOther, { "Expected $this to not be less than $theOther" })
 
-infix fun Short.shouldNotBeLessThan(theOther: Short) = assertThat(this >= theOther).`as`("Expected $this to not be less than $theOther").isTrue()
+infix fun Int.shouldNotBeLessThan(theOther: Int) = assert(this >= theOther, { "Expected $this to not be less than $theOther" })
 
-infix fun Int.shouldNotBeLessThan(theOther: Int) = assertThat(this >= theOther).`as`("Expected $this to not be less than $theOther").isTrue()
+infix fun Long.shouldNotBeLessThan(theOther: Long) = assert(this >= theOther, { "Expected $this to not be less than $theOther" })
 
-infix fun Long.shouldNotBeLessThan(theOther: Long) = assertThat(this >= theOther).`as`("Expected $this to not be less than $theOther").isTrue()
+infix fun Float.shouldNotBeLessThan(theOther: Float) = assert(this >= theOther, { "Expected $this to not be less than $theOther" })
 
-infix fun Float.shouldNotBeLessThan(theOther: Float) = assertThat(this >= theOther).`as`("Expected $this to not be less than $theOther").isTrue()
+infix fun Double.shouldNotBeLessThan(theOther: Double) = assert(this >= theOther, { "Expected $this to not be less than $theOther" })
 
-infix fun Double.shouldNotBeLessThan(theOther: Double) = assertThat(this >= theOther).`as`("Expected $this to not be less than $theOther").isTrue()
+infix fun Byte.shouldBeLessOrEqualTo(theOther: Byte) = assert(this <= theOther, { "Expected $this to be less or equal to $theOther" })
 
-infix fun Byte.shouldBeLessOrEqualTo(theOther: Byte) = assertThat(this <= theOther).`as`("Expected $this to be less or equal to $theOther").isTrue()
+infix fun Short.shouldBeLessOrEqualTo(theOther: Short) = assert(this <= theOther, { "Expected $this to be less or equal to $theOther" })
 
-infix fun Short.shouldBeLessOrEqualTo(theOther: Short) = assertThat(this <= theOther).`as`("Expected $this to be less or equal to $theOther").isTrue()
+infix fun Int.shouldBeLessOrEqualTo(theOther: Int) = assert(this <= theOther, { "Expected $this to be less or equal to $theOther" })
 
-infix fun Int.shouldBeLessOrEqualTo(theOther: Int) = assertThat(this <= theOther).`as`("Expected $this to be less or equal to $theOther").isTrue()
+infix fun Long.shouldBeLessOrEqualTo(theOther: Long) = assert(this <= theOther, { "Expected $this to be less or equal to $theOther" })
 
-infix fun Long.shouldBeLessOrEqualTo(theOther: Long) = assertThat(this <= theOther).`as`("Expected $this to be less or equal to $theOther").isTrue()
+infix fun Float.shouldBeLessOrEqualTo(theOther: Float) = assert(this <= theOther, { "Expected $this to be less or equal to $theOther" })
 
-infix fun Float.shouldBeLessOrEqualTo(theOther: Float) = assertThat(this <= theOther).`as`("Expected $this to be less or equal to $theOther").isTrue()
+infix fun Double.shouldBeLessOrEqualTo(theOther: Double) = assert(this <= theOther, { "Expected $this to be less or equal to $theOther" })
 
-infix fun Double.shouldBeLessOrEqualTo(theOther: Double) = assertThat(this <= theOther).`as`("Expected $this to be less or equal to $theOther").isTrue()
+infix fun Byte.shouldNotBeLessOrEqualTo(theOther: Byte) = assert(this > theOther, { "Expected $this to not be less or equal to $theOther" })
 
-infix fun Byte.shouldNotBeLessOrEqualTo(theOther: Byte) = assertThat(this > theOther).`as`("Expected $this to not be less or equal to $theOther").isTrue()
+infix fun Short.shouldNotBeLessOrEqualTo(theOther: Short) = assert(this > theOther, { "Expected $this to not be less or equal to $theOther" })
 
-infix fun Short.shouldNotBeLessOrEqualTo(theOther: Short) = assertThat(this > theOther).`as`("Expected $this to not be less or equal to $theOther").isTrue()
+infix fun Int.shouldNotBeLessOrEqualTo(theOther: Int) = assert(this > theOther, { "Expected $this to not be less or equal to $theOther" })
 
-infix fun Int.shouldNotBeLessOrEqualTo(theOther: Int) = assertThat(this > theOther).`as`("Expected $this to not be less or equal to $theOther").isTrue()
+infix fun Long.shouldNotBeLessOrEqualTo(theOther: Long) = assert(this > theOther, { "Expected $this to not be less or equal to $theOther" })
 
-infix fun Long.shouldNotBeLessOrEqualTo(theOther: Long) = assertThat(this > theOther).`as`("Expected $this to not be less or equal to $theOther").isTrue()
+infix fun Float.shouldNotBeLessOrEqualTo(theOther: Float) = assert(this > theOther, { "Expected $this to not be less or equal to $theOther" })
 
-infix fun Float.shouldNotBeLessOrEqualTo(theOther: Float) = assertThat(this > theOther).`as`("Expected $this to not be less or equal to $theOther").isTrue()
+infix fun Double.shouldNotBeLessOrEqualTo(theOther: Double) = assert(this > theOther, { "Expected $this to not be less or equal to $theOther" })
 
-infix fun Double.shouldNotBeLessOrEqualTo(theOther: Double) = assertThat(this > theOther).`as`("Expected $this to not be less or equal to $theOther").isTrue()
+fun Byte.shouldBePositive() = assert(this > 0, { "Expected $this to be positive" })
 
-fun Byte.shouldBePositive() = assertThat(this > 0).`as`("Expected $this to be positive").isTrue()
+fun Short.shouldBePositive() = assert(this > 0, { "Expected $this to be positive" })
 
-fun Short.shouldBePositive() = assertThat(this > 0).`as`("Expected $this to be positive").isTrue()
+fun Int.shouldBePositive() = assert(this > 0, { "Expected $this to be positive" })
 
-fun Int.shouldBePositive() = assertThat(this > 0).`as`("Expected $this to be positive").isTrue()
+fun Long.shouldBePositive() = assert(this > 0, { "Expected $this to be positive" })
 
-fun Long.shouldBePositive() = assertThat(this > 0).`as`("Expected $this to be positive").isTrue()
+fun Float.shouldBePositive() = assert(this > 0, { "Expected $this to be positive" })
 
-fun Float.shouldBePositive() = assertThat(this > 0).`as`("Expected $this to be positive").isTrue()
+fun Double.shouldBePositive() = assert(this > 0, { "Expected $this to be positive" })
 
-fun Double.shouldBePositive() = assertThat(this > 0).`as`("Expected $this to be positive").isTrue()
+fun Byte.shouldBeNegative() = assert(this < 0, { "Expected $this to be negative" })
 
-fun Byte.shouldBeNegative() = assertThat(this < 0).`as`("Expected $this to be negative").isTrue()
+fun Short.shouldBeNegative() = assert(this < 0, { "Expected $this to be negative" })
 
-fun Short.shouldBeNegative() = assertThat(this < 0).`as`("Expected $this to be negative").isTrue()
+fun Int.shouldBeNegative() = assert(this < 0, { "Expected $this to be negative" })
 
-fun Int.shouldBeNegative() = assertThat(this < 0).`as`("Expected $this to be negative").isTrue()
+fun Long.shouldBeNegative() = assert(this < 0, { "Expected $this to be negative" })
 
-fun Long.shouldBeNegative() = assertThat(this < 0).`as`("Expected $this to be negative").isTrue()
+fun Float.shouldBeNegative() = assert(this < 0, { "Expected $this to be negative" })
 
-fun Float.shouldBeNegative() = assertThat(this < 0).`as`("Expected $this to be negative").isTrue()
+fun Double.shouldBeNegative() = assert(this < 0, { "Expected $this to be negative" })
 
-fun Double.shouldBeNegative() = assertThat(this < 0).`as`("Expected $this to be negative").isTrue()
+fun Byte.shouldBeInRange(lowerBound: Byte, upperBound: Byte) = assert(this >= lowerBound && this <= upperBound, { "Expected $this to be between (and including) $lowerBound and $upperBound" })
 
-fun Byte.shouldBeInRange(lowerBound: Byte, upperBound: Byte) = assertThat(this >= lowerBound && this <= upperBound).`as`("Expected $this to be between (and including) $lowerBound and $upperBound").isTrue()
+fun Short.shouldBeInRange(lowerBound: Short, upperBound: Short) = assert(this >= lowerBound && this <= upperBound, { "Expected $this to be between (and including) $lowerBound and $upperBound" })
 
-fun Short.shouldBeInRange(lowerBound: Short, upperBound: Short) = assertThat(this >= lowerBound && this <= upperBound).`as`("Expected $this to be between (and including) $lowerBound and $upperBound").isTrue()
+fun Int.shouldBeInRange(lowerBound: Int, upperBound: Int) = assert(this >= lowerBound && this <= upperBound, { "Expected $this to be between (and including) $lowerBound and $upperBound" })
 
-fun Int.shouldBeInRange(lowerBound: Int, upperBound: Int) = assertThat(this >= lowerBound && this <= upperBound).`as`("Expected $this to be between (and including) $lowerBound and $upperBound").isTrue()
+fun Long.shouldBeInRange(lowerBound: Long, upperBound: Long) = assert(this >= lowerBound && this <= upperBound, { "Expected $this to be between (and including) $lowerBound and $upperBound" })
 
-fun Long.shouldBeInRange(lowerBound: Long, upperBound: Long) = assertThat(this >= lowerBound && this <= upperBound).`as`("Expected $this to be between (and including) $lowerBound and $upperBound").isTrue()
+fun Float.shouldBeInRange(lowerBound: Float, upperBound: Float) = assert(this >= lowerBound && this <= upperBound, { "Expected $this to be between (and including) $lowerBound and $upperBound" })
 
-fun Float.shouldBeInRange(lowerBound: Float, upperBound: Float) = assertThat(this >= lowerBound && this <= upperBound).`as`("Expected $this to be between (and including) $lowerBound and $upperBound").isTrue()
+fun Double.shouldBeInRange(lowerBound: Double, upperBound: Double) = assert(this >= lowerBound && this <= upperBound, { "Expected $this to be between (and including) $lowerBound and $upperBound" })
 
-fun Double.shouldBeInRange(lowerBound: Double, upperBound: Double) = assertThat(this >= lowerBound && this <= upperBound).`as`("Expected $this to be between (and including) $lowerBound and $upperBound").isTrue()
+fun Byte.shouldNotBeInRange(lowerBound: Byte, upperBound: Byte) = assert(this < lowerBound || this > upperBound, { "Expected $this to not be between (and including) $lowerBound and $upperBound" })
 
-fun Byte.shouldNotBeInRange(lowerBound: Byte, upperBound: Byte) = assertThat(this < lowerBound || this > upperBound).`as`("Expected $this to not be between (and including) $lowerBound and $upperBound").isTrue()
+fun Short.shouldNotBeInRange(lowerBound: Short, upperBound: Short) = assert(this < lowerBound || this > upperBound, { "Expected $this to not be between (and including) $lowerBound and $upperBound" })
 
-fun Short.shouldNotBeInRange(lowerBound: Short, upperBound: Short) = assertThat(this < lowerBound || this > upperBound).`as`("Expected $this to not be between (and including) $lowerBound and $upperBound").isTrue()
+fun Int.shouldNotBeInRange(lowerBound: Int, upperBound: Int) = assert(this < lowerBound || this > upperBound, { "Expected $this to not be between (and including) $lowerBound and $upperBound" })
 
-fun Int.shouldNotBeInRange(lowerBound: Int, upperBound: Int) = assertThat(this < lowerBound || this > upperBound).`as`("Expected $this to not be between (and including) $lowerBound and $upperBound").isTrue()
+fun Long.shouldNotBeInRange(lowerBound: Long, upperBound: Long) = assert(this < lowerBound || this > upperBound, { "Expected $this to not be between (and including) $lowerBound and $upperBound" })
 
-fun Long.shouldNotBeInRange(lowerBound: Long, upperBound: Long) = assertThat(this < lowerBound || this > upperBound).`as`("Expected $this to not be between (and including) $lowerBound and $upperBound").isTrue()
+fun Float.shouldNotBeInRange(lowerBound: Float, upperBound: Float) = assert(this < lowerBound || this > upperBound, { "Expected $this to not be between (and including) $lowerBound and $upperBound" })
 
-fun Float.shouldNotBeInRange(lowerBound: Float, upperBound: Float) = assertThat(this < lowerBound || this > upperBound).`as`("Expected $this to not be between (and including) $lowerBound and $upperBound").isTrue()
-
-fun Double.shouldNotBeInRange(lowerBound: Double, upperBound: Double) = assertThat(this < lowerBound || this > upperBound).`as`("Expected $this to not be between (and including) $lowerBound and $upperBound").isTrue()
+fun Double.shouldNotBeInRange(lowerBound: Double, upperBound: Double) = assert(this < lowerBound || this > upperBound, { "Expected $this to not be between (and including) $lowerBound and $upperBound" })
 
 infix fun Byte.shouldBeInRange(range: IntRange) = (this.toInt()).shouldBeInRange(range)
 

--- a/src/main/kotlin/org/amshove/kluent/Numerical.kt
+++ b/src/main/kotlin/org/amshove/kluent/Numerical.kt
@@ -1,178 +1,178 @@
 package org.amshove.kluent
 
-import org.junit.jupiter.api.Assertions.*
+import org.assertj.core.api.Assertions.assertThat
 
-infix fun Boolean.shouldEqualTo(theOther: Boolean) = assertEquals(theOther, this)
+infix fun Boolean.shouldEqualTo(theOther: Boolean) = assertThat(this).isEqualTo(theOther)
 
-infix fun Byte.shouldEqualTo(theOther: Byte) = assertEquals(theOther, this)
+infix fun Byte.shouldEqualTo(theOther: Byte) = assertThat(this).isEqualTo(theOther)
 
-infix fun Short.shouldEqualTo(theOther: Short) = assertEquals(theOther, this)
+infix fun Short.shouldEqualTo(theOther: Short) = assertThat(this).isEqualTo(theOther)
 
-infix fun Int.shouldEqualTo(theOther: Int) = assertEquals(theOther, this)
+infix fun Int.shouldEqualTo(theOther: Int) = assertThat(this).isEqualTo(theOther)
 
-infix fun Long.shouldEqualTo(theOther: Long) = assertEquals(theOther, this)
+infix fun Long.shouldEqualTo(theOther: Long) = assertThat(this).isEqualTo(theOther)
 
-infix fun Float.shouldEqualTo(theOther: Float) = assertEquals(theOther, this)
+infix fun Float.shouldEqualTo(theOther: Float) = assertThat(this).isEqualTo(theOther)
 
-infix fun Double.shouldEqualTo(theOther: Double) = assertEquals(theOther, this)
+infix fun Double.shouldEqualTo(theOther: Double) = assertThat(this).isEqualTo(theOther)
 
-infix fun Boolean.shouldNotEqualTo(theOther: Boolean) = assertNotEquals(theOther, this)
+infix fun Boolean.shouldNotEqualTo(theOther: Boolean) = assertThat(this).isNotEqualTo(theOther)
 
-infix fun Byte.shouldNotEqualTo(theOther: Byte) = assertNotEquals(theOther, this)
+infix fun Byte.shouldNotEqualTo(theOther: Byte) = assertThat(this).isNotEqualTo(theOther)
 
-infix fun Short.shouldNotEqualTo(theOther: Short) = assertNotEquals(theOther, this)
+infix fun Short.shouldNotEqualTo(theOther: Short) = assertThat(this).isNotEqualTo(theOther)
 
-infix fun Int.shouldNotEqualTo(theOther: Int) = assertNotEquals(theOther, this)
+infix fun Int.shouldNotEqualTo(theOther: Int) = assertThat(this).isNotEqualTo(theOther)
 
-infix fun Long.shouldNotEqualTo(theOther: Long) = assertNotEquals(theOther, this)
+infix fun Long.shouldNotEqualTo(theOther: Long) = assertThat(this).isNotEqualTo(theOther)
 
-infix fun Float.shouldNotEqualTo(theOther: Float) = assertNotEquals(theOther, this)
+infix fun Float.shouldNotEqualTo(theOther: Float) = assertThat(this).isNotEqualTo(theOther)
 
-infix fun Double.shouldNotEqualTo(theOther: Double) = assertNotEquals(theOther, this)
+infix fun Double.shouldNotEqualTo(theOther: Double) = assertThat(this).isNotEqualTo(theOther)
 
-infix fun Byte.shouldBeGreaterThan(theOther: Byte) = assertTrue(this > theOther, "Expected $this to be greater than $theOther")
+infix fun Byte.shouldBeGreaterThan(theOther: Byte) = assertThat(this > theOther).`as`("Expected $this to be greater than $theOther").isTrue()
 
-infix fun Short.shouldBeGreaterThan(theOther: Short) = assertTrue(this > theOther, "Expected $this to be greater than $theOther")
+infix fun Short.shouldBeGreaterThan(theOther: Short) = assertThat(this > theOther).`as`("Expected $this to be greater than $theOther").isTrue()
 
-infix fun Int.shouldBeGreaterThan(theOther: Int) = assertTrue(this > theOther, "Expected $this to be greater than $theOther")
+infix fun Int.shouldBeGreaterThan(theOther: Int) = assertThat(this > theOther).`as`("Expected $this to be greater than $theOther").isTrue()
 
-infix fun Long.shouldBeGreaterThan(theOther: Long) = assertTrue(this > theOther, "Expected $this to be greater than $theOther")
+infix fun Long.shouldBeGreaterThan(theOther: Long) = assertThat(this > theOther).`as`("Expected $this to be greater than $theOther").isTrue()
 
-infix fun Float.shouldBeGreaterThan(theOther: Float) = assertTrue(this > theOther, "Expected $this to be greater than $theOther")
+infix fun Float.shouldBeGreaterThan(theOther: Float) = assertThat(this > theOther).`as`("Expected $this to be greater than $theOther").isTrue()
 
-infix fun Double.shouldBeGreaterThan(theOther: Double) = assertTrue(this > theOther, "Expected $this to be greater than $theOther")
+infix fun Double.shouldBeGreaterThan(theOther: Double) = assertThat(this > theOther).`as`("Expected $this to be greater than $theOther").isTrue()
 
-infix fun Byte.shouldNotBeGreaterThan(theOther: Byte) = assertTrue(this <= theOther, "Expected $this to not be greater than $theOther")
+infix fun Byte.shouldNotBeGreaterThan(theOther: Byte) = assertThat(this <= theOther).`as`("Expected $this to not be greater than $theOther").isTrue()
 
-infix fun Short.shouldNotBeGreaterThan(theOther: Short) = assertTrue(this <= theOther, "Expected $this to not be greater than $theOther")
+infix fun Short.shouldNotBeGreaterThan(theOther: Short) = assertThat(this <= theOther).`as`("Expected $this to not be greater than $theOther").isTrue()
 
-infix fun Int.shouldNotBeGreaterThan(theOther: Int) = assertTrue(this <= theOther, "Expected $this to not be greater than $theOther")
+infix fun Int.shouldNotBeGreaterThan(theOther: Int) = assertThat(this <= theOther).`as`("Expected $this to not be greater than $theOther").isTrue()
 
-infix fun Long.shouldNotBeGreaterThan(theOther: Long) = assertTrue(this <= theOther, "Expected $this to not be greater than $theOther")
+infix fun Long.shouldNotBeGreaterThan(theOther: Long) = assertThat(this <= theOther).`as`("Expected $this to not be greater than $theOther").isTrue()
 
-infix fun Float.shouldNotBeGreaterThan(theOther: Float) = assertTrue(this <= theOther, "Expected $this to not be greater than $theOther")
+infix fun Float.shouldNotBeGreaterThan(theOther: Float) = assertThat(this <= theOther).`as`("Expected $this to not be greater than $theOther").isTrue()
 
-infix fun Double.shouldNotBeGreaterThan(theOther: Double) = assertTrue(this <= theOther, "Expected $this to not be greater than $theOther")
+infix fun Double.shouldNotBeGreaterThan(theOther: Double) = assertThat(this <= theOther).`as`("Expected $this to not be greater than $theOther").isTrue()
 
-infix fun Byte.shouldBeGreaterOrEqualTo(theOther: Byte) = assertTrue(this >= theOther, "Expected $this to be greater or equal to $theOther")
+infix fun Byte.shouldBeGreaterOrEqualTo(theOther: Byte) = assertThat(this >= theOther).`as`("Expected $this to be greater or equal to $theOther").isTrue()
 
-infix fun Short.shouldBeGreaterOrEqualTo(theOther: Short) = assertTrue(this >= theOther, "Expected $this to be greater or equal to $theOther")
+infix fun Short.shouldBeGreaterOrEqualTo(theOther: Short) = assertThat(this >= theOther).`as`("Expected $this to be greater or equal to $theOther").isTrue()
 
-infix fun Int.shouldBeGreaterOrEqualTo(theOther: Int) = assertTrue(this >= theOther, "Expected $this to be greater or equal to $theOther")
+infix fun Int.shouldBeGreaterOrEqualTo(theOther: Int) = assertThat(this >= theOther).`as`("Expected $this to be greater or equal to $theOther").isTrue()
 
-infix fun Long.shouldBeGreaterOrEqualTo(theOther: Long) = assertTrue(this >= theOther, "Expected $this to be greater or equal to $theOther")
+infix fun Long.shouldBeGreaterOrEqualTo(theOther: Long) = assertThat(this >= theOther).`as`("Expected $this to be greater or equal to $theOther").isTrue()
 
-infix fun Float.shouldBeGreaterOrEqualTo(theOther: Float) = assertTrue(this >= theOther, "Expected $this to be greater or equal to $theOther")
+infix fun Float.shouldBeGreaterOrEqualTo(theOther: Float) = assertThat(this >= theOther).`as`("Expected $this to be greater or equal to $theOther").isTrue()
 
-infix fun Double.shouldBeGreaterOrEqualTo(theOther: Double) = assertTrue(this >= theOther, "Expected $this to be greater or equal to $theOther")
+infix fun Double.shouldBeGreaterOrEqualTo(theOther: Double) = assertThat(this >= theOther).`as`("Expected $this to be greater or equal to $theOther").isTrue()
 
-infix fun Byte.shouldNotBeGreaterOrEqualTo(theOther: Byte) = assertTrue(this < theOther, "Expected $this to be not be greater or equal to $theOther")
+infix fun Byte.shouldNotBeGreaterOrEqualTo(theOther: Byte) = assertThat(this < theOther).`as`("Expected $this to be not be greater or equal to $theOther").isTrue()
 
-infix fun Short.shouldNotBeGreaterOrEqualTo(theOther: Short) = assertTrue(this < theOther, "Expected $this to not be greater or equal to $theOther")
+infix fun Short.shouldNotBeGreaterOrEqualTo(theOther: Short) = assertThat(this < theOther).`as`("Expected $this to not be greater or equal to $theOther").isTrue()
 
-infix fun Int.shouldNotBeGreaterOrEqualTo(theOther: Int) = assertTrue(this < theOther, "Expected $this to not be greater or equal to $theOther")
+infix fun Int.shouldNotBeGreaterOrEqualTo(theOther: Int) = assertThat(this < theOther).`as`("Expected $this to not be greater or equal to $theOther").isTrue()
 
-infix fun Long.shouldNotBeGreaterOrEqualTo(theOther: Long) = assertTrue(this < theOther, "Expected $this to not be greater or equal to $theOther")
+infix fun Long.shouldNotBeGreaterOrEqualTo(theOther: Long) = assertThat(this < theOther).`as`("Expected $this to not be greater or equal to $theOther").isTrue()
 
-infix fun Float.shouldNotBeGreaterOrEqualTo(theOther: Float) = assertTrue(this < theOther, "Expected $this to not be greater or equal to $theOther")
+infix fun Float.shouldNotBeGreaterOrEqualTo(theOther: Float) = assertThat(this < theOther).`as`("Expected $this to not be greater or equal to $theOther").isTrue()
 
-infix fun Double.shouldNotBeGreaterOrEqualTo(theOther: Double) = assertTrue(this < theOther, "Expected $this to not be greater or equal to $theOther")
+infix fun Double.shouldNotBeGreaterOrEqualTo(theOther: Double) = assertThat(this < theOther).`as`("Expected $this to not be greater or equal to $theOther").isTrue()
 
-infix fun Byte.shouldBeLessThan(theOther: Byte) = assertTrue(this < theOther, "Expected $this to be less than $theOther")
+infix fun Byte.shouldBeLessThan(theOther: Byte) = assertThat(this < theOther).`as`("Expected $this to be less than $theOther").isTrue()
 
-infix fun Short.shouldBeLessThan(theOther: Short) = assertTrue(this < theOther, "Expected $this to be less than $theOther")
+infix fun Short.shouldBeLessThan(theOther: Short) = assertThat(this < theOther).`as`("Expected $this to be less than $theOther").isTrue()
 
-infix fun Int.shouldBeLessThan(theOther: Int) = assertTrue(this < theOther, "Expected $this to be less than $theOther")
+infix fun Int.shouldBeLessThan(theOther: Int) = assertThat(this < theOther).`as`("Expected $this to be less than $theOther").isTrue()
 
-infix fun Long.shouldBeLessThan(theOther: Long) = assertTrue(this < theOther, "Expected $this to be less than $theOther")
+infix fun Long.shouldBeLessThan(theOther: Long) = assertThat(this < theOther).`as`("Expected $this to be less than $theOther").isTrue()
 
-infix fun Float.shouldBeLessThan(theOther: Float) = assertTrue(this < theOther, "Expected $this to be less than $theOther")
+infix fun Float.shouldBeLessThan(theOther: Float) = assertThat(this < theOther).`as`("Expected $this to be less than $theOther").isTrue()
 
-infix fun Double.shouldBeLessThan(theOther: Double) = assertTrue(this < theOther, "Expected $this to be less than $theOther")
+infix fun Double.shouldBeLessThan(theOther: Double) = assertThat(this < theOther).`as`("Expected $this to be less than $theOther").isTrue()
 
-infix fun Byte.shouldNotBeLessThan(theOther: Byte) = assertTrue(this >= theOther, "Expected $this to not be less than $theOther")
+infix fun Byte.shouldNotBeLessThan(theOther: Byte) = assertThat(this >= theOther).`as`("Expected $this to not be less than $theOther").isTrue()
 
-infix fun Short.shouldNotBeLessThan(theOther: Short) = assertTrue(this >= theOther, "Expected $this to not be less than $theOther")
+infix fun Short.shouldNotBeLessThan(theOther: Short) = assertThat(this >= theOther).`as`("Expected $this to not be less than $theOther").isTrue()
 
-infix fun Int.shouldNotBeLessThan(theOther: Int) = assertTrue(this >= theOther, "Expected $this to not be less than $theOther")
+infix fun Int.shouldNotBeLessThan(theOther: Int) = assertThat(this >= theOther).`as`("Expected $this to not be less than $theOther").isTrue()
 
-infix fun Long.shouldNotBeLessThan(theOther: Long) = assertTrue(this >= theOther, "Expected $this to not be less than $theOther")
+infix fun Long.shouldNotBeLessThan(theOther: Long) = assertThat(this >= theOther).`as`("Expected $this to not be less than $theOther").isTrue()
 
-infix fun Float.shouldNotBeLessThan(theOther: Float) = assertTrue(this >= theOther, "Expected $this to not be less than $theOther")
+infix fun Float.shouldNotBeLessThan(theOther: Float) = assertThat(this >= theOther).`as`("Expected $this to not be less than $theOther").isTrue()
 
-infix fun Double.shouldNotBeLessThan(theOther: Double) = assertTrue(this >= theOther, "Expected $this to not be less than $theOther")
+infix fun Double.shouldNotBeLessThan(theOther: Double) = assertThat(this >= theOther).`as`("Expected $this to not be less than $theOther").isTrue()
 
-infix fun Byte.shouldBeLessOrEqualTo(theOther: Byte) = assertTrue(this <= theOther, "Expected $this to be less or equal to $theOther")
+infix fun Byte.shouldBeLessOrEqualTo(theOther: Byte) = assertThat(this <= theOther).`as`("Expected $this to be less or equal to $theOther").isTrue()
 
-infix fun Short.shouldBeLessOrEqualTo(theOther: Short) = assertTrue(this <= theOther, "Expected $this to be less or equal to $theOther")
+infix fun Short.shouldBeLessOrEqualTo(theOther: Short) = assertThat(this <= theOther).`as`("Expected $this to be less or equal to $theOther").isTrue()
 
-infix fun Int.shouldBeLessOrEqualTo(theOther: Int) = assertTrue(this <= theOther, "Expected $this to be less or equal to $theOther")
+infix fun Int.shouldBeLessOrEqualTo(theOther: Int) = assertThat(this <= theOther).`as`("Expected $this to be less or equal to $theOther").isTrue()
 
-infix fun Long.shouldBeLessOrEqualTo(theOther: Long) = assertTrue(this <= theOther, "Expected $this to be less or equal to $theOther")
+infix fun Long.shouldBeLessOrEqualTo(theOther: Long) = assertThat(this <= theOther).`as`("Expected $this to be less or equal to $theOther").isTrue()
 
-infix fun Float.shouldBeLessOrEqualTo(theOther: Float) = assertTrue(this <= theOther, "Expected $this to be less or equal to $theOther")
+infix fun Float.shouldBeLessOrEqualTo(theOther: Float) = assertThat(this <= theOther).`as`("Expected $this to be less or equal to $theOther").isTrue()
 
-infix fun Double.shouldBeLessOrEqualTo(theOther: Double) = assertTrue(this <= theOther, "Expected $this to be less or equal to $theOther")
+infix fun Double.shouldBeLessOrEqualTo(theOther: Double) = assertThat(this <= theOther).`as`("Expected $this to be less or equal to $theOther").isTrue()
 
-infix fun Byte.shouldNotBeLessOrEqualTo(theOther: Byte) = assertTrue(this > theOther, "Expected $this to not be less or equal to $theOther")
+infix fun Byte.shouldNotBeLessOrEqualTo(theOther: Byte) = assertThat(this > theOther).`as`("Expected $this to not be less or equal to $theOther").isTrue()
 
-infix fun Short.shouldNotBeLessOrEqualTo(theOther: Short) = assertTrue(this > theOther, "Expected $this to not be less or equal to $theOther")
+infix fun Short.shouldNotBeLessOrEqualTo(theOther: Short) = assertThat(this > theOther).`as`("Expected $this to not be less or equal to $theOther").isTrue()
 
-infix fun Int.shouldNotBeLessOrEqualTo(theOther: Int) = assertTrue(this > theOther, "Expected $this to not be less or equal to $theOther")
+infix fun Int.shouldNotBeLessOrEqualTo(theOther: Int) = assertThat(this > theOther).`as`("Expected $this to not be less or equal to $theOther").isTrue()
 
-infix fun Long.shouldNotBeLessOrEqualTo(theOther: Long) = assertTrue(this > theOther, "Expected $this to not be less or equal to $theOther")
+infix fun Long.shouldNotBeLessOrEqualTo(theOther: Long) = assertThat(this > theOther).`as`("Expected $this to not be less or equal to $theOther").isTrue()
 
-infix fun Float.shouldNotBeLessOrEqualTo(theOther: Float) = assertTrue(this > theOther, "Expected $this to not be less or equal to $theOther")
+infix fun Float.shouldNotBeLessOrEqualTo(theOther: Float) = assertThat(this > theOther).`as`("Expected $this to not be less or equal to $theOther").isTrue()
 
-infix fun Double.shouldNotBeLessOrEqualTo(theOther: Double) = assertTrue(this > theOther, "Expected $this to not be less or equal to $theOther")
+infix fun Double.shouldNotBeLessOrEqualTo(theOther: Double) = assertThat(this > theOther).`as`("Expected $this to not be less or equal to $theOther").isTrue()
 
-fun Byte.shouldBePositive() = assertTrue(this > 0, "Expected $this to be positive")
+fun Byte.shouldBePositive() = assertThat(this > 0).`as`("Expected $this to be positive").isTrue()
 
-fun Short.shouldBePositive() = assertTrue(this > 0, "Expected $this to be positive")
+fun Short.shouldBePositive() = assertThat(this > 0).`as`("Expected $this to be positive").isTrue()
 
-fun Int.shouldBePositive() = assertTrue(this > 0, "Expected $this to be positive")
+fun Int.shouldBePositive() = assertThat(this > 0).`as`("Expected $this to be positive").isTrue()
 
-fun Long.shouldBePositive() = assertTrue(this > 0, "Expected $this to be positive")
+fun Long.shouldBePositive() = assertThat(this > 0).`as`("Expected $this to be positive").isTrue()
 
-fun Float.shouldBePositive() = assertTrue(this > 0, "Expected $this to be positive")
+fun Float.shouldBePositive() = assertThat(this > 0).`as`("Expected $this to be positive").isTrue()
 
-fun Double.shouldBePositive() = assertTrue(this > 0, "Expected $this to be positive")
+fun Double.shouldBePositive() = assertThat(this > 0).`as`("Expected $this to be positive").isTrue()
 
-fun Byte.shouldBeNegative() = assertTrue(this < 0, "Expected $this to be negative")
+fun Byte.shouldBeNegative() = assertThat(this < 0).`as`("Expected $this to be negative").isTrue()
 
-fun Short.shouldBeNegative() = assertTrue(this < 0, "Expected $this to be negative")
+fun Short.shouldBeNegative() = assertThat(this < 0).`as`("Expected $this to be negative").isTrue()
 
-fun Int.shouldBeNegative() = assertTrue(this < 0, "Expected $this to be negative")
+fun Int.shouldBeNegative() = assertThat(this < 0).`as`("Expected $this to be negative").isTrue()
 
-fun Long.shouldBeNegative() = assertTrue(this < 0, "Expected $this to be negative")
+fun Long.shouldBeNegative() = assertThat(this < 0).`as`("Expected $this to be negative").isTrue()
 
-fun Float.shouldBeNegative() = assertTrue(this < 0, "Expected $this to be negative")
+fun Float.shouldBeNegative() = assertThat(this < 0).`as`("Expected $this to be negative").isTrue()
 
-fun Double.shouldBeNegative() = assertTrue(this < 0, "Expected $this to be negative")
+fun Double.shouldBeNegative() = assertThat(this < 0).`as`("Expected $this to be negative").isTrue()
 
-fun Byte.shouldBeInRange(lowerBound: Byte, upperBound: Byte) = assertTrue(this >= lowerBound && this <= upperBound, "Expected $this to be between (and including) $lowerBound and $upperBound")
+fun Byte.shouldBeInRange(lowerBound: Byte, upperBound: Byte) = assertThat(this >= lowerBound && this <= upperBound).`as`("Expected $this to be between (and including) $lowerBound and $upperBound").isTrue()
 
-fun Short.shouldBeInRange(lowerBound: Short, upperBound: Short) = assertTrue(this >= lowerBound && this <= upperBound, "Expected $this to be between (and including) $lowerBound and $upperBound")
+fun Short.shouldBeInRange(lowerBound: Short, upperBound: Short) = assertThat(this >= lowerBound && this <= upperBound).`as`("Expected $this to be between (and including) $lowerBound and $upperBound").isTrue()
 
-fun Int.shouldBeInRange(lowerBound: Int, upperBound: Int) = assertTrue(this >= lowerBound && this <= upperBound, "Expected $this to be between (and including) $lowerBound and $upperBound")
+fun Int.shouldBeInRange(lowerBound: Int, upperBound: Int) = assertThat(this >= lowerBound && this <= upperBound).`as`("Expected $this to be between (and including) $lowerBound and $upperBound").isTrue()
 
-fun Long.shouldBeInRange(lowerBound: Long, upperBound: Long) = assertTrue(this >= lowerBound && this <= upperBound, "Expected $this to be between (and including) $lowerBound and $upperBound")
+fun Long.shouldBeInRange(lowerBound: Long, upperBound: Long) = assertThat(this >= lowerBound && this <= upperBound).`as`("Expected $this to be between (and including) $lowerBound and $upperBound").isTrue()
 
-fun Float.shouldBeInRange(lowerBound: Float, upperBound: Float) = assertTrue(this >= lowerBound && this <= upperBound, "Expected $this to be between (and including) $lowerBound and $upperBound")
+fun Float.shouldBeInRange(lowerBound: Float, upperBound: Float) = assertThat(this >= lowerBound && this <= upperBound).`as`("Expected $this to be between (and including) $lowerBound and $upperBound").isTrue()
 
-fun Double.shouldBeInRange(lowerBound: Double, upperBound: Double) = assertTrue(this >= lowerBound && this <= upperBound, "Expected $this to be between (and including) $lowerBound and $upperBound")
+fun Double.shouldBeInRange(lowerBound: Double, upperBound: Double) = assertThat(this >= lowerBound && this <= upperBound).`as`("Expected $this to be between (and including) $lowerBound and $upperBound").isTrue()
 
-fun Byte.shouldNotBeInRange(lowerBound: Byte, upperBound: Byte) = assertTrue(this < lowerBound || this > upperBound, "Expected $this to not be between (and including) $lowerBound and $upperBound")
+fun Byte.shouldNotBeInRange(lowerBound: Byte, upperBound: Byte) = assertThat(this < lowerBound || this > upperBound).`as`("Expected $this to not be between (and including) $lowerBound and $upperBound").isTrue()
 
-fun Short.shouldNotBeInRange(lowerBound: Short, upperBound: Short) = assertTrue(this < lowerBound || this > upperBound, "Expected $this to not be between (and including) $lowerBound and $upperBound")
+fun Short.shouldNotBeInRange(lowerBound: Short, upperBound: Short) = assertThat(this < lowerBound || this > upperBound).`as`("Expected $this to not be between (and including) $lowerBound and $upperBound").isTrue()
 
-fun Int.shouldNotBeInRange(lowerBound: Int, upperBound: Int) = assertTrue(this < lowerBound || this > upperBound, "Expected $this to not be between (and including) $lowerBound and $upperBound")
+fun Int.shouldNotBeInRange(lowerBound: Int, upperBound: Int) = assertThat(this < lowerBound || this > upperBound).`as`("Expected $this to not be between (and including) $lowerBound and $upperBound").isTrue()
 
-fun Long.shouldNotBeInRange(lowerBound: Long, upperBound: Long) = assertTrue(this < lowerBound || this > upperBound, "Expected $this to not be between (and including) $lowerBound and $upperBound")
+fun Long.shouldNotBeInRange(lowerBound: Long, upperBound: Long) = assertThat(this < lowerBound || this > upperBound).`as`("Expected $this to not be between (and including) $lowerBound and $upperBound").isTrue()
 
-fun Float.shouldNotBeInRange(lowerBound: Float, upperBound: Float) = assertTrue(this < lowerBound || this > upperBound, "Expected $this to not be between (and including) $lowerBound and $upperBound")
+fun Float.shouldNotBeInRange(lowerBound: Float, upperBound: Float) = assertThat(this < lowerBound || this > upperBound).`as`("Expected $this to not be between (and including) $lowerBound and $upperBound").isTrue()
 
-fun Double.shouldNotBeInRange(lowerBound: Double, upperBound: Double) = assertTrue(this < lowerBound || this > upperBound, "Expected $this to not be between (and including) $lowerBound and $upperBound")
+fun Double.shouldNotBeInRange(lowerBound: Double, upperBound: Double) = assertThat(this < lowerBound || this > upperBound).`as`("Expected $this to not be between (and including) $lowerBound and $upperBound").isTrue()
 
 infix fun Byte.shouldBeInRange(range: IntRange) = (this.toInt()).shouldBeInRange(range)
 

--- a/src/main/kotlin/org/amshove/kluent/Numerical.kt
+++ b/src/main/kotlin/org/amshove/kluent/Numerical.kt
@@ -28,149 +28,293 @@ infix fun Float.shouldNotEqualTo(theOther: Float) = assert(this != theOther)
 
 infix fun Double.shouldNotEqualTo(theOther: Double) = assert(this != theOther)
 
-infix fun Byte.shouldBeGreaterThan(theOther: Byte) = assert(this > theOther, { "Expected $this to be greater than $theOther" })
-
-infix fun Short.shouldBeGreaterThan(theOther: Short) = assert(this > theOther, { "Expected $this to be greater than $theOther" })
-
-infix fun Int.shouldBeGreaterThan(theOther: Int) = assert(this > theOther, { "Expected $this to be greater than $theOther" })
-
-infix fun Long.shouldBeGreaterThan(theOther: Long) = assert(this > theOther, { "Expected $this to be greater than $theOther" })
-
-infix fun Float.shouldBeGreaterThan(theOther: Float) = assert(this > theOther, { "Expected $this to be greater than $theOther" })
-
-infix fun Double.shouldBeGreaterThan(theOther: Double) = assert(this > theOther, { "Expected $this to be greater than $theOther" })
-
-infix fun Byte.shouldNotBeGreaterThan(theOther: Byte) = assert(this <= theOther, { "Expected $this to not be greater than $theOther" })
-
-infix fun Short.shouldNotBeGreaterThan(theOther: Short) = assert(this <= theOther, { "Expected $this to not be greater than $theOther" })
-
-infix fun Int.shouldNotBeGreaterThan(theOther: Int) = assert(this <= theOther, { "Expected $this to not be greater than $theOther" })
-
-infix fun Long.shouldNotBeGreaterThan(theOther: Long) = assert(this <= theOther, { "Expected $this to not be greater than $theOther" })
-
-infix fun Float.shouldNotBeGreaterThan(theOther: Float) = assert(this <= theOther, { "Expected $this to not be greater than $theOther" })
-
-infix fun Double.shouldNotBeGreaterThan(theOther: Double) = assert(this <= theOther, { "Expected $this to not be greater than $theOther" })
-
-infix fun Byte.shouldBeGreaterOrEqualTo(theOther: Byte) = assert(this >= theOther, { "Expected $this to be greater or equal to $theOther" })
-
-infix fun Short.shouldBeGreaterOrEqualTo(theOther: Short) = assert(this >= theOther, { "Expected $this to be greater or equal to $theOther" })
-
-infix fun Int.shouldBeGreaterOrEqualTo(theOther: Int) = assert(this >= theOther, { "Expected $this to be greater or equal to $theOther" })
-
-infix fun Long.shouldBeGreaterOrEqualTo(theOther: Long) = assert(this >= theOther, { "Expected $this to be greater or equal to $theOther" })
-
-infix fun Float.shouldBeGreaterOrEqualTo(theOther: Float) = assert(this >= theOther, { "Expected $this to be greater or equal to $theOther" })
-
-infix fun Double.shouldBeGreaterOrEqualTo(theOther: Double) = assert(this >= theOther, { "Expected $this to be greater or equal to $theOther" })
-
-infix fun Byte.shouldNotBeGreaterOrEqualTo(theOther: Byte) = assert(this < theOther, { "Expected $this to be not be greater or equal to $theOther" })
-
-infix fun Short.shouldNotBeGreaterOrEqualTo(theOther: Short) = assert(this < theOther, { "Expected $this to not be greater or equal to $theOther" })
-
-infix fun Int.shouldNotBeGreaterOrEqualTo(theOther: Int) = assert(this < theOther, { "Expected $this to not be greater or equal to $theOther" })
-
-infix fun Long.shouldNotBeGreaterOrEqualTo(theOther: Long) = assert(this < theOther, { "Expected $this to not be greater or equal to $theOther" })
-
-infix fun Float.shouldNotBeGreaterOrEqualTo(theOther: Float) = assert(this < theOther, { "Expected $this to not be greater or equal to $theOther" })
-
-infix fun Double.shouldNotBeGreaterOrEqualTo(theOther: Double) = assert(this < theOther, { "Expected $this to not be greater or equal to $theOther" })
-
-infix fun Byte.shouldBeLessThan(theOther: Byte) = assert(this < theOther, { "Expected $this to be less than $theOther" })
-
-infix fun Short.shouldBeLessThan(theOther: Short) = assert(this < theOther, { "Expected $this to be less than $theOther" })
-
-infix fun Int.shouldBeLessThan(theOther: Int) = assert(this < theOther, { "Expected $this to be less than $theOther" })
-
-infix fun Long.shouldBeLessThan(theOther: Long) = assert(this < theOther, { "Expected $this to be less than $theOther" })
-
-infix fun Float.shouldBeLessThan(theOther: Float) = assert(this < theOther, { "Expected $this to be less than $theOther" })
-
-infix fun Double.shouldBeLessThan(theOther: Double) = assert(this < theOther, { "Expected $this to be less than $theOther" })
-
-infix fun Byte.shouldNotBeLessThan(theOther: Byte) = assert(this >= theOther, { "Expected $this to not be less than $theOther" })
-
-infix fun Short.shouldNotBeLessThan(theOther: Short) = assert(this >= theOther, { "Expected $this to not be less than $theOther" })
-
-infix fun Int.shouldNotBeLessThan(theOther: Int) = assert(this >= theOther, { "Expected $this to not be less than $theOther" })
-
-infix fun Long.shouldNotBeLessThan(theOther: Long) = assert(this >= theOther, { "Expected $this to not be less than $theOther" })
-
-infix fun Float.shouldNotBeLessThan(theOther: Float) = assert(this >= theOther, { "Expected $this to not be less than $theOther" })
-
-infix fun Double.shouldNotBeLessThan(theOther: Double) = assert(this >= theOther, { "Expected $this to not be less than $theOther" })
-
-infix fun Byte.shouldBeLessOrEqualTo(theOther: Byte) = assert(this <= theOther, { "Expected $this to be less or equal to $theOther" })
-
-infix fun Short.shouldBeLessOrEqualTo(theOther: Short) = assert(this <= theOther, { "Expected $this to be less or equal to $theOther" })
-
-infix fun Int.shouldBeLessOrEqualTo(theOther: Int) = assert(this <= theOther, { "Expected $this to be less or equal to $theOther" })
-
-infix fun Long.shouldBeLessOrEqualTo(theOther: Long) = assert(this <= theOther, { "Expected $this to be less or equal to $theOther" })
-
-infix fun Float.shouldBeLessOrEqualTo(theOther: Float) = assert(this <= theOther, { "Expected $this to be less or equal to $theOther" })
-
-infix fun Double.shouldBeLessOrEqualTo(theOther: Double) = assert(this <= theOther, { "Expected $this to be less or equal to $theOther" })
-
-infix fun Byte.shouldNotBeLessOrEqualTo(theOther: Byte) = assert(this > theOther, { "Expected $this to not be less or equal to $theOther" })
-
-infix fun Short.shouldNotBeLessOrEqualTo(theOther: Short) = assert(this > theOther, { "Expected $this to not be less or equal to $theOther" })
-
-infix fun Int.shouldNotBeLessOrEqualTo(theOther: Int) = assert(this > theOther, { "Expected $this to not be less or equal to $theOther" })
-
-infix fun Long.shouldNotBeLessOrEqualTo(theOther: Long) = assert(this > theOther, { "Expected $this to not be less or equal to $theOther" })
-
-infix fun Float.shouldNotBeLessOrEqualTo(theOther: Float) = assert(this > theOther, { "Expected $this to not be less or equal to $theOther" })
-
-infix fun Double.shouldNotBeLessOrEqualTo(theOther: Double) = assert(this > theOther, { "Expected $this to not be less or equal to $theOther" })
-
-fun Byte.shouldBePositive() = assert(this > 0, { "Expected $this to be positive" })
-
-fun Short.shouldBePositive() = assert(this > 0, { "Expected $this to be positive" })
-
-fun Int.shouldBePositive() = assert(this > 0, { "Expected $this to be positive" })
-
-fun Long.shouldBePositive() = assert(this > 0, { "Expected $this to be positive" })
-
-fun Float.shouldBePositive() = assert(this > 0, { "Expected $this to be positive" })
-
-fun Double.shouldBePositive() = assert(this > 0, { "Expected $this to be positive" })
-
-fun Byte.shouldBeNegative() = assert(this < 0, { "Expected $this to be negative" })
-
-fun Short.shouldBeNegative() = assert(this < 0, { "Expected $this to be negative" })
-
-fun Int.shouldBeNegative() = assert(this < 0, { "Expected $this to be negative" })
-
-fun Long.shouldBeNegative() = assert(this < 0, { "Expected $this to be negative" })
-
-fun Float.shouldBeNegative() = assert(this < 0, { "Expected $this to be negative" })
-
-fun Double.shouldBeNegative() = assert(this < 0, { "Expected $this to be negative" })
-
-fun Byte.shouldBeInRange(lowerBound: Byte, upperBound: Byte) = assert(this >= lowerBound && this <= upperBound, { "Expected $this to be between (and including) $lowerBound and $upperBound" })
-
-fun Short.shouldBeInRange(lowerBound: Short, upperBound: Short) = assert(this >= lowerBound && this <= upperBound, { "Expected $this to be between (and including) $lowerBound and $upperBound" })
-
-fun Int.shouldBeInRange(lowerBound: Int, upperBound: Int) = assert(this >= lowerBound && this <= upperBound, { "Expected $this to be between (and including) $lowerBound and $upperBound" })
-
-fun Long.shouldBeInRange(lowerBound: Long, upperBound: Long) = assert(this >= lowerBound && this <= upperBound, { "Expected $this to be between (and including) $lowerBound and $upperBound" })
-
-fun Float.shouldBeInRange(lowerBound: Float, upperBound: Float) = assert(this >= lowerBound && this <= upperBound, { "Expected $this to be between (and including) $lowerBound and $upperBound" })
-
-fun Double.shouldBeInRange(lowerBound: Double, upperBound: Double) = assert(this >= lowerBound && this <= upperBound, { "Expected $this to be between (and including) $lowerBound and $upperBound" })
-
-fun Byte.shouldNotBeInRange(lowerBound: Byte, upperBound: Byte) = assert(this < lowerBound || this > upperBound, { "Expected $this to not be between (and including) $lowerBound and $upperBound" })
-
-fun Short.shouldNotBeInRange(lowerBound: Short, upperBound: Short) = assert(this < lowerBound || this > upperBound, { "Expected $this to not be between (and including) $lowerBound and $upperBound" })
-
-fun Int.shouldNotBeInRange(lowerBound: Int, upperBound: Int) = assert(this < lowerBound || this > upperBound, { "Expected $this to not be between (and including) $lowerBound and $upperBound" })
-
-fun Long.shouldNotBeInRange(lowerBound: Long, upperBound: Long) = assert(this < lowerBound || this > upperBound, { "Expected $this to not be between (and including) $lowerBound and $upperBound" })
-
-fun Float.shouldNotBeInRange(lowerBound: Float, upperBound: Float) = assert(this < lowerBound || this > upperBound, { "Expected $this to not be between (and including) $lowerBound and $upperBound" })
-
-fun Double.shouldNotBeInRange(lowerBound: Double, upperBound: Double) = assert(this < lowerBound || this > upperBound, { "Expected $this to not be between (and including) $lowerBound and $upperBound" })
+infix fun Byte.shouldBeGreaterThan(theOther: Byte) = assert(this > theOther) {
+    "Expected $this to be greater than $theOther"
+}
+
+infix fun Short.shouldBeGreaterThan(theOther: Short) = assert(this > theOther) {
+    "Expected $this to be greater than $theOther"
+}
+
+infix fun Int.shouldBeGreaterThan(theOther: Int) = assert(this > theOther) {
+    "Expected $this to be greater than $theOther"
+}
+
+infix fun Long.shouldBeGreaterThan(theOther: Long) = assert(this > theOther) {
+    "Expected $this to be greater than $theOther"
+}
+
+infix fun Float.shouldBeGreaterThan(theOther: Float) = assert(this > theOther) {
+    "Expected $this to be greater than $theOther"
+}
+
+infix fun Double.shouldBeGreaterThan(theOther: Double) = assert(this > theOther) {
+    "Expected $this to be greater than $theOther"
+}
+
+infix fun Byte.shouldNotBeGreaterThan(theOther: Byte) = assert(this <= theOther) {
+    "Expected $this to not be greater than $theOther"
+}
+
+infix fun Short.shouldNotBeGreaterThan(theOther: Short) = assert(this <= theOther) {
+    "Expected $this to not be greater than $theOther"
+}
+
+infix fun Int.shouldNotBeGreaterThan(theOther: Int) = assert(this <= theOther) {
+    "Expected $this to not be greater than $theOther"
+}
+
+infix fun Long.shouldNotBeGreaterThan(theOther: Long) = assert(this <= theOther) {
+    "Expected $this to not be greater than $theOther"
+}
+
+infix fun Float.shouldNotBeGreaterThan(theOther: Float) = assert(this <= theOther) {
+    "Expected $this to not be greater than $theOther"
+}
+
+infix fun Double.shouldNotBeGreaterThan(theOther: Double) = assert(this <= theOther) {
+    "Expected $this to not be greater than $theOther"
+}
+
+infix fun Byte.shouldBeGreaterOrEqualTo(theOther: Byte) = assert(this >= theOther) {
+    "Expected $this to be greater or equal to $theOther"
+}
+
+infix fun Short.shouldBeGreaterOrEqualTo(theOther: Short) = assert(this >= theOther) {
+    "Expected $this to be greater or equal to $theOther"
+}
+
+infix fun Int.shouldBeGreaterOrEqualTo(theOther: Int) = assert(this >= theOther) {
+    "Expected $this to be greater or equal to $theOther"
+}
+
+infix fun Long.shouldBeGreaterOrEqualTo(theOther: Long) = assert(this >= theOther) {
+    "Expected $this to be greater or equal to $theOther"
+}
+
+infix fun Float.shouldBeGreaterOrEqualTo(theOther: Float) = assert(this >= theOther) {
+    "Expected $this to be greater or equal to $theOther"
+}
+
+infix fun Double.shouldBeGreaterOrEqualTo(theOther: Double) = assert(this >= theOther) {
+    "Expected $this to be greater or equal to $theOther"
+}
+
+infix fun Byte.shouldNotBeGreaterOrEqualTo(theOther: Byte) = assert(this < theOther) {
+    "Expected $this to be not be greater or equal to $theOther"
+}
+
+infix fun Short.shouldNotBeGreaterOrEqualTo(theOther: Short) = assert(this < theOther) {
+    "Expected $this to not be greater or equal to $theOther"
+}
+
+infix fun Int.shouldNotBeGreaterOrEqualTo(theOther: Int) = assert(this < theOther) {
+    "Expected $this to not be greater or equal to $theOther"
+}
+
+infix fun Long.shouldNotBeGreaterOrEqualTo(theOther: Long) = assert(this < theOther) {
+    "Expected $this to not be greater or equal to $theOther"
+}
+
+infix fun Float.shouldNotBeGreaterOrEqualTo(theOther: Float) = assert(this < theOther) {
+    "Expected $this to not be greater or equal to $theOther"
+}
+
+infix fun Double.shouldNotBeGreaterOrEqualTo(theOther: Double) = assert(this < theOther) {
+    "Expected $this to not be greater or equal to $theOther"
+}
+
+infix fun Byte.shouldBeLessThan(theOther: Byte) = assert(this < theOther) {
+    "Expected $this to be less than $theOther"
+}
+
+infix fun Short.shouldBeLessThan(theOther: Short) = assert(this < theOther) {
+    "Expected $this to be less than $theOther"
+}
+
+infix fun Int.shouldBeLessThan(theOther: Int) = assert(this < theOther) {
+    "Expected $this to be less than $theOther"
+}
+
+infix fun Long.shouldBeLessThan(theOther: Long) = assert(this < theOther) {
+    "Expected $this to be less than $theOther"
+}
+
+infix fun Float.shouldBeLessThan(theOther: Float) = assert(this < theOther) {
+    "Expected $this to be less than $theOther"
+}
+
+infix fun Double.shouldBeLessThan(theOther: Double) = assert(this < theOther) {
+    "Expected $this to be less than $theOther"
+}
+
+infix fun Byte.shouldNotBeLessThan(theOther: Byte) = assert(this >= theOther) {
+    "Expected $this to not be less than $theOther"
+}
+
+infix fun Short.shouldNotBeLessThan(theOther: Short) = assert(this >= theOther) {
+    "Expected $this to not be less than $theOther"
+}
+
+infix fun Int.shouldNotBeLessThan(theOther: Int) = assert(this >= theOther) {
+    "Expected $this to not be less than $theOther"
+}
+
+infix fun Long.shouldNotBeLessThan(theOther: Long) = assert(this >= theOther) {
+    "Expected $this to not be less than $theOther"
+}
+
+infix fun Float.shouldNotBeLessThan(theOther: Float) = assert(this >= theOther) {
+    "Expected $this to not be less than $theOther"
+}
+
+infix fun Double.shouldNotBeLessThan(theOther: Double) = assert(this >= theOther) {
+    "Expected $this to not be less than $theOther"
+}
+
+infix fun Byte.shouldBeLessOrEqualTo(theOther: Byte) = assert(this <= theOther) {
+    "Expected $this to be less or equal to $theOther"
+}
+
+infix fun Short.shouldBeLessOrEqualTo(theOther: Short) = assert(this <= theOther) {
+    "Expected $this to be less or equal to $theOther"
+}
+
+infix fun Int.shouldBeLessOrEqualTo(theOther: Int) = assert(this <= theOther) {
+    "Expected $this to be less or equal to $theOther"
+}
+
+infix fun Long.shouldBeLessOrEqualTo(theOther: Long) = assert(this <= theOther) {
+    "Expected $this to be less or equal to $theOther"
+}
+
+infix fun Float.shouldBeLessOrEqualTo(theOther: Float) = assert(this <= theOther) {
+    "Expected $this to be less or equal to $theOther"
+}
+
+infix fun Double.shouldBeLessOrEqualTo(theOther: Double) = assert(this <= theOther) {
+    "Expected $this to be less or equal to $theOther"
+}
+
+infix fun Byte.shouldNotBeLessOrEqualTo(theOther: Byte) = assert(this > theOther) {
+    "Expected $this to not be less or equal to $theOther"
+}
+
+infix fun Short.shouldNotBeLessOrEqualTo(theOther: Short) = assert(this > theOther) {
+    "Expected $this to not be less or equal to $theOther"
+}
+
+infix fun Int.shouldNotBeLessOrEqualTo(theOther: Int) = assert(this > theOther) {
+    "Expected $this to not be less or equal to $theOther"
+}
+
+infix fun Long.shouldNotBeLessOrEqualTo(theOther: Long) = assert(this > theOther) {
+    "Expected $this to not be less or equal to $theOther"
+}
+
+infix fun Float.shouldNotBeLessOrEqualTo(theOther: Float) = assert(this > theOther) {
+    "Expected $this to not be less or equal to $theOther"
+}
+
+infix fun Double.shouldNotBeLessOrEqualTo(theOther: Double) = assert(this > theOther) {
+    "Expected $this to not be less or equal to $theOther"
+}
+
+fun Byte.shouldBePositive() = assert(this > 0) {
+    "Expected $this to be positive"
+}
+
+fun Short.shouldBePositive() = assert(this > 0) {
+    "Expected $this to be positive"
+}
+
+fun Int.shouldBePositive() = assert(this > 0) {
+    "Expected $this to be positive"
+}
+
+fun Long.shouldBePositive() = assert(this > 0) {
+    "Expected $this to be positive"
+}
+
+fun Float.shouldBePositive() = assert(this > 0) {
+    "Expected $this to be positive"
+}
+
+fun Double.shouldBePositive() = assert(this > 0) {
+    "Expected $this to be positive"
+}
+
+fun Byte.shouldBeNegative() = assert(this < 0) {
+    "Expected $this to be negative"
+}
+
+fun Short.shouldBeNegative() = assert(this < 0) {
+    "Expected $this to be negative"
+}
+
+fun Int.shouldBeNegative() = assert(this < 0) {
+    "Expected $this to be negative"
+}
+
+fun Long.shouldBeNegative() = assert(this < 0) {
+    "Expected $this to be negative"
+}
+
+fun Float.shouldBeNegative() = assert(this < 0) {
+    "Expected $this to be negative"
+}
+
+fun Double.shouldBeNegative() = assert(this < 0) {
+    "Expected $this to be negative"
+}
+
+fun Byte.shouldBeInRange(lowerBound: Byte, upperBound: Byte) = assert(this >= lowerBound && this <= upperBound) {
+    "Expected $this to be between (and including) $lowerBound and $upperBound"
+}
+
+fun Short.shouldBeInRange(lowerBound: Short, upperBound: Short) = assert(this >= lowerBound && this <= upperBound) {
+    "Expected $this to be between (and including) $lowerBound and $upperBound"
+}
+
+fun Int.shouldBeInRange(lowerBound: Int, upperBound: Int) = assert(this >= lowerBound && this <= upperBound) {
+    "Expected $this to be between (and including) $lowerBound and $upperBound"
+}
+
+fun Long.shouldBeInRange(lowerBound: Long, upperBound: Long) = assert(this >= lowerBound && this <= upperBound) {
+    "Expected $this to be between (and including) $lowerBound and $upperBound"
+}
+
+fun Float.shouldBeInRange(lowerBound: Float, upperBound: Float) = assert(this >= lowerBound && this <= upperBound) {
+    "Expected $this to be between (and including) $lowerBound and $upperBound"
+}
+
+fun Double.shouldBeInRange(lowerBound: Double, upperBound: Double) = assert(this >= lowerBound && this <= upperBound) {
+    "Expected $this to be between (and including) $lowerBound and $upperBound"
+}
+
+fun Byte.shouldNotBeInRange(lowerBound: Byte, upperBound: Byte) = assert(this < lowerBound || this > upperBound) {
+    "Expected $this to not be between (and including) $lowerBound and $upperBound"
+}
+
+fun Short.shouldNotBeInRange(lowerBound: Short, upperBound: Short) = assert(this < lowerBound || this > upperBound) {
+    "Expected $this to not be between (and including) $lowerBound and $upperBound"
+}
+
+fun Int.shouldNotBeInRange(lowerBound: Int, upperBound: Int) = assert(this < lowerBound || this > upperBound) {
+    "Expected $this to not be between (and including) $lowerBound and $upperBound"
+}
+
+fun Long.shouldNotBeInRange(lowerBound: Long, upperBound: Long) = assert(this < lowerBound || this > upperBound) {
+    "Expected $this to not be between (and including) $lowerBound and $upperBound"
+}
+
+fun Float.shouldNotBeInRange(lowerBound: Float, upperBound: Float) = assert(this < lowerBound || this > upperBound) {
+    "Expected $this to not be between (and including) $lowerBound and $upperBound"
+}
+
+fun Double.shouldNotBeInRange(lowerBound: Double, upperBound: Double) = assert(this < lowerBound || this > upperBound) {
+    "Expected $this to not be between (and including) $lowerBound and $upperBound"
+}
 
 infix fun Byte.shouldBeInRange(range: IntRange) = (this.toInt()).shouldBeInRange(range)
 

--- a/src/test/kotlin/org/amshove/kluent/tests/HelperMethods.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/HelperMethods.kt
@@ -1,15 +1,16 @@
 package org.amshove.kluent.tests
 
-import org.junit.ComparisonFailure
+import org.opentest4j.AssertionFailedError
 
-fun getFailure(func: () -> Unit): ComparisonFailure {
+fun getFailure(func: () -> Unit): FailureMessage {
     try {
         func.invoke()
         throw Exception("Test didn't fail")
-    } catch (f: ComparisonFailure) {
-        return f
+    } catch (f: AssertionFailedError) {
+        return FailureMessage(f.actual.stringRepresentation, f.expected.stringRepresentation)
     } catch (e: Exception) {
         throw Exception("Test didn't fail")
     }
 }
 
+class FailureMessage(val actual: String, val expected: String)

--- a/src/test/kotlin/org/amshove/kluent/tests/HelperMethods.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/HelperMethods.kt
@@ -3,11 +3,13 @@ package org.amshove.kluent.tests
 import org.opentest4j.AssertionFailedError
 
 fun getFailure(func: () -> Unit): FailureMessage {
-    try {
+    return try {
         func.invoke()
         throw Exception("Test didn't fail")
     } catch (f: AssertionFailedError) {
-        return FailureMessage(f.actual.stringRepresentation, f.expected.stringRepresentation)
+        FailureMessage(f.actual.stringRepresentation, f.expected.stringRepresentation)
+    } catch (f: AssertionError) {
+        FailureMessage(f.message.orEmpty(), f.message.orEmpty())
     } catch (e: Exception) {
         throw Exception("Test didn't fail")
     }

--- a/src/test/kotlin/org/amshove/kluent/tests/assertions/ShouldEqualTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/assertions/ShouldEqualTests.kt
@@ -3,7 +3,6 @@ package org.amshove.kluent.tests.assertions
 import org.amshove.kluent.shouldEqual
 import org.amshove.kluent.tests.helpclasses.Person
 import org.jetbrains.spek.api.Spek
-import java.time.Duration
 import kotlin.test.assertFails
 
 class ShouldEqualTests : Spek({
@@ -42,6 +41,28 @@ class ShouldEqualTests : Spek({
             val secondArray = arrayOf(4, 5, 6)
             it("should fail") {
                 assertFails({ firstArray shouldEqual secondArray })
+            }
+        }
+        on("checking two empty arrays") {
+            val firstArray = emptyArray<Int>()
+            val secondArray = emptyArray<Int>()
+            it("should pass") {
+                firstArray shouldEqual secondArray
+            }
+        }
+        on("checking two null arrays") {
+            val firstArray: Array<Any>? = null
+            val secondArray = arrayOf(4, 5, 6)
+            it("should pass") {
+                assertFails({ firstArray shouldEqual secondArray })
+                assertFails({ secondArray shouldEqual firstArray })
+            }
+        }
+        on("checking two null arrays") {
+            val firstArray: Array<Any>? = null
+            val secondArray: Array<Any>? = null
+            it("should pass") {
+                firstArray shouldEqual secondArray
             }
         }
         on("checking two equal iterables") {


### PR DESCRIPTION
Removes dependency from `JUnit`. Project internally uses `kotlintest`

Users can choose their own test runners ([JUnit 4](http://junit.org/junit4/), [JUnit 5](http://junit.org/junit5/) or [Spek](http://spekframework.org/)). Kluent provides a fluent wrapper around [kotlintest](https://github.com/kotlintest/kotlintest).

**Note:**

- Major version has been bumped from 1.x to 2.x