### PR TITLE
Expect an Exception instance to be thrown compared by equals

### DIFF
--- a/src/main/kotlin/org/amshove/kluent/Exceptions.kt
+++ b/src/main/kotlin/org/amshove/kluent/Exceptions.kt
@@ -27,6 +27,17 @@ infix fun <T : Throwable> (() -> Any?).shouldNotThrow(expectedException: KClass<
     }
 }
 
+infix fun <T : Throwable> (() -> Any?).shouldThrow(expectedException: T) {
+    try {
+        this.invoke()
+        fail("There was an Exception expected to be thrown, but nothing was thrown", "$expectedException", "None")
+    } catch (e: Throwable) {
+        if (!e.equals(expectedException)) {
+            throw ComparisonFailure("Expected ${expectedException} to be thrown", "${expectedException}", "${e.javaClass}")
+        }
+    }
+}
+
 @Deprecated("Use shouldThrow instead", ReplaceWith("x shouldThrow expectedException"))
 infix fun <T : Throwable> (() -> Any).shouldThrowTheException(expectedException: KClass<T>): ExceptionResult<T> = this shouldThrow expectedException
 

--- a/src/test/kotlin/org/amshove/kluent/tests/assertions/ShouldThrowTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/assertions/ShouldThrowTests.kt
@@ -92,7 +92,7 @@ class ShouldThrowTests : Spek({
         }
 
         given("a custom exception") {
-            class CustomException(val code: Int) : Exception("code is $code")
+            data class CustomException(val code: Int) : Exception("code is $code")
 
             on("throwing an exception of the right type") {
                 it("should return the exception result with the given type") {
@@ -102,10 +102,25 @@ class ShouldThrowTests : Spek({
                     func.shouldThrow(CustomException::class).exception.code.shouldEqualTo(10)
                 }
             }
+
             on("throwing an exception of the wrong type") {
                 it("should fail") {
                     val func = { throw IllegalArgumentException() }
                     assertFails { func.shouldThrow(CustomException::class).exception.code.shouldEqualTo(10) }
+                }
+            }
+
+            on("expecting an exact thrown exception") {
+                it("should pass") {
+                    val func = { throw CustomException(12345) }
+                    func shouldThrow CustomException(12345)
+                }
+            }
+
+            on("expecting an exact thrown exception with wrong field values") {
+                it("should failing") {
+                    val func = { throw CustomException(12345) }
+                    assertFails({ func shouldThrow CustomException(54321) })
                 }
             }
         }


### PR DESCRIPTION
This change enables to expect an exception to be thrown by a block
compared by the .equals method. This provides a more readable
and maintainable way when you deal with exceptions that contain lots of
fields. So you can use this instead of checking every single field.