### PR TITLE
Resolves #83 - `itAnswers` should allow original Mockito Answer types

### DIFF
--- a/src/main/kotlin/org/amshove/kluent/Mocking.kt
+++ b/src/main/kotlin/org/amshove/kluent/Mocking.kt
@@ -4,9 +4,11 @@ import com.nhaarman.mockito_kotlin.never
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
 import com.nhaarman.mockito_kotlin.verifyZeroInteractions
+import org.mockito.AdditionalAnswers.*
 import org.mockito.Mockito.`when`
 import org.mockito.internal.util.MockUtil
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.Answer
 import org.mockito.stubbing.OngoingStubbing
 import kotlin.reflect.KClass
 
@@ -35,6 +37,8 @@ inline fun <reified T : Any> any(kClass: KClass<T>): T = any()
 
 inline fun <reified T : Any> any(): T = com.nhaarman.mockito_kotlin.any()
 
+infix fun <T> WhenKeyword.calling(methodCall: T): OngoingStubbing<T> = `when`(methodCall)
+
 infix fun <T> OngoingStubbing<T>.itReturns(value: T): OngoingStubbing<T> = this.thenReturn(value)
 
 infix fun <T> OngoingStubbing<T>.itThrows(value: RuntimeException): OngoingStubbing<T> = this.thenThrow(value)
@@ -43,8 +47,19 @@ infix fun <T> OngoingStubbing<T>.itThrows(value: Error): OngoingStubbing<T> = th
 
 infix fun <T> OngoingStubbing<T>.itAnswers(value: (InvocationOnMock) -> T): OngoingStubbing<T> = this.thenAnswer(value)
 
-infix fun <T> WhenKeyword.calling(methodCall: T): OngoingStubbing<T> = `when`(methodCall)
+infix fun <T> OngoingStubbing<T>.itAnswers(value: Answer<T>): OngoingStubbing<T> = this.thenAnswer(value)
 
+/**
+ * Returns the parameter of an invocation at the given position.
+ * @param position Location of the parameter to return, zero based.
+ * @see [returnsArgAt]
+ */
+fun <T> withArgAt(position: Int): Answer<T> = returnsArgAt(position)
+fun <T> withFirstArg(): Answer<T> = returnsFirstArg()
+fun <T> withSecondArg(): Answer<T> = returnsSecondArg()
+fun <T> withThirdArg(): Answer<T> = withArgAt(2)
+fun <T> withFourthArg(): Answer<T> = withArgAt(3)
+fun <T> withLastArg(): Answer<T> = returnsLastArg()
 
 private fun <T> ensureMock(obj: T) {
     if (!MockUtil.isMock(obj)) {

--- a/src/main/kotlin/org/amshove/kluent/MockingBacktick.kt
+++ b/src/main/kotlin/org/amshove/kluent/MockingBacktick.kt
@@ -1,11 +1,13 @@
 package org.amshove.kluent
 
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.Answer
 import org.mockito.stubbing.OngoingStubbing
 
 infix fun <T> OngoingStubbing<T>.`it returns`(value: T) = this.itReturns(value)
 infix fun <T> OngoingStubbing<T>.`it throws`(value: RuntimeException) = this.itThrows(value)
 infix fun <T> OngoingStubbing<T>.`it throws`(value: Error) = this.itThrows(value)
 infix fun <T> OngoingStubbing<T>.`it answers`(value: (InvocationOnMock) -> T) = this.itAnswers(value)
+infix fun <T> OngoingStubbing<T>.`it answers`(value: Answer<T>) = this.itAnswers(value)
 val `Verify no interactions` = VerifyNoInteractions
 val `Verify no further interactions` = VerifyNoFurtherInteractions

--- a/src/test/kotlin/org/amshove/kluent/tests/backtickmockings/StubTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/backtickmockings/StubTests.kt
@@ -1,8 +1,10 @@
 package org.amshove.kluent.tests.backtickmockings
 
+import com.nhaarman.mockito_kotlin.reset
 import org.amshove.kluent.*
 import org.amshove.kluent.tests.helpclasses.Database
 import org.amshove.kluent.tests.helpclasses.Person
+import org.amshove.kluent.tests.helpclasses.Sizes
 import org.jetbrains.spek.api.Spek
 import org.junit.Assert.assertSame
 import org.mockito.exceptions.misusing.InvalidUseOfMatchersException
@@ -55,6 +57,36 @@ class StubTests : Spek({
                 When calling mock.getPerson() `it returns` any()
                 val func = { mock.getPerson() }
                 func `should throw` InvalidUseOfMatchersException::class
+            }
+        }
+        context("with specific arguments") {
+            val mock = mock(Sizes::class)
+            val firstArg = 1
+            val secondArg = 2
+            val thirdArg = 3
+            val fourthArg = 4
+            val fifthArg = 5
+            val sixthArg = 6
+
+            afterEach {
+                reset(mock)
+            }
+
+            on("telling it to return the first argument") {
+                it("returns the first argument") {
+                    When calling mock.getValue(any(), any(), any(), any(), any(), any()) `it answers` withFirstArg()
+
+                    val result = mock.getValue(firstArg, secondArg, thirdArg, fourthArg, fifthArg, sixthArg)
+                    assertEquals(firstArg, result)
+                }
+            }
+            on("telling it to return the argument in the last spot") {
+                it("returns the last argument") {
+                    When calling mock.getValue(any(), any(), any(), any(), any(), any()) `it answers` withLastArg()
+
+                    val result = mock.getValue(firstArg, secondArg, thirdArg, fourthArg, fifthArg, sixthArg)
+                    assertEquals(sixthArg, result)
+                }
             }
         }
     }

--- a/src/test/kotlin/org/amshove/kluent/tests/helpclasses/Interfaces.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/helpclasses/Interfaces.kt
@@ -10,3 +10,7 @@ interface Shape {
     fun getArea(): Double
 }
 
+interface Sizes {
+    fun getValue(firstArg: Int, secondArg: Int, thirdArg: Int, fourthArg: Int, fifthArg: Int, sixthArg: Int): Int
+}
+

--- a/src/test/kotlin/org/amshove/kluent/tests/mocking/StubTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/mocking/StubTests.kt
@@ -1,10 +1,14 @@
 package org.amshove.kluent.tests.mocking
 
+import com.nhaarman.mockito_kotlin.anyVararg
+import com.nhaarman.mockito_kotlin.reset
 import org.amshove.kluent.*
 import org.amshove.kluent.tests.helpclasses.Database
 import org.amshove.kluent.tests.helpclasses.Person
+import org.amshove.kluent.tests.helpclasses.Sizes
 import org.jetbrains.spek.api.Spek
 import org.junit.Assert.assertSame
+import org.mockito.ArgumentMatchers.anyList
 import org.mockito.exceptions.misusing.InvalidUseOfMatchersException
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -62,6 +66,69 @@ class StubTests : Spek({
                 When calling mock.getPerson() itReturns any()
                 val func = { mock.getPerson() }
                 func shouldThrow InvalidUseOfMatchersException::class
+            }
+        }
+
+        context("with specific arguments") {
+            val mock = mock(Sizes::class)
+            val firstArg = 1
+            val secondArg = 2
+            val thirdArg = 3
+            val fourthArg = 4
+            val fifthArg = 5
+            val sixthArg = 6
+
+            afterEach {
+                reset(mock)
+            }
+
+            on("telling it to return the first argument") {
+                it("returns the first argument") {
+                    When calling mock.getValue(any(), any(), any(), any(), any(), any()) itAnswers withFirstArg()
+
+                    val result = mock.getValue(firstArg, secondArg, thirdArg, fourthArg, fifthArg, sixthArg)
+                    assertEquals(firstArg, result)
+                }
+            }
+            on("telling it to return the second argument") {
+                it("returns the second argument") {
+                    When calling mock.getValue(any(), any(), any(), any(), any(), any()) itAnswers withSecondArg()
+
+                    val result = mock.getValue(firstArg, secondArg, thirdArg, fourthArg, fifthArg, sixthArg)
+                    assertEquals(secondArg, result)
+                }
+            }
+            on("telling it to return the third argument") {
+                it("returns the third argument") {
+                    When calling mock.getValue(any(), any(), any(), any(), any(), any()) itAnswers withThirdArg()
+
+                    val result = mock.getValue(firstArg, secondArg, thirdArg, fourthArg, fifthArg, sixthArg)
+                    assertEquals(thirdArg, result)
+                }
+            }
+            on("telling it to return the fourth argument") {
+                it("returns the fourth argument") {
+                    When calling mock.getValue(any(), any(), any(), any(), any(), any()) itAnswers withFourthArg()
+
+                    val result = mock.getValue(firstArg, secondArg, thirdArg, fourthArg, fifthArg, sixthArg)
+                    assertEquals(fourthArg, result)
+                }
+            }
+            on("telling it to return the argument in the fifth spot") {
+                it("returns the fifth spot argument") {
+                    When calling mock.getValue(any(), any(), any(), any(), any(), any()) itAnswers withArgAt(4)
+
+                    val result = mock.getValue(firstArg, secondArg, thirdArg, fourthArg, fifthArg, sixthArg)
+                    assertEquals(fifthArg, result)
+                }
+            }
+            on("telling it to return the argument in the last spot") {
+                it("returns the last argument") {
+                    When calling mock.getValue(any(), any(), any(), any(), any(), any()) itAnswers withLastArg()
+
+                    val result = mock.getValue(firstArg, secondArg, thirdArg, fourthArg, fifthArg, sixthArg)
+                    assertEquals(sixthArg, result)
+                }
             }
         }
     }


### PR DESCRIPTION
- Added new `itAnswers` method that takes an `Answer<T>` instance
- Added simple parameter location methods like `withFirstArg` and `withLastArg`
- Added new `it answers` method