### PR TITLE
Implementing should contain same

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -43,3 +43,5 @@ Ole Kristian Sandum [@okkero](https://github.com/okkero)
 Gabriel Aumala [@GAumala](https://github.com/GAumala)
 
 Deconinck Alban [@neyb](https://github.com/neyb)
+
+Fabrício Rissetto [@fabriciorissetto](https://github.com/fabriciorissetto)

--- a/common/src/main/kotlin/org/amshove/kluent/Collections.kt
+++ b/common/src/main/kotlin/org/amshove/kluent/Collections.kt
@@ -20,7 +20,7 @@ infix fun <T> Array<T>.shouldContainAll(expected: Iterable<T>) = apply { expecte
 
 infix fun <T> Array<T>.shouldContainSame(expected: Array<T>) = assertBothCollectionsContainsSame(expected.toList(), this.toList())
 
-infix fun <T> Array<T>.shouldContainSame(expected: Iterable<T>) = assertBothCollectionsContainsSame(expected.iterator().asSequence().toList(), this.toList())
+infix fun <T> Array<T>.shouldContainSame(expected: Iterable<T>) = assertBothCollectionsContainsSame(expected.toList(), this.toList())
 
 infix fun <T> Array<T>.shouldNotContain(expected: T) = apply { if (!this.contains(expected)) Unit else failExpectedActual("Array should not contain \"$expected\"", "the Array to not contain \"$expected\"", join(this)) }
 
@@ -60,7 +60,7 @@ infix fun IntArray.shouldContainAll(expected: Iterable<Int>) = apply { this.toLi
 
 infix fun IntArray.shouldContainSame(expected: IntArray) = assertBothCollectionsContainsSame(expected.toList(), this.toList())
 
-infix fun IntArray.shouldContainSame(expected: Iterable<Int>) = assertBothCollectionsContainsSame(expected.iterator().asSequence().toList(), this.toList())
+infix fun IntArray.shouldContainSame(expected: Iterable<Int>) = assertBothCollectionsContainsSame(expected.toList(), this.toList())
 
 infix fun IntArray.shouldNotContain(expected: Int) = apply { this.toTypedArray() shouldNotContain expected }
 
@@ -98,7 +98,7 @@ infix fun BooleanArray.shouldNotContain(expected: Boolean) = apply { this.toType
 
 infix fun BooleanArray.shouldContainSame(expected: BooleanArray) = assertBothCollectionsContainsSame(expected.toList(), this.toList())
 
-infix fun BooleanArray.shouldContainSame(expected: Iterable<Boolean>) = assertBothCollectionsContainsSame(expected.iterator().asSequence().toList(), this.toList())
+infix fun BooleanArray.shouldContainSame(expected: Iterable<Boolean>) = assertBothCollectionsContainsSame(expected.toList(), this.toList())
 
 infix fun BooleanArray.shouldNotContainAny(expected: BooleanArray) = apply { expected.forEach { shouldNotContain(it) } }
 
@@ -132,7 +132,7 @@ infix fun ByteArray.shouldContainAll(expected: Iterable<Byte>) = apply { this.to
 
 infix fun ByteArray.shouldContainSame(expected: ByteArray) = assertBothCollectionsContainsSame(expected.toList(), this.toList())
 
-infix fun ByteArray.shouldContainSame(expected: Iterable<Byte>) = assertBothCollectionsContainsSame(expected.iterator().asSequence().toList(), this.toList())
+infix fun ByteArray.shouldContainSame(expected: Iterable<Byte>) = assertBothCollectionsContainsSame(expected.toList(), this.toList())
 
 infix fun ByteArray.shouldNotContain(expected: Byte) = apply { this.toTypedArray() shouldNotContain expected }
 
@@ -168,7 +168,7 @@ infix fun CharArray.shouldContainAll(expected: Iterable<Char>) = apply { this.to
 
 infix fun CharArray.shouldContainSame(expected: CharArray) = assertBothCollectionsContainsSame(expected.toList(), this.toList())
 
-infix fun CharArray.shouldContainSame(expected: Iterable<Char>) = assertBothCollectionsContainsSame(expected.iterator().asSequence().toList(), this.toList())
+infix fun CharArray.shouldContainSame(expected: Iterable<Char>) = assertBothCollectionsContainsSame(expected.toList(), this.toList())
 
 infix fun CharArray.shouldNotContain(expected: Char) = apply { this.toTypedArray() shouldNotContain expected }
 
@@ -204,7 +204,7 @@ infix fun DoubleArray.shouldContainAll(expected: Iterable<Double>) = apply { thi
 
 infix fun DoubleArray.shouldContainSame(expected: DoubleArray) = assertBothCollectionsContainsSame(expected.toList(), this.toList())
 
-infix fun DoubleArray.shouldContainSame(expected: Iterable<Double>) = assertBothCollectionsContainsSame(expected.iterator().asSequence().toList(), this.toList())
+infix fun DoubleArray.shouldContainSame(expected: Iterable<Double>) = assertBothCollectionsContainsSame(expected.toList(), this.toList())
 
 infix fun DoubleArray.shouldNotContain(expected: Double) = apply { this.toTypedArray() shouldNotContain expected }
 
@@ -240,7 +240,7 @@ infix fun FloatArray.shouldContainAll(expected: Iterable<Float>) = apply { this.
 
 infix fun FloatArray.shouldContainSame(expected: FloatArray) = assertBothCollectionsContainsSame(expected.toList(), this.toList())
 
-infix fun FloatArray.shouldContainSame(expected: Iterable<Float>) = assertBothCollectionsContainsSame(expected.iterator().asSequence().toList(), this.toList())
+infix fun FloatArray.shouldContainSame(expected: Iterable<Float>) = assertBothCollectionsContainsSame(expected.toList(), this.toList())
 
 infix fun FloatArray.shouldNotContain(expected: Float) = apply { this.toTypedArray() shouldNotContain expected }
 
@@ -276,7 +276,7 @@ infix fun LongArray.shouldContainAll(expected: Iterable<Long>) = apply { this.to
 
 infix fun LongArray.shouldContainSame(expected: LongArray) = assertBothCollectionsContainsSame(expected.toList(), this.toList())
 
-infix fun LongArray.shouldContainSame(expected: Iterable<Long>) = assertBothCollectionsContainsSame(expected.iterator().asSequence().toList(), this.toList())
+infix fun LongArray.shouldContainSame(expected: Iterable<Long>) = assertBothCollectionsContainsSame(expected.toList(), this.toList())
 
 infix fun LongArray.shouldNotContain(expected: Long) = apply { this.toTypedArray() shouldNotContain expected }
 
@@ -312,7 +312,7 @@ infix fun ShortArray.shouldContainAll(expected: Iterable<Short>) = apply { this.
 
 infix fun ShortArray.shouldContainSame(expected: ShortArray) = assertBothCollectionsContainsSame(expected.toList(), this.toList())
 
-infix fun ShortArray.shouldContainSame(expected: Iterable<Short>) = assertBothCollectionsContainsSame(expected.iterator().asSequence().toList(), this.toList())
+infix fun ShortArray.shouldContainSame(expected: Iterable<Short>) = assertBothCollectionsContainsSame(expected.toList(), this.toList())
 
 infix fun ShortArray.shouldNotContain(expected: Short) = apply { this.toTypedArray() shouldNotContain expected }
 

--- a/common/src/main/kotlin/org/amshove/kluent/Collections.kt
+++ b/common/src/main/kotlin/org/amshove/kluent/Collections.kt
@@ -18,6 +18,10 @@ infix fun <T> Array<T>.shouldContainAll(expected: Array<T>) = apply { expected.f
 
 infix fun <T> Array<T>.shouldContainAll(expected: Iterable<T>) = apply { expected.forEach { shouldContain(it) } }
 
+infix fun <T> Array<T>.shouldContainSame(expected: Array<T>) = assertBothCollectionsContainsSame(expected.toList(), this.toList())
+
+infix fun <T> Array<T>.shouldContainSame(expected: Iterable<T>) = assertBothCollectionsContainsSame(expected.iterator().asSequence().toList(), this.toList())
+
 infix fun <T> Array<T>.shouldNotContain(expected: T) = apply { if (!this.contains(expected)) Unit else failExpectedActual("Array should not contain \"$expected\"", "the Array to not contain \"$expected\"", join(this)) }
 
 infix fun <T> Array<T>.shouldNotContainAny(expected: Array<T>) = apply { expected.forEach { shouldNotContain(it) } }
@@ -54,6 +58,10 @@ infix fun IntArray.shouldContainAll(expected: IntArray) = apply { expected.forEa
 
 infix fun IntArray.shouldContainAll(expected: Iterable<Int>) = apply { this.toList().shouldContainAll(expected) }
 
+infix fun IntArray.shouldContainSame(expected: IntArray) = assertBothCollectionsContainsSame(expected.toList(), this.toList())
+
+infix fun IntArray.shouldContainSame(expected: Iterable<Int>) = assertBothCollectionsContainsSame(expected.iterator().asSequence().toList(), this.toList())
+
 infix fun IntArray.shouldNotContain(expected: Int) = apply { this.toTypedArray() shouldNotContain expected }
 
 infix fun IntArray.shouldNotContainAny(expected: IntArray) = apply { expected.forEach { shouldNotContain(it) } }
@@ -88,6 +96,10 @@ infix fun BooleanArray.shouldContainAll(expected: Iterable<Boolean>) = apply { t
 
 infix fun BooleanArray.shouldNotContain(expected: Boolean) = apply { this.toTypedArray() shouldNotContain expected }
 
+infix fun BooleanArray.shouldContainSame(expected: BooleanArray) = assertBothCollectionsContainsSame(expected.toList(), this.toList())
+
+infix fun BooleanArray.shouldContainSame(expected: Iterable<Boolean>) = assertBothCollectionsContainsSame(expected.iterator().asSequence().toList(), this.toList())
+
 infix fun BooleanArray.shouldNotContainAny(expected: BooleanArray) = apply { expected.forEach { shouldNotContain(it) } }
 
 infix fun BooleanArray.shouldNotContainAny(expected: Iterable<Boolean>) = apply { this.toList().shouldNotContainAny(expected) }
@@ -117,6 +129,10 @@ infix fun ByteArray.shouldContainNone(expected: Iterable<Byte>) = apply { this.t
 infix fun ByteArray.shouldContainAll(expected: ByteArray) = apply { expected.forEach { shouldContain(it) } }
 
 infix fun ByteArray.shouldContainAll(expected: Iterable<Byte>) = apply { this.toList().shouldContainAll(expected) }
+
+infix fun ByteArray.shouldContainSame(expected: ByteArray) = assertBothCollectionsContainsSame(expected.toList(), this.toList())
+
+infix fun ByteArray.shouldContainSame(expected: Iterable<Byte>) = assertBothCollectionsContainsSame(expected.iterator().asSequence().toList(), this.toList())
 
 infix fun ByteArray.shouldNotContain(expected: Byte) = apply { this.toTypedArray() shouldNotContain expected }
 
@@ -150,6 +166,10 @@ infix fun CharArray.shouldContainAll(expected: CharArray) = apply { expected.for
 
 infix fun CharArray.shouldContainAll(expected: Iterable<Char>) = apply { this.toList().shouldContainAll(expected) }
 
+infix fun CharArray.shouldContainSame(expected: CharArray) = assertBothCollectionsContainsSame(expected.toList(), this.toList())
+
+infix fun CharArray.shouldContainSame(expected: Iterable<Char>) = assertBothCollectionsContainsSame(expected.iterator().asSequence().toList(), this.toList())
+
 infix fun CharArray.shouldNotContain(expected: Char) = apply { this.toTypedArray() shouldNotContain expected }
 
 infix fun CharArray.shouldNotContainAny(expected: CharArray) = apply { expected.forEach { shouldNotContain(it) } }
@@ -181,6 +201,10 @@ infix fun DoubleArray.shouldContainNone(expected: Iterable<Double>) = apply { th
 infix fun DoubleArray.shouldContainAll(expected: DoubleArray) = apply { expected.forEach { shouldContain(it) } }
 
 infix fun DoubleArray.shouldContainAll(expected: Iterable<Double>) = apply { this.toList().shouldContainAll(expected) }
+
+infix fun DoubleArray.shouldContainSame(expected: DoubleArray) = assertBothCollectionsContainsSame(expected.toList(), this.toList())
+
+infix fun DoubleArray.shouldContainSame(expected: Iterable<Double>) = assertBothCollectionsContainsSame(expected.iterator().asSequence().toList(), this.toList())
 
 infix fun DoubleArray.shouldNotContain(expected: Double) = apply { this.toTypedArray() shouldNotContain expected }
 
@@ -214,6 +238,10 @@ infix fun FloatArray.shouldContainAll(expected: FloatArray) = apply { expected.f
 
 infix fun FloatArray.shouldContainAll(expected: Iterable<Float>) = apply { this.toList().shouldContainAll(expected) }
 
+infix fun FloatArray.shouldContainSame(expected: FloatArray) = assertBothCollectionsContainsSame(expected.toList(), this.toList())
+
+infix fun FloatArray.shouldContainSame(expected: Iterable<Float>) = assertBothCollectionsContainsSame(expected.iterator().asSequence().toList(), this.toList())
+
 infix fun FloatArray.shouldNotContain(expected: Float) = apply { this.toTypedArray() shouldNotContain expected }
 
 infix fun FloatArray.shouldNotContainAny(expected: FloatArray) = apply { expected.forEach { shouldNotContain(it) } }
@@ -245,6 +273,10 @@ infix fun LongArray.shouldContainNone(expected: Iterable<Long>) = apply { this.t
 infix fun LongArray.shouldContainAll(expected: LongArray) = apply { expected.forEach { shouldContain(it) } }
 
 infix fun LongArray.shouldContainAll(expected: Iterable<Long>) = apply { this.toList().shouldContainAll(expected) }
+
+infix fun LongArray.shouldContainSame(expected: LongArray) = assertBothCollectionsContainsSame(expected.toList(), this.toList())
+
+infix fun LongArray.shouldContainSame(expected: Iterable<Long>) = assertBothCollectionsContainsSame(expected.iterator().asSequence().toList(), this.toList())
 
 infix fun LongArray.shouldNotContain(expected: Long) = apply { this.toTypedArray() shouldNotContain expected }
 
@@ -278,6 +310,10 @@ infix fun ShortArray.shouldContainAll(expected: ShortArray) = apply { expected.f
 
 infix fun ShortArray.shouldContainAll(expected: Iterable<Short>) = apply { this.toList().shouldContainAll(expected) }
 
+infix fun ShortArray.shouldContainSame(expected: ShortArray) = assertBothCollectionsContainsSame(expected.toList(), this.toList())
+
+infix fun ShortArray.shouldContainSame(expected: Iterable<Short>) = assertBothCollectionsContainsSame(expected.iterator().asSequence().toList(), this.toList())
+
 infix fun ShortArray.shouldNotContain(expected: Short) = apply { this.toTypedArray() shouldNotContain expected }
 
 infix fun ShortArray.shouldNotContainAny(expected: ShortArray) = apply { expected.forEach { shouldNotContain(it) } }
@@ -301,6 +337,10 @@ infix fun <T, I : Iterable<T>> I.shouldContainNone(expected: Array<T>): I = appl
 infix fun <T, I : Iterable<T>> I.shouldContainAll(expected: Iterable<T>): I = apply { expected.forEach { shouldContain(it) } }
 
 infix fun <T, I : Iterable<T>> I.shouldContainAll(expected: Array<T>): I = apply { expected.forEach { shouldContain(it) } }
+
+infix fun <T, I : Iterable<T>> I.shouldContainSame(expected: Iterable<T>): I = assertBothIterablesContainsSame(expected.toList(), this.toList())
+
+infix fun <T, I : Iterable<T>> I.shouldContainSame(expected: Array<T>): I = assertBothIterablesContainsSame(expected.toList(), this.toList())
 
 infix fun <T, I : Iterable<T>> I.shouldNotContain(expected: T): I = apply { if (!this.contains(expected)) Unit else failExpectedActual("Iterable should not contain \"$expected\"", "the Iterable to not contain \"$expected\"", join(this)) }
 
@@ -332,6 +372,8 @@ infix fun <K, V, M : Map<K, V>> M.shouldContain(expected: Pair<K, V>): M = apply
 
 infix fun <K, V, M : Map<K, V>> M.shouldContainAll(expected: M): M = apply { expected.forEach { shouldContain(it.toPair()) } }
 
+infix fun <K, V, M : Map<K, V>> M.shouldContainSame(expected: M): M = apply { expected.forEach { shouldContain(it.toPair()); this.forEach { shouldContain(it.toPair()) } } }
+
 infix fun <K, V, M : Map<K, V>> M.shouldNotContain(expected: Pair<K, V>): M = apply { if (this[expected.first] != expected.second) Unit else failExpectedActual("Map should not contain Pair $expected", "the Map to not contain the Pair $expected", joinPairs(this)) }
 
 infix fun <K, V, M : Map<K, V>> M.shouldNotContainAny(expected: M): M = apply { expected.forEach { shouldNotContain(it.toPair()) } }
@@ -350,3 +392,21 @@ infix fun <T> Any?.shouldBeIn(array: Array<T>) = apply { if (array.contains(this
 
 internal fun <T> assertEmpty(iterable: Iterable<T>, collectionType: String) = assertTrue("Expected the $collectionType to be empty, but has ${iterable.count()} elements", iterable.count() == 0)
 internal fun <T> assertNotEmpty(iterable: Iterable<T>, collectionType: String) = assertTrue("Expected the $collectionType to contain elements, but is empty", iterable.count() > 0)
+
+internal fun <T, I : Iterable<T>> I.assertBothIterablesContainsSame(expected: Iterable<T>, actual: Iterable<T>): I {
+    assertBothCollectionsContainsSame(expected.toList(), actual.toList())
+    return this
+}
+
+internal fun <T> assertBothCollectionsContainsSame(expected: List<T>, actual: List<T>) {
+    val remainingItemsOnExpectedList = expected.toMutableList()
+    val notPresentOnList = mutableListOf<T>()
+
+    actual.forEach {
+        if (!remainingItemsOnExpectedList.remove(it))
+            notPresentOnList.add(it)
+    }
+
+    if (remainingItemsOnExpectedList.isNotEmpty() || notPresentOnList.isNotEmpty())
+        failCollectionWithDifferentItems("The collection doesn't have the same items", join(remainingItemsOnExpectedList), join(notPresentOnList))
+}

--- a/common/src/main/kotlin/org/amshove/kluent/internal/Assertions.kt
+++ b/common/src/main/kotlin/org/amshove/kluent/internal/Assertions.kt
@@ -59,8 +59,8 @@ internal fun failExpectedActual(message: String, expected: String?, actual: Stri
 
 internal fun failCollectionWithDifferentItems(message: String, expected: String?, actual: String?): Nothing = fail("""
     |$message
-    |${ if(actual.isNullOrEmpty()) "Items included on the expected collection but not in the actual: $expected" else "" }
-    |${ if(expected.isNullOrEmpty()) "Items included on the actual collection but not in the expected: $actual" else "" }
+    |${ if(!expected.isNullOrEmpty()) "Items included on the expected collection but not in the actual: $expected" else "" }
+    |${ if(!actual.isNullOrEmpty()) "Items included on the actual collection but not in the expected: $actual" else "" }
 """.trimMargin())
 
 internal fun failFirstSecond(message: String, first: String?, second: String?): Nothing = fail("""

--- a/common/src/main/kotlin/org/amshove/kluent/internal/Assertions.kt
+++ b/common/src/main/kotlin/org/amshove/kluent/internal/Assertions.kt
@@ -57,6 +57,12 @@ internal fun failExpectedActual(message: String, expected: String?, actual: Stri
     |   Actual:     $actual
 """.trimMargin())
 
+internal fun failCollectionWithDifferentItems(message: String, expected: String?, actual: String?): Nothing = fail("""
+    |$message
+    |${ if(actual.isNullOrEmpty()) "Items included on the expected collection but not in the actual: $expected" else "" }
+    |${ if(expected.isNullOrEmpty()) "Items included on the actual collection but not in the expected: $actual" else "" }
+""".trimMargin())
+
 internal fun failFirstSecond(message: String, first: String?, second: String?): Nothing = fail("""
     |$message
     |   First:      $first

--- a/common/src/test/kotlin/org/amshove/kluent/collections/ShouldContainAllShould.kt
+++ b/common/src/test/kotlin/org/amshove/kluent/collections/ShouldContainAllShould.kt
@@ -36,8 +36,8 @@ class ShouldContainAllShould {
     @Test
     fun passWhenTestingABooleanArrayWhichContainsAllValues() {
         val array = booleanArrayOf(true, false)
-        array shouldContainAll booleanArrayOf(false, true, false)
-        array shouldContainAll listOf(false, true, false)
+        array shouldContainAll booleanArrayOf(false, true)
+        array shouldContainAll listOf(false, true)
     }
 
     @Test

--- a/common/src/test/kotlin/org/amshove/kluent/collections/ShouldContainAllShould.kt
+++ b/common/src/test/kotlin/org/amshove/kluent/collections/ShouldContainAllShould.kt
@@ -36,8 +36,8 @@ class ShouldContainAllShould {
     @Test
     fun passWhenTestingABooleanArrayWhichContainsAllValues() {
         val array = booleanArrayOf(true, false)
-        array shouldContainAll booleanArrayOf(false, true)
-        array shouldContainAll listOf(false, true)
+        array shouldContainAll booleanArrayOf(false, true, false)
+        array shouldContainAll listOf(false, true, false)
     }
 
     @Test

--- a/common/src/test/kotlin/org/amshove/kluent/collections/ShouldContainSameShould.kt
+++ b/common/src/test/kotlin/org/amshove/kluent/collections/ShouldContainSameShould.kt
@@ -1,0 +1,173 @@
+package org.amshove.kluent.collections
+
+import org.amshove.kluent.shouldContainSame
+import kotlin.test.Test
+import kotlin.test.assertFails
+
+class ShouldContainSameShould {
+    @Test
+    fun passWhenTestingAnArrayWhichContainsSameValues() {
+        val array = arrayOf("World", "Wide", "Web", "Hello")
+        array shouldContainSame arrayOf("Hello", "World", "Wide", "Web")
+        array shouldContainSame listOf("Hello", "World", "Wide", "Web")
+    }
+
+    @Test
+    fun failWhenTestingAnArrayWhichDoesNotContainSameValues() {
+        val array = arrayOf("Hello", "World", "Wide", "Web")
+        assertFails { array shouldContainSame arrayOf("Hello", "World", "Wide", "Web", "Hello") }
+        assertFails { array shouldContainSame listOf("Hello", "World", "Wide", "Web", "Hello") }
+    }
+
+    @Test
+    fun passWhenTestingAnIntArrayWithSameValues() {
+        val array = intArrayOf(4, 3, 2, 1)
+        array shouldContainSame intArrayOf(1, 2, 3, 4)
+        array shouldContainSame listOf(1, 2, 3, 4)
+    }
+
+    @Test
+    fun failWhenTestingAnIntArrayWithDoesNotContainSameValues() {
+        val array = intArrayOf(2, 3, 4)
+        assertFails { array shouldContainSame intArrayOf(2, 3, 4, 4) }
+        assertFails { array shouldContainSame listOf(2, 3, 4, 4) }
+    }
+
+    @Test
+    fun passWhenTestingABooleanArrayWhichContainsSameValues() {
+        val array = booleanArrayOf(true, false)
+        array shouldContainSame booleanArrayOf(false, true)
+        array shouldContainSame listOf(false, true)
+    }
+
+    @Test
+    fun failWhenTestingABooleanArrayWhichDoesNotContainSameValues() {
+        val array = booleanArrayOf(false, true)
+        assertFails { array shouldContainSame booleanArrayOf(true, false, true) }
+        assertFails { array shouldContainSame listOf(true, false, true) }
+    }
+
+    @Test
+    fun passWhenTestingAByteArrayWhichContainsSameValues() {
+        val array = byteArrayOf(4, 3, 2, 1)
+        array shouldContainSame byteArrayOf(1, 2, 3, 4)
+        array shouldContainSame listOf<Byte>(1, 2, 3, 4)
+    }
+
+    @Test
+    fun failWhenTestingAByteArrayWhichDoesNotContainSameValues() {
+        val array = byteArrayOf(2, 3, 4)
+        assertFails { array shouldContainSame byteArrayOf(2, 3, 4, 4) }
+        assertFails { array shouldContainSame listOf<Byte>(2, 3, 4, 4) }
+    }
+
+    @Test
+    fun passWhenTestingACharArrayWhichContainsSameValues() {
+        val array = charArrayOf('a', 'f', 'z')
+        array shouldContainSame charArrayOf('z', 'f', 'a')
+        array shouldContainSame listOf('z', 'f', 'a')
+    }
+
+    @Test
+    fun failWhenTestingACharArrayWhichDoesNotContainSameValues() {
+        val array = charArrayOf('a', '-')
+        assertFails { array shouldContainSame charArrayOf('a', '-', 'a') }
+        assertFails { array shouldContainSame listOf('a', '-', 'a') }
+    }
+
+    @Test
+    fun passWhenTestingADoubleArrayWhichContainsSameValues() {
+        val array = doubleArrayOf(0.3, 1.1, 5.7)
+        array shouldContainSame doubleArrayOf(5.7, 0.3, 1.1)
+        array shouldContainSame listOf(5.7, 0.3, 1.1)
+    }
+
+    @Test
+    fun failWhenTestingADoubleArrayWhichDoesNotContainSameValues() {
+        val array = doubleArrayOf(0.3, 1.1, 5.7)
+        assertFails { array shouldContainSame doubleArrayOf(0.3, 1.1, 5.7, 0.3) }
+        assertFails { array shouldContainSame listOf(0.3, 1.1, 5.7, 0.3) }
+    }
+
+    @Test
+    fun passWhenTestingAFloatArrayWhichContainsSameValues() {
+        val array = floatArrayOf(5.6f, 7.0f, 0.33f)
+        array shouldContainSame floatArrayOf(0.33f, 5.6f, 7.0f)
+        array shouldContainSame listOf(0.33f, 5.6f, 7.0f)
+    }
+
+    @Test
+    fun failWhenTestingAFloatArrayWhichDoesNotContainSameValues() {
+        val array = floatArrayOf(2.2f, 1.1f)
+        assertFails { array shouldContainSame floatArrayOf(2.2f, 1.1f, 2.2f) }
+        assertFails { array shouldContainSame listOf(2.2f, 1.1f, 2.2f) }
+    }
+
+    @Test
+    fun passWhenTestingALongArrayWhichContainsSameValues() {
+        val array = longArrayOf(1L, 4L, 120L)
+        array shouldContainSame longArrayOf(120L, 4L, 1L)
+        array shouldContainSame listOf(120L, 4L, 1L)
+    }
+
+    @Test
+    fun failWhenTestingALongArrayWhichDoesNotContainSameValues() {
+        val array = longArrayOf(4L, 3L)
+        assertFails { array shouldContainSame longArrayOf(4L, 3L, 4L) }
+        assertFails { array shouldContainSame listOf(4L, 3L, 4L) }
+    }
+
+    @Test
+    fun passWhenTestingAShortArrayWhichContainsSameValues() {
+        val array = shortArrayOf(5, 6, 7)
+        array shouldContainSame shortArrayOf(7, 5, 6)
+        array shouldContainSame listOf<Short>(7, 5, 6)
+    }
+
+    @Test
+    fun failWhenTestingAShortArrayWhichDoesNotContainSameValues() {
+        val array = shortArrayOf(6, 8, 8)
+        assertFails { array shouldContainSame shortArrayOf(6, 8) }
+        assertFails { array shouldContainSame listOf<Short>(6, 8) }
+    }
+
+    @Test
+    fun passWhenTestingAnIterableWhichContainsSameValues() {
+        val list = listOf(5, 8, 12)
+        list shouldContainSame listOf(12, 8, 5)
+    }
+
+    @Test
+    fun failWhenTestingAnIterableWhichDoesNotContainSameValues() {
+        val set = setOf(4, 9)
+        assertFails { set shouldContainSame setOf(4, 6) }
+    }
+
+    @Test
+    fun passWhenTestingAMapWhichContainsSameValues() {
+        val map = mapOf('a' to 1, 'b' to 2, 'c' to 3)
+        map shouldContainSame mapOf('b' to 2, 'a' to 1, 'c' to 3)
+    }
+
+    @Test
+    fun failWhenTestingAMapWhichDoesNotContainSameValues() {
+        val map = mapOf('a' to 1, 'b' to 2)
+        assertFails { map shouldContainSame mapOf('a' to 1, 'b' to 3) }
+    }
+
+    @Test
+    fun passWhenTestingAnIterableWhichContainsSameValuesOfAnArray() {
+        val anIterable = listOf("Berlin", "Washington")
+        val anArray = arrayOf("Washington", "Berlin")
+
+        anIterable.shouldContainSame(anArray)
+    }
+
+    @Test
+    fun passWhenTestingAnArrayWhichContainsSameValuesOfAnIterable() {
+        val anArray = arrayOf("Washington", "Berlin")
+        val anIterable = listOf("Berlin", "Washington")
+
+        anArray.shouldContainSame(anIterable)
+    }
+}

--- a/common/src/test/kotlin/org/amshove/kluent/collections/ShouldContainSameShould.kt
+++ b/common/src/test/kotlin/org/amshove/kluent/collections/ShouldContainSameShould.kt
@@ -91,9 +91,9 @@ class ShouldContainSameShould {
 
     @Test
     fun passWhenTestingAFloatArrayWhichContainsSameValues() {
-        val array = floatArrayOf(5.6f, 7.0f, 0.33f)
-        array shouldContainSame floatArrayOf(0.33f, 5.6f, 7.0f)
-        array shouldContainSame listOf(0.33f, 5.6f, 7.0f)
+        val array = floatArrayOf(5.0f, 7.0f, 3.0f)
+        array shouldContainSame floatArrayOf(3.0f, 5.0f, 7.0f)
+        array shouldContainSame listOf(3.0f, 5.0f, 7.0f)
     }
 
     @Test

--- a/docs/CollectionAssertions.md
+++ b/docs/CollectionAssertions.md
@@ -22,6 +22,8 @@ theIntArray.shouldNotBeEmpty()
 
 listOf(10, 15, 20) shouldContainAll listOf(10, 15, 20)
 listOf(10, 15, 20) shouldNotContainAny listOf(5, 7)
+
+listOf(1, 2, 3) shouldContainSame listOf(3, 1, 2)
 ```
 
 ## Maps


### PR DESCRIPTION
## Description
The current assertions doesn't support a comparisson between two arrays **with items in different order**. The `shouldEqual` excpects that the positions of both arrays are the same. This sometimes makes the test harder, because the developer needs to create the expected array in order, even if it is not relevant for the related test. Also, sometimes the class under test doesn't have a pre determined order for its items to be returned.

This PR is including the assertion `shouldContainSame`:

```
val list = listOf(1, 2, 3)
list shouldContainSame listOf(2, 1, 3)

val array = charArrayOf('a', 'f', 'z')
array shouldContainSame charArrayOf('z', 'f', 'a')
array shouldContainSame listOf('z', 'f', 'a')
```

## Checklist

- [x] I've added my name to the `AUTHORS` file, if it wasn't already present
- [x] Included code samples in `docs/CollectionAssertions.md`

## Finally
Let me know if there is something that need to be improved, or some mistake that I've made. I'm not a native english speaker, so I'm open to suggestions if the name `shouldCountainSame` is not clear enough.