### PR TITLE
CharSequence shouldNotBeNullOrBlank (/empty) does not return non null

### DIFF
--- a/src/main/kotlin/org/amshove/kluent/CharSequence.kt
+++ b/src/main/kotlin/org/amshove/kluent/CharSequence.kt
@@ -2,47 +2,33 @@ package org.amshove.kluent
 
 import org.junit.Assert.*
 
-infix fun CharSequence.shouldStartWith(expected: CharSequence) =
-    this.apply { assertTrue("Expected the CharSequence $this to start with $expected", this.startsWith(expected)) }
+infix fun CharSequence.shouldStartWith(expected: CharSequence) = this.apply { assertTrue("Expected the CharSequence $this to start with $expected", this.startsWith(expected)) }
 
-infix fun CharSequence.shouldEndWith(expected: CharSequence) =
-    this.apply { assertTrue("Expected the CharSequence $this to end with $expected", this.endsWith(expected)) }
+infix fun CharSequence.shouldEndWith(expected: CharSequence) = this.apply { assertTrue("Expected the CharSequence $this to end with $expected", this.endsWith(expected)) }
 
-infix fun CharSequence.shouldContain(char: Char) =
-    this.apply { assertTrue("Expected '$this' to contain '$char'", this.contains(char)) }
+infix fun CharSequence.shouldContain(char: Char) = this.apply { assertTrue("Expected '$this' to contain '$char'", this.contains(char))}
 
-infix fun CharSequence.shouldContainSome(things: Iterable<CharSequence>) =
-    this.apply { assertTrue("Expected '$this' to contain at least one of $things", things.any { this.contains(it) }) }
+infix fun CharSequence.shouldContainSome(things: Iterable<CharSequence>) = this.apply { assertTrue("Expected '$this' to contain at least one of $things", things.any { this.contains(it) }) }
 
-infix fun CharSequence.shouldContainNone(things: Iterable<CharSequence>) =
-    this.apply { assertTrue("Expected '$this' to not contain any of $things", things.none { this.contains(it) }) }
+infix fun CharSequence.shouldContainNone(things: Iterable<CharSequence>) = this.apply { assertTrue("Expected '$this' to not contain any of $things", things.none { this.contains(it) }) }
 
-infix fun CharSequence.shouldContain(expected: CharSequence) =
-    this.apply { assertTrue("Expected the CharSequence $this to contain $expected", this.contains(expected)) }
+infix fun CharSequence.shouldContain(expected: CharSequence) = this.apply { assertTrue("Expected the CharSequence $this to contain $expected", this.contains(expected)) }
 
-infix fun CharSequence.shouldNotContain(char: Char) =
-    this.apply { assertFalse("Expected '$this' to not contain '$char'", this.contains(char)) }
+infix fun CharSequence.shouldNotContain(char: Char) = this.apply { assertFalse("Expected '$this' to not contain '$char'", this.contains(char))}
 
-infix fun CharSequence.shouldNotContainAny(things: Iterable<CharSequence>) =
-    this.apply { this shouldContainNone things }
+infix fun CharSequence.shouldNotContainAny(things: Iterable<CharSequence>) = this.apply { this shouldContainNone things }
 
-infix fun CharSequence.shouldMatch(regex: String) =
-    this.apply { assertTrue("Expected $this to match $regex", this.matches(Regex(regex))) }
+infix fun CharSequence.shouldMatch(regex: String) = this.apply { assertTrue("Expected $this to match $regex", this.matches(Regex(regex))) }
 
-infix fun CharSequence.shouldMatch(regex: Regex) =
-    this.apply { assertTrue("Expected $this to match ${regex.pattern}", this.matches(regex)) }
+infix fun CharSequence.shouldMatch(regex: Regex) = this.apply { assertTrue("Expected $this to match ${regex.pattern}", this.matches(regex)) }
 
-fun CharSequence.shouldBeEmpty() =
-    this.apply { assertTrue("Expected the CharSequence to be empty, but was $this", this.isEmpty()) }
+fun CharSequence.shouldBeEmpty() = this.apply { assertTrue("Expected the CharSequence to be empty, but was $this", this.isEmpty()) }
 
-fun CharSequence?.shouldBeNullOrEmpty() =
-    this.apply { assertTrue("Expected $this to be null or empty", this == null || this.isEmpty()) }
+fun CharSequence?.shouldBeNullOrEmpty() = this.apply { assertTrue("Expected $this to be null or empty", this == null || this.isEmpty()) }
 
-fun CharSequence.shouldBeBlank() =
-    this.apply { assertTrue("Expected the CharSequence to be blank, but was $this", this.isBlank()) }
+fun CharSequence.shouldBeBlank() = this.apply { assertTrue("Expected the CharSequence to be blank, but was $this", this.isBlank()) }
 
-fun CharSequence?.shouldBeNullOrBlank() =
-    this.apply { assertTrue("Expected $this to be null or blank", this == null || this.isBlank()) }
+fun CharSequence?.shouldBeNullOrBlank() = this.apply { assertTrue("Expected $this to be null or blank", this == null || this.isBlank()) }
 
 @Deprecated("Use shouldBeEqualTo", ReplaceWith("this.shouldBeEqualTo(expected)"))
 infix fun String.shouldEqualTo(expected: String) = shouldBeEqualTo(expected)
@@ -54,20 +40,15 @@ infix fun String.shouldNotEqualTo(expected: String) = shouldNotBeEqualTo(expecte
 
 infix fun String.shouldNotBeEqualTo(expected: String) = this.apply { assertNotEquals(expected, this) }
 
-infix fun CharSequence.shouldNotStartWith(expected: CharSequence) =
-    this.apply { assertFalse("Expected the CharSequence $this to not start with $expected", this.startsWith(expected)) }
+infix fun CharSequence.shouldNotStartWith(expected: CharSequence) = this.apply { assertFalse("Expected the CharSequence $this to not start with $expected", this.startsWith(expected)) }
 
-infix fun CharSequence.shouldNotEndWith(expected: CharSequence) =
-    this.apply { assertFalse("Expected the CharSequence $this to not end with $expected", this.endsWith(expected)) }
+infix fun CharSequence.shouldNotEndWith(expected: CharSequence) = this.apply { assertFalse("Expected the CharSequence $this to not end with $expected", this.endsWith(expected)) }
 
-infix fun CharSequence.shouldNotContain(expected: CharSequence) =
-    this.apply { assertFalse("Expected the CharSequence $this to not contain $expected", this.contains(expected)) }
+infix fun CharSequence.shouldNotContain(expected: CharSequence) = this.apply { assertFalse("Expected the CharSequence $this to not contain $expected", this.contains(expected)) }
 
-infix fun CharSequence.shouldNotMatch(regex: String) =
-    this.apply { assertFalse("Expected $this to not match $regex", this.matches(Regex(regex))) }
+infix fun CharSequence.shouldNotMatch(regex: String) = this.apply { assertFalse("Expected $this to not match $regex", this.matches(Regex(regex))) }
 
-infix fun CharSequence.shouldNotMatch(regex: Regex) =
-    this.apply { assertFalse("Expected $this to not match ${regex.pattern}", this.matches(regex)) }
+infix fun CharSequence.shouldNotMatch(regex: Regex) = this.apply { assertFalse("Expected $this to not match ${regex.pattern}", this.matches(regex)) }
 
 fun <T : CharSequence> T.shouldNotBeEmpty(): T =
     this.apply { assertTrue("Expected the CharSequence to not be empty", this.isNotEmpty()) }

--- a/src/main/kotlin/org/amshove/kluent/CharSequence.kt
+++ b/src/main/kotlin/org/amshove/kluent/CharSequence.kt
@@ -2,33 +2,47 @@ package org.amshove.kluent
 
 import org.junit.Assert.*
 
-infix fun CharSequence.shouldStartWith(expected: CharSequence) = this.apply { assertTrue("Expected the CharSequence $this to start with $expected", this.startsWith(expected)) }
+infix fun CharSequence.shouldStartWith(expected: CharSequence) =
+    this.apply { assertTrue("Expected the CharSequence $this to start with $expected", this.startsWith(expected)) }
 
-infix fun CharSequence.shouldEndWith(expected: CharSequence) = this.apply { assertTrue("Expected the CharSequence $this to end with $expected", this.endsWith(expected)) }
+infix fun CharSequence.shouldEndWith(expected: CharSequence) =
+    this.apply { assertTrue("Expected the CharSequence $this to end with $expected", this.endsWith(expected)) }
 
-infix fun CharSequence.shouldContain(char: Char) = this.apply { assertTrue("Expected '$this' to contain '$char'", this.contains(char))}
+infix fun CharSequence.shouldContain(char: Char) =
+    this.apply { assertTrue("Expected '$this' to contain '$char'", this.contains(char)) }
 
-infix fun CharSequence.shouldContainSome(things: Iterable<CharSequence>) = this.apply { assertTrue("Expected '$this' to contain at least one of $things", things.any { this.contains(it) }) }
+infix fun CharSequence.shouldContainSome(things: Iterable<CharSequence>) =
+    this.apply { assertTrue("Expected '$this' to contain at least one of $things", things.any { this.contains(it) }) }
 
-infix fun CharSequence.shouldContainNone(things: Iterable<CharSequence>) = this.apply { assertTrue("Expected '$this' to not contain any of $things", things.none { this.contains(it) }) }
+infix fun CharSequence.shouldContainNone(things: Iterable<CharSequence>) =
+    this.apply { assertTrue("Expected '$this' to not contain any of $things", things.none { this.contains(it) }) }
 
-infix fun CharSequence.shouldContain(expected: CharSequence) = this.apply { assertTrue("Expected the CharSequence $this to contain $expected", this.contains(expected)) }
+infix fun CharSequence.shouldContain(expected: CharSequence) =
+    this.apply { assertTrue("Expected the CharSequence $this to contain $expected", this.contains(expected)) }
 
-infix fun CharSequence.shouldNotContain(char: Char) = this.apply { assertFalse("Expected '$this' to not contain '$char'", this.contains(char))}
+infix fun CharSequence.shouldNotContain(char: Char) =
+    this.apply { assertFalse("Expected '$this' to not contain '$char'", this.contains(char)) }
 
-infix fun CharSequence.shouldNotContainAny(things: Iterable<CharSequence>) = this.apply { this shouldContainNone things }
+infix fun CharSequence.shouldNotContainAny(things: Iterable<CharSequence>) =
+    this.apply { this shouldContainNone things }
 
-infix fun CharSequence.shouldMatch(regex: String) = this.apply { assertTrue("Expected $this to match $regex", this.matches(Regex(regex))) }
+infix fun CharSequence.shouldMatch(regex: String) =
+    this.apply { assertTrue("Expected $this to match $regex", this.matches(Regex(regex))) }
 
-infix fun CharSequence.shouldMatch(regex: Regex) = this.apply { assertTrue("Expected $this to match ${regex.pattern}", this.matches(regex)) }
+infix fun CharSequence.shouldMatch(regex: Regex) =
+    this.apply { assertTrue("Expected $this to match ${regex.pattern}", this.matches(regex)) }
 
-fun CharSequence.shouldBeEmpty() = this.apply { assertTrue("Expected the CharSequence to be empty, but was $this", this.isEmpty()) }
+fun CharSequence.shouldBeEmpty() =
+    this.apply { assertTrue("Expected the CharSequence to be empty, but was $this", this.isEmpty()) }
 
-fun CharSequence?.shouldBeNullOrEmpty() = this.apply { assertTrue("Expected $this to be null or empty", this == null || this.isEmpty()) }
+fun CharSequence?.shouldBeNullOrEmpty() =
+    this.apply { assertTrue("Expected $this to be null or empty", this == null || this.isEmpty()) }
 
-fun CharSequence.shouldBeBlank() = this.apply { assertTrue("Expected the CharSequence to be blank, but was $this", this.isBlank()) }
+fun CharSequence.shouldBeBlank() =
+    this.apply { assertTrue("Expected the CharSequence to be blank, but was $this", this.isBlank()) }
 
-fun CharSequence?.shouldBeNullOrBlank() = this.apply { assertTrue("Expected $this to be null or blank", this == null || this.isBlank()) }
+fun CharSequence?.shouldBeNullOrBlank() =
+    this.apply { assertTrue("Expected $this to be null or blank", this == null || this.isBlank()) }
 
 @Deprecated("Use shouldBeEqualTo", ReplaceWith("this.shouldBeEqualTo(expected)"))
 infix fun String.shouldEqualTo(expected: String) = shouldBeEqualTo(expected)
@@ -40,31 +54,30 @@ infix fun String.shouldNotEqualTo(expected: String) = shouldNotBeEqualTo(expecte
 
 infix fun String.shouldNotBeEqualTo(expected: String) = this.apply { assertNotEquals(expected, this) }
 
-infix fun CharSequence.shouldNotStartWith(expected: CharSequence) = this.apply { assertFalse("Expected the CharSequence $this to not start with $expected", this.startsWith(expected)) }
+infix fun CharSequence.shouldNotStartWith(expected: CharSequence) =
+    this.apply { assertFalse("Expected the CharSequence $this to not start with $expected", this.startsWith(expected)) }
 
-infix fun CharSequence.shouldNotEndWith(expected: CharSequence) = this.apply { assertFalse("Expected the CharSequence $this to not end with $expected", this.endsWith(expected)) }
+infix fun CharSequence.shouldNotEndWith(expected: CharSequence) =
+    this.apply { assertFalse("Expected the CharSequence $this to not end with $expected", this.endsWith(expected)) }
 
-infix fun CharSequence.shouldNotContain(expected: CharSequence) = this.apply { assertFalse("Expected the CharSequence $this to not contain $expected", this.contains(expected)) }
+infix fun CharSequence.shouldNotContain(expected: CharSequence) =
+    this.apply { assertFalse("Expected the CharSequence $this to not contain $expected", this.contains(expected)) }
 
-infix fun CharSequence.shouldNotMatch(regex: String) = this.apply { assertFalse("Expected $this to not match $regex", this.matches(Regex(regex))) }
+infix fun CharSequence.shouldNotMatch(regex: String) =
+    this.apply { assertFalse("Expected $this to not match $regex", this.matches(Regex(regex))) }
 
-infix fun CharSequence.shouldNotMatch(regex: Regex) = this.apply { assertFalse("Expected $this to not match ${regex.pattern}", this.matches(regex)) }
+infix fun CharSequence.shouldNotMatch(regex: Regex) =
+    this.apply { assertFalse("Expected $this to not match ${regex.pattern}", this.matches(regex)) }
 
-fun CharSequence.shouldNotBeEmpty() = this.apply { assertTrue("Expected the CharSequence to not be empty", this.isNotEmpty()) }
+fun <T : CharSequence> T.shouldNotBeEmpty(): T =
+    this.apply { assertTrue("Expected the CharSequence to not be empty", this.isNotEmpty()) }
 
-fun CharSequence?.shouldNotBeNullOrEmpty(): CharSequence? {
-    this.shouldNotBeNull()
-    this!!.shouldNotBeEmpty()
-    return this
-}
+fun <T : CharSequence> T?.shouldNotBeNullOrEmpty(): T = this.shouldNotBeNull().shouldNotBeEmpty()
 
-fun CharSequence.shouldNotBeBlank() = this.apply { assertTrue("Expected the CharSequence to not be blank", this.isNotBlank()) }
+fun <T : CharSequence> T.shouldNotBeBlank(): T =
+    this.apply { assertTrue("Expected the CharSequence to not be blank", this.isNotBlank()) }
 
-fun CharSequence?.shouldNotBeNullOrBlank(): CharSequence? {
-    this.shouldNotBeNull()
-    this!!.shouldNotBeBlank()
-    return this
-}
+fun <T : CharSequence> T?.shouldNotBeNullOrBlank(): T = this.shouldNotBeNull().shouldNotBeBlank()
 
 infix fun CharSequence.shouldContainAll(items: Iterable<CharSequence>): CharSequence = this.apply {
     items.forEach { this shouldContain it }

--- a/src/main/kotlin/org/amshove/kluent/CharSequenceBacktick.kt
+++ b/src/main/kotlin/org/amshove/kluent/CharSequenceBacktick.kt
@@ -50,11 +50,11 @@ infix fun CharSequence.`should not match`(regex: Regex) = this.shouldNotMatch(re
 
 fun CharSequence.`should not be empty`() = this.shouldNotBeEmpty()
 
-fun CharSequence?.`should not be null or empty`() = this.shouldNotBeNullOrEmpty()
+fun <T : CharSequence> T?.`should not be null or empty`(): T = this.shouldNotBeNullOrEmpty()
 
 fun CharSequence.`should not be blank`() = this.shouldNotBeBlank()
 
-fun CharSequence?.`should not be null or blank`() = this.shouldNotBeNullOrBlank()
+fun <T : CharSequence> T?.`should not be null or blank`(): T = this.shouldNotBeNullOrBlank()
 
 infix fun CharSequence.`should contain all`(items: Iterable<CharSequence>): CharSequence = this shouldContainAll items
 

--- a/src/main/kotlin/org/amshove/kluent/CharSequenceBacktick.kt
+++ b/src/main/kotlin/org/amshove/kluent/CharSequenceBacktick.kt
@@ -48,13 +48,13 @@ infix fun CharSequence.`should not match`(regex: String) = this.shouldNotMatch(r
 
 infix fun CharSequence.`should not match`(regex: Regex) = this.shouldNotMatch(regex)
 
-fun CharSequence.`should not be empty`() = this.shouldNotBeEmpty()
+fun <T: CharSequence> T.`should not be empty`(): T = this.shouldNotBeEmpty()
 
-fun <T : CharSequence> T?.`should not be null or empty`(): T = this.shouldNotBeNullOrEmpty()
+fun <T: CharSequence> T?.`should not be null or empty`(): T = this.shouldNotBeNullOrEmpty()
 
-fun CharSequence.`should not be blank`() = this.shouldNotBeBlank()
+fun <T: CharSequence> T.`should not be blank`(): T = this.shouldNotBeBlank()
 
-fun <T : CharSequence> T?.`should not be null or blank`(): T = this.shouldNotBeNullOrBlank()
+fun <T: CharSequence> T?.`should not be null or blank`(): T = this.shouldNotBeNullOrBlank()
 
 infix fun CharSequence.`should contain all`(items: Iterable<CharSequence>): CharSequence = this shouldContainAll items
 

--- a/src/test/kotlin/org/amshove/kluent/tests/assertions/charsequence/ShouldNotBeNullOrBlankTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/assertions/charsequence/ShouldNotBeNullOrBlankTests.kt
@@ -22,5 +22,11 @@ class ShouldNotBeNullOrBlankTests : Spek({
                 assertFails({ str.shouldNotBeNullOrBlank() })
             }
         }
+        on("checking a nullable string") {
+            it("should return non null") {
+                val nullable: String? = "is this null?"
+                val result: String = nullable.shouldNotBeNullOrBlank()
+            }
+        }
     }
 })

--- a/src/test/kotlin/org/amshove/kluent/tests/assertions/charsequence/ShouldNotBeNullOrEmptyTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/assertions/charsequence/ShouldNotBeNullOrEmptyTests.kt
@@ -22,5 +22,11 @@ class ShouldNotBeNullOrEmptyTests : Spek({
                 assertFails({ str.shouldNotBeNullOrEmpty() })
             }
         }
+        on("checking a nullable string") {
+            it("should return non null") {
+                val nullable: String? = "is this null?"
+                val result: String = nullable.shouldNotBeNullOrEmpty()
+            }
+        }
     }
 })

--- a/src/test/kotlin/org/amshove/kluent/tests/backtickassertions/charsequence/ShouldNotBeNullOrBlankTests.kt
+++ b/src/test/kotlin/org/amshove/kluent/tests/backtickassertions/charsequence/ShouldNotBeNullOrBlankTests.kt
@@ -22,5 +22,11 @@ class ShouldNotBeNullOrBlankTests : Spek({
                 assertFails({ str.`should not be null or blank`() })
             }
         }
+        on("checking a nullable string") {
+            it("should return non null") {
+                val nullable: String? = "is this null?"
+                val result: String = nullable.`should not be null or blank`()
+            }
+        }
     }
 })


### PR DESCRIPTION
Fixed to return non null, as well as correct type. 
#104 