### PR TITLE
Add Assertions for BigDecimal

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -109,6 +109,9 @@ number
 
 # Changelog
 
+# 1.41 (WIP)
+* Implement numerical assertions for `BigDecimal` | [Issue](https://github.com/MarkusAmshove/Kluent/issues/114) | [PR](https://github.com/MarkusAmshove/Kluent/pull/116)
+
 # 1.40
 * Implement `shouldContainSame` | [PR](https://github.com/MarkusAmshove/Kluent/pull/113) | thanks to [@fabriciorissetto](https://github.com/fabriciorissetto)
 

--- a/jvm/src/main/kotlin/org/amshove/kluent/BigDecimal.kt
+++ b/jvm/src/main/kotlin/org/amshove/kluent/BigDecimal.kt
@@ -1,0 +1,12 @@
+package org.amshove.kluent
+
+import org.amshove.kluent.internal.assertTrue
+import java.math.BigDecimal
+
+infix fun BigDecimal.shouldEqualTo(expected: BigDecimal) = this.apply { assertTrue("Expected $this to be equal to $expected", this == expected) }
+
+infix fun BigDecimal.shouldNotEqualTo(expected: BigDecimal) = this.apply { assertTrue("Expected $this to not be equal to $expected", this != expected ) }
+
+infix fun BigDecimal.shouldBeGreaterThan(expected: BigDecimal) = this.apply { assertTrue("Expected $this to be greater than $expected", this > expected ) }
+
+infix fun BigDecimal.shouldNotBeGreaterThan(expected: BigDecimal) = this.apply { assertTrue("Expected $this to not be greater than $expected", this <= expected )}

--- a/jvm/src/main/kotlin/org/amshove/kluent/BigDecimal.kt
+++ b/jvm/src/main/kotlin/org/amshove/kluent/BigDecimal.kt
@@ -35,3 +35,6 @@ infix fun BigDecimal.shouldNotBeLessOrEqualTo(expected: BigDecimal) =
 
 fun BigDecimal.shouldBePositive() =
     this.apply { assertTrue("Expected $this to be positive", this.compareTo(java.math.BigDecimal.ZERO) > 0) }
+
+fun BigDecimal.shouldBeNegative() =
+    this.apply { assertTrue("Expected $this to be negative", this.compareTo(java.math.BigDecimal.ZERO) < 0) }

--- a/jvm/src/main/kotlin/org/amshove/kluent/BigDecimal.kt
+++ b/jvm/src/main/kotlin/org/amshove/kluent/BigDecimal.kt
@@ -26,3 +26,9 @@ infix fun BigDecimal.shouldBeLessThan(expected: BigDecimal) =
 
 infix fun BigDecimal.shouldNotBeLessThan(expected: BigDecimal) =
     this.apply { assertTrue("Expected $this to not be less than $expected", this.compareTo(expected) >= 0) }
+
+infix fun BigDecimal.shouldBeLessOrEqualTo(expected: BigDecimal) =
+    this.apply { assertTrue("Expected $this to be less or equal to $expected", this.compareTo(expected) <= 0) }
+
+infix fun BigDecimal.shouldNotBeLessOrEqualTo(expected: BigDecimal) =
+    this.apply { assertTrue("Expected $this to not be less or equal to $expected", this.compareTo(expected) > 0) }

--- a/jvm/src/main/kotlin/org/amshove/kluent/BigDecimal.kt
+++ b/jvm/src/main/kotlin/org/amshove/kluent/BigDecimal.kt
@@ -3,10 +3,20 @@ package org.amshove.kluent
 import org.amshove.kluent.internal.assertTrue
 import java.math.BigDecimal
 
-infix fun BigDecimal.shouldEqualTo(expected: BigDecimal) = this.apply { assertTrue("Expected $this to be equal to $expected", this == expected) }
+infix fun BigDecimal.shouldEqualTo(expected: BigDecimal) =
+    this.apply { assertTrue("Expected $this to be equal to $expected", this == expected) }
 
-infix fun BigDecimal.shouldNotEqualTo(expected: BigDecimal) = this.apply { assertTrue("Expected $this to not be equal to $expected", this != expected ) }
+infix fun BigDecimal.shouldNotEqualTo(expected: BigDecimal) =
+    this.apply { assertTrue("Expected $this to not be equal to $expected", this != expected) }
 
-infix fun BigDecimal.shouldBeGreaterThan(expected: BigDecimal) = this.apply { assertTrue("Expected $this to be greater than $expected", this > expected ) }
+infix fun BigDecimal.shouldBeGreaterThan(expected: BigDecimal) =
+    this.apply { assertTrue("Expected $this to be greater than $expected", this > expected) }
 
-infix fun BigDecimal.shouldNotBeGreaterThan(expected: BigDecimal) = this.apply { assertTrue("Expected $this to not be greater than $expected", this <= expected )}
+infix fun BigDecimal.shouldNotBeGreaterThan(expected: BigDecimal) =
+    this.apply { assertTrue("Expected $this to not be greater than $expected", this <= expected) }
+
+infix fun BigDecimal.shouldBeGreaterOrEqualTo(expected: BigDecimal) =
+    this.apply { assertTrue("Expected $this to be greater or equal to $expected", this >= expected) }
+
+infix fun BigDecimal.shouldNotBeGreaterOrEqualTo(expected: BigDecimal) =
+    this.apply { assertTrue("Expected $this to not be greater or equal to $expected", this < expected) }

--- a/jvm/src/main/kotlin/org/amshove/kluent/BigDecimal.kt
+++ b/jvm/src/main/kotlin/org/amshove/kluent/BigDecimal.kt
@@ -20,3 +20,9 @@ infix fun BigDecimal.shouldBeGreaterOrEqualTo(expected: BigDecimal) =
 
 infix fun BigDecimal.shouldNotBeGreaterOrEqualTo(expected: BigDecimal) =
     this.apply { assertTrue("Expected $this to not be greater or equal to $expected", this < expected) }
+
+infix fun BigDecimal.shouldBeLessThan(expected: BigDecimal) =
+    this.apply { assertTrue("Expected $this to be less than $expected", this < expected) }
+
+infix fun BigDecimal.shouldNotBeLessThan(expected: BigDecimal) =
+    this.apply { assertTrue("Expected $this to not be less than $expected", this >= expected) }

--- a/jvm/src/main/kotlin/org/amshove/kluent/BigDecimal.kt
+++ b/jvm/src/main/kotlin/org/amshove/kluent/BigDecimal.kt
@@ -41,3 +41,25 @@ fun BigDecimal.shouldBePositive() =
 
 fun BigDecimal.shouldBeNegative() =
     this.apply { assertTrue("Expected $this to be negative", this.compareTo(java.math.BigDecimal.ZERO) < 0) }
+
+fun BigDecimal.shouldBeInRange(lowerBound: BigDecimal, upperBound: BigDecimal) = this.apply {
+    assertTrue(
+        "Expected $this to be between $lowerBound and $upperBound",
+        this.compareTo(lowerBound) >= 0 && this.compareTo(upperBound) <= 0
+    )
+}
+
+fun BigDecimal.shouldNotBeInRange(lowerBound: BigDecimal, upperBound: BigDecimal) = this.apply {
+    assertTrue(
+        "Expected $this to not be between $lowerBound and $upperBound",
+        this.compareTo(lowerBound) < 0 || this.compareTo(upperBound) > 0
+    )
+}
+
+infix fun BigDecimal.shouldBeInRange(range: ClosedRange<BigDecimal>) = this.apply {
+    this.shouldBeInRange(range.start, range.endInclusive)
+}
+
+infix fun BigDecimal.shouldNotBeInRange(range: ClosedRange<BigDecimal>) = this.apply {
+    this.shouldNotBeInRange(range.start, range.endInclusive)
+}

--- a/jvm/src/main/kotlin/org/amshove/kluent/BigDecimal.kt
+++ b/jvm/src/main/kotlin/org/amshove/kluent/BigDecimal.kt
@@ -32,3 +32,6 @@ infix fun BigDecimal.shouldBeLessOrEqualTo(expected: BigDecimal) =
 
 infix fun BigDecimal.shouldNotBeLessOrEqualTo(expected: BigDecimal) =
     this.apply { assertTrue("Expected $this to not be less or equal to $expected", this.compareTo(expected) > 0) }
+
+fun BigDecimal.shouldBePositive() =
+    this.apply { assertTrue("Expected $this to be positive", this.compareTo(java.math.BigDecimal.ZERO) > 0) }

--- a/jvm/src/main/kotlin/org/amshove/kluent/BigDecimal.kt
+++ b/jvm/src/main/kotlin/org/amshove/kluent/BigDecimal.kt
@@ -4,25 +4,25 @@ import org.amshove.kluent.internal.assertTrue
 import java.math.BigDecimal
 
 infix fun BigDecimal.shouldEqualTo(expected: BigDecimal) =
-    this.apply { assertTrue("Expected $this to be equal to $expected", this == expected) }
+    this.apply { assertTrue("Expected $this to be equal to $expected", this.compareTo(expected) == 0) }
 
 infix fun BigDecimal.shouldNotEqualTo(expected: BigDecimal) =
-    this.apply { assertTrue("Expected $this to not be equal to $expected", this != expected) }
+    this.apply { assertTrue("Expected $this to not be equal to $expected", this.compareTo(expected) != 0) }
 
 infix fun BigDecimal.shouldBeGreaterThan(expected: BigDecimal) =
-    this.apply { assertTrue("Expected $this to be greater than $expected", this > expected) }
+    this.apply { assertTrue("Expected $this to be greater than $expected", this.compareTo(expected) > 0) }
 
 infix fun BigDecimal.shouldNotBeGreaterThan(expected: BigDecimal) =
-    this.apply { assertTrue("Expected $this to not be greater than $expected", this <= expected) }
+    this.apply { assertTrue("Expected $this to not be greater than $expected", this.compareTo(expected) <= 0) }
 
 infix fun BigDecimal.shouldBeGreaterOrEqualTo(expected: BigDecimal) =
-    this.apply { assertTrue("Expected $this to be greater or equal to $expected", this >= expected) }
+    this.apply { assertTrue("Expected $this to be greater or equal to $expected", this.compareTo(expected) >= 0) }
 
 infix fun BigDecimal.shouldNotBeGreaterOrEqualTo(expected: BigDecimal) =
-    this.apply { assertTrue("Expected $this to not be greater or equal to $expected", this < expected) }
+    this.apply { assertTrue("Expected $this to not be greater or equal to $expected", this.compareTo(expected) < 0) }
 
 infix fun BigDecimal.shouldBeLessThan(expected: BigDecimal) =
-    this.apply { assertTrue("Expected $this to be less than $expected", this < expected) }
+    this.apply { assertTrue("Expected $this to be less than $expected", this.compareTo(expected) < 0) }
 
 infix fun BigDecimal.shouldNotBeLessThan(expected: BigDecimal) =
-    this.apply { assertTrue("Expected $this to not be less than $expected", this >= expected) }
+    this.apply { assertTrue("Expected $this to not be less than $expected", this.compareTo(expected) >= 0) }

--- a/jvm/src/main/kotlin/org/amshove/kluent/BigDecimal.kt
+++ b/jvm/src/main/kotlin/org/amshove/kluent/BigDecimal.kt
@@ -1,3 +1,6 @@
+// The Java API of operators prefers calls to `compareTo`
+@file:Suppress("ReplaceCallWithBinaryOperator")
+
 package org.amshove.kluent
 
 import org.amshove.kluent.internal.assertTrue

--- a/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/bigdecimal/BigDecimalShouldBeGreaterOrEqualTo.kt
+++ b/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/bigdecimal/BigDecimalShouldBeGreaterOrEqualTo.kt
@@ -1,0 +1,33 @@
+package org.amshove.kluent.tests.assertions.bigdecimal
+
+import org.amshove.kluent.shouldBeGreaterOrEqualTo
+import kotlin.test.Test
+import java.math.BigDecimal
+import kotlin.test.assertFails
+
+class BigDecimalShouldBeGreaterOrEqualTo {
+    @Test
+    fun passWhenTestingAgainstASmallerValue() {
+        val a = BigDecimal("158295189289152")
+        val b = BigDecimal("125081258125")
+
+        a.shouldBeGreaterOrEqualTo(b)
+    }
+
+    @Test
+    fun passWhenTestingAgainstAnEqualValue() {
+        val a = BigDecimal("5821995812")
+        val b = BigDecimal("5821995812")
+
+        a.shouldBeGreaterOrEqualTo(b)
+    }
+
+    @Test
+    fun failWhenTestingAgainstAGreaterValue() {
+        val a = BigDecimal("125102951205")
+        val b = BigDecimal("2215091250125")
+
+        assertFails { a.shouldBeGreaterOrEqualTo(b) }
+    }
+
+}

--- a/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/bigdecimal/BigDecimalShouldBeGreaterOrEqualToShould.kt
+++ b/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/bigdecimal/BigDecimalShouldBeGreaterOrEqualToShould.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 import java.math.BigDecimal
 import kotlin.test.assertFails
 
-class BigDecimalShouldBeGreaterOrEqualTo {
+class BigDecimalShouldBeGreaterOrEqualToShould {
     @Test
     fun passWhenTestingAgainstASmallerValue() {
         val a = BigDecimal("158295189289152")

--- a/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/bigdecimal/BigDecimalShouldBeGreaterThanShould.kt
+++ b/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/bigdecimal/BigDecimalShouldBeGreaterThanShould.kt
@@ -1,0 +1,32 @@
+package org.amshove.kluent.tests.assertions.bigdecimal
+
+import org.amshove.kluent.shouldBeGreaterThan
+import org.junit.Test
+import java.math.BigDecimal
+import kotlin.test.assertFails
+
+class BigDecimalShouldBeGreaterThanShould {
+    @Test
+    fun passWhenTestingAgainstASmallerValue() {
+        val a = BigDecimal("1250125809125809125")
+        val b = BigDecimal("125809125809125")
+
+        a.shouldBeGreaterThan(b)
+    }
+
+    @Test
+    fun failWhenTestingAgainstAnEqualValue() {
+        val a = BigDecimal("1250125809125809125")
+        val b = BigDecimal("1250125809125809125")
+
+        assertFails { a.shouldBeGreaterThan(b) }
+    }
+
+    @Test
+    fun failWhenTestingAgainstAGreaterValue() {
+        val a = BigDecimal("1250125809125809125")
+        val b = BigDecimal("125012580912580912555")
+
+        assertFails { a.shouldBeGreaterThan(b) }
+    }
+}

--- a/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/bigdecimal/BigDecimalShouldBeInRangeShould.kt
+++ b/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/bigdecimal/BigDecimalShouldBeInRangeShould.kt
@@ -1,0 +1,46 @@
+package org.amshove.kluent.tests.assertions.bigdecimal
+
+import org.amshove.kluent.shouldBeInRange
+import java.math.BigDecimal
+import kotlin.test.Test
+import kotlin.test.assertFails
+
+class BigDecimalShouldBeInRangeShould {
+    @Test
+    fun passWhenAValueIsWithinTheRange() {
+        BigDecimal("0.15").shouldBeInRange(BigDecimal.valueOf(10, 2), BigDecimal.valueOf(10, 1) )
+        BigDecimal("0.15").shouldBeInRange(BigDecimal.valueOf(10, 2) .. BigDecimal.valueOf(10, 1) )
+    }
+
+    @Test
+    fun passWhenAValueIsExactlyTheLowerBound() {
+        BigDecimal.valueOf(1000, -1000).shouldBeInRange(BigDecimal.valueOf(1000, -1000), BigDecimal.valueOf(1005, -1000))
+        BigDecimal.valueOf(1000, -1000).shouldBeInRange(BigDecimal.valueOf(1000, -1000) .. BigDecimal.valueOf(1005, -1000))
+    }
+
+    @Test
+    fun passWhenAValueIsExactlyTheUpperBound() {
+        BigDecimal.valueOf(1000, -1).shouldBeInRange(BigDecimal("1000"), BigDecimal("10000"))
+        BigDecimal.valueOf(1000, -1).shouldBeInRange(BigDecimal("1000") .. BigDecimal("10000"))
+    }
+
+    @Test
+    fun failWhenAValueIsBelowTheLowerBound() {
+        assertFails {
+            BigDecimal("500").shouldBeInRange(BigDecimal("600"), BigDecimal("700"))
+        }
+        assertFails {
+            BigDecimal("500").shouldBeInRange(BigDecimal("600") .. BigDecimal("700"))
+        }
+    }
+
+    @Test
+    fun failWhenAValueIsAboveTheUpperBound() {
+        assertFails {
+            BigDecimal("800").shouldBeInRange(BigDecimal("600"), BigDecimal("700"))
+        }
+        assertFails {
+            BigDecimal("800").shouldBeInRange(BigDecimal("600") .. BigDecimal("700"))
+        }
+    }
+}

--- a/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/bigdecimal/BigDecimalShouldBeLessOrEqualToShould.kt
+++ b/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/bigdecimal/BigDecimalShouldBeLessOrEqualToShould.kt
@@ -1,0 +1,32 @@
+package org.amshove.kluent.tests.assertions.bigdecimal
+
+import org.amshove.kluent.shouldBeLessOrEqualTo
+import java.math.BigDecimal
+import kotlin.test.Test
+import kotlin.test.assertFails
+
+class BigDecimalShouldBeLessOrEqualToShould {
+    @Test
+    fun passWhenTestingAgainstAGreaterValue() {
+        val a = BigDecimal("100")
+        val b = BigDecimal.valueOf(10, -2)
+
+        a.shouldBeLessOrEqualTo(b)
+    }
+
+    @Test
+    fun passWhenTestingAgainstAnEqualValue() {
+        val a = BigDecimal("100")
+        val b = BigDecimal.valueOf(10, -1)
+
+        a.shouldBeLessOrEqualTo(b)
+    }
+
+    @Test
+    fun failWhenTestingAgainstASmallerValue() {
+        val a = BigDecimal("10000")
+        val b = BigDecimal.valueOf(10, 1)
+
+        assertFails { a.shouldBeLessOrEqualTo(b) }
+    }
+}

--- a/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/bigdecimal/BigDecimalShouldBeLessThanShould.kt
+++ b/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/bigdecimal/BigDecimalShouldBeLessThanShould.kt
@@ -1,0 +1,23 @@
+package org.amshove.kluent.tests.assertions.bigdecimal
+
+import org.amshove.kluent.shouldBeLessThan
+import java.math.BigDecimal
+import kotlin.test.Test
+import kotlin.test.assertFails
+
+class BigDecimalShouldBeLessThanShould {
+    @Test
+    fun passWhenTestingAgainstAGreaterValue() {
+        BigDecimal("12345").shouldBeLessThan(BigDecimal("1582918952"))
+    }
+
+    @Test
+    fun failWhenTestingAgainstASmallerValue() {
+        assertFails { BigDecimal("123124091250").shouldBeLessThan(BigDecimal("15251152")) }
+    }
+
+    @Test
+    fun failWhenTestingAgainstAnEqualValue() {
+        assertFails { BigDecimal("9815289512985").shouldBeLessThan(BigDecimal("9815289512985")) }
+    }
+}

--- a/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/bigdecimal/BigDecimalShouldBeNegativeShould.kt
+++ b/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/bigdecimal/BigDecimalShouldBeNegativeShould.kt
@@ -1,0 +1,33 @@
+package org.amshove.kluent.tests.assertions.bigdecimal
+
+import org.amshove.kluent.shouldBeNegative
+import kotlin.test.Test
+import java.math.BigDecimal
+import kotlin.test.assertFails
+
+class BigDecimalShouldBeNegativeShould {
+    @Test
+    fun passWhenTestingANegativeValue() {
+        BigDecimal("-10").shouldBeNegative()
+    }
+
+    @Test
+    fun passWhenTestingANegativeValueWithScale() {
+        BigDecimal.valueOf(-5, 1).shouldBeNegative()
+    }
+
+    @Test
+    fun failWhenTestingAPositiveValue() {
+        assertFails { BigDecimal("123").shouldBeNegative() }
+    }
+
+    @Test
+    fun failWhenTestingAPositiveValueWithScale() {
+        assertFails { BigDecimal.valueOf(1, 1).shouldBeNegative() }
+    }
+
+    @Test
+    fun failWhenTestingAgainstZero() {
+        assertFails { BigDecimal.valueOf(0).shouldBeNegative() }
+    }
+}

--- a/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/bigdecimal/BigDecimalShouldBePositiveShould.kt
+++ b/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/bigdecimal/BigDecimalShouldBePositiveShould.kt
@@ -1,0 +1,33 @@
+package org.amshove.kluent.tests.assertions.bigdecimal
+
+import org.amshove.kluent.shouldBePositive
+import kotlin.test.Test
+import java.math.BigDecimal
+import kotlin.test.assertFails
+
+class BigDecimalShouldBePositiveShould {
+    @Test
+    fun passWhenTestingAPositiveValue() {
+        BigDecimal("123").shouldBePositive()
+    }
+
+    @Test
+    fun passWhenTestingAPositiveValueWithScale() {
+        BigDecimal.valueOf(1, 1).shouldBePositive()
+    }
+
+    @Test
+    fun failWhenTestingANegativeValue() {
+        assertFails { BigDecimal("-10").shouldBePositive() }
+    }
+
+    @Test
+    fun failWhenTestingANegativeValueWithScale() {
+        assertFails { BigDecimal.valueOf(-5, 1).shouldBePositive() }
+    }
+
+    @Test
+    fun failWhenTestingAgainstZero() {
+        assertFails { BigDecimal.valueOf(0).shouldBePositive() }
+    }
+}

--- a/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/bigdecimal/BigDecimalShouldEqualToShould.kt
+++ b/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/bigdecimal/BigDecimalShouldEqualToShould.kt
@@ -2,6 +2,7 @@ package org.amshove.kluent.tests.assertions.bigdecimal
 
 import org.amshove.kluent.shouldEqualTo
 import java.math.BigDecimal
+import java.math.BigInteger
 import kotlin.test.Test
 import kotlin.test.assertFails
 
@@ -12,6 +13,14 @@ class BigDecimalShouldEqualToShould {
     fun passWhenComparingTwoEqualValues() {
         val a = BigDecimal(1925112616126126)
         val b = BigDecimal(1925112616126126)
+        a.shouldEqualTo(b)
+    }
+
+    @Test
+    fun passWhenComparingTwoEqualValuesWithDifferentScale() {
+        val a = BigDecimal(BigInteger.valueOf(1), -1) // 10
+        val b = BigDecimal(BigInteger.valueOf(10)) // 10
+
         a.shouldEqualTo(b)
     }
 

--- a/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/bigdecimal/BigDecimalShouldEqualToShould.kt
+++ b/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/bigdecimal/BigDecimalShouldEqualToShould.kt
@@ -1,0 +1,25 @@
+package org.amshove.kluent.tests.assertions.bigdecimal
+
+import org.amshove.kluent.shouldEqualTo
+import java.math.BigDecimal
+import kotlin.test.Test
+import kotlin.test.assertFails
+
+
+class BigDecimalShouldEqualToShould {
+
+    @Test
+    fun passWhenComparingTwoEqualValues() {
+        val a = BigDecimal(1925112616126126)
+        val b = BigDecimal(1925112616126126)
+        a.shouldEqualTo(b)
+    }
+
+    @Test
+    fun failWhenComparingUnequalValues() {
+        val a = BigDecimal(1925112616126126)
+        val b = BigDecimal(1925112616126127)
+        assertFails { a.shouldEqualTo(b) }
+    }
+
+}

--- a/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/bigdecimal/BigDecimalShouldNotBeGreaterOrEqualTo.kt
+++ b/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/bigdecimal/BigDecimalShouldNotBeGreaterOrEqualTo.kt
@@ -1,0 +1,26 @@
+package org.amshove.kluent.tests.assertions.bigdecimal
+
+import org.amshove.kluent.shouldNotBeGreaterOrEqualTo
+import java.math.BigDecimal
+import kotlin.test.Test
+import kotlin.test.assertFails
+
+class BigDecimalNotShouldNotBeGreaterOrEqualTo {
+    @Test
+    fun passWhenTestingAgainstAGreaterValue() {
+        val a = BigDecimal("1234567890")
+        val b = BigDecimal("1234567895125")
+
+        a.shouldNotBeGreaterOrEqualTo(b)
+    }
+
+    @Test
+    fun failWhenTestingAgainstASmallerValue() {
+        assertFails { BigDecimal("12345").shouldNotBeGreaterOrEqualTo(BigDecimal("123")) }
+    }
+
+    @Test
+    fun failWhenTestingAgainstAnEqualValue() {
+        assertFails { BigDecimal("12345").shouldNotBeGreaterOrEqualTo(BigDecimal("12345")) }
+    }
+}

--- a/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/bigdecimal/BigDecimalShouldNotBeGreaterOrEqualTo.kt
+++ b/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/bigdecimal/BigDecimalShouldNotBeGreaterOrEqualTo.kt
@@ -5,7 +5,7 @@ import java.math.BigDecimal
 import kotlin.test.Test
 import kotlin.test.assertFails
 
-class BigDecimalNotShouldNotBeGreaterOrEqualTo {
+class BigDecimalShouldNotBeGreaterOrEqualTo {
     @Test
     fun passWhenTestingAgainstAGreaterValue() {
         val a = BigDecimal("1234567890")

--- a/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/bigdecimal/BigDecimalShouldNotBeGreaterThanShould.kt
+++ b/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/bigdecimal/BigDecimalShouldNotBeGreaterThanShould.kt
@@ -1,0 +1,29 @@
+package org.amshove.kluent.tests.assertions.bigdecimal
+
+import org.amshove.kluent.shouldNotBeGreaterThan
+import org.junit.Test
+import java.math.BigDecimal
+import kotlin.test.assertFails
+
+class BigDecimalShouldNotBeGreaterThanShould {
+    @Test
+    fun passWhenTestingAgainstAGreaterValue() {
+        val a = BigDecimal("9125125")
+        val b = BigDecimal("12589125125")
+        a.shouldNotBeGreaterThan(b)
+    }
+
+    @Test
+    fun passWhenTestingAgainstAnEqualValue() {
+        val a = BigDecimal("2112580125")
+        val b = BigDecimal("2112580125")
+        a.shouldNotBeGreaterThan(b)
+    }
+
+    @Test
+    fun failWhenTestingAgainstASmallerValue() {
+        val a = BigDecimal("12412491284")
+        val b = BigDecimal("12412284")
+        assertFails { a.shouldNotBeGreaterThan(b) }
+    }
+}

--- a/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/bigdecimal/BigDecimalShouldNotBeInRangeShould.kt
+++ b/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/bigdecimal/BigDecimalShouldNotBeInRangeShould.kt
@@ -1,0 +1,52 @@
+package org.amshove.kluent.tests.assertions.bigdecimal
+
+import org.amshove.kluent.shouldNotBeInRange
+import java.math.BigDecimal
+import kotlin.test.Test
+import kotlin.test.assertFails
+
+class BigDecimalShouldNotBeInRangeShould {
+    @Test
+    fun passWhenAValueIsBelowTheLowerBound() {
+        BigDecimal("500").shouldNotBeInRange(BigDecimal("600"), BigDecimal("700"))
+        BigDecimal("500").shouldNotBeInRange(BigDecimal("600") .. BigDecimal("700"))
+    }
+
+    @Test
+    fun passWhenAValueIsAboveTheUpperBound() {
+        BigDecimal("800").shouldNotBeInRange(BigDecimal("600"), BigDecimal("700"))
+        BigDecimal("800").shouldNotBeInRange(BigDecimal("600") .. BigDecimal("700"))
+    }
+
+    @Test
+    fun failWhenAValueIsWithinTheRange() {
+        assertFails {
+            BigDecimal("0.15").shouldNotBeInRange(BigDecimal.valueOf(10, 2), BigDecimal.valueOf(10, 1))
+        }
+        assertFails {
+            BigDecimal("0.15").shouldNotBeInRange(BigDecimal.valueOf(10, 2)..BigDecimal.valueOf(10, 1))
+        }
+    }
+
+    @Test
+    fun failWhenAValueIsExactlyTheLowerBound() {
+        assertFails {
+            BigDecimal.valueOf(1000, -1000)
+                .shouldNotBeInRange(BigDecimal.valueOf(1000, -1000), BigDecimal.valueOf(1005, -1000))
+        }
+        assertFails {
+            BigDecimal.valueOf(1000, -1000)
+                .shouldNotBeInRange(BigDecimal.valueOf(1000, -1000)..BigDecimal.valueOf(1005, -1000))
+        }
+    }
+
+    @Test
+    fun failWhenAValueIsExactlyTheUpperBound() {
+        assertFails {
+            BigDecimal.valueOf(1000, -1).shouldNotBeInRange(BigDecimal("1000"), BigDecimal("10000"))
+        }
+        assertFails {
+            BigDecimal.valueOf(1000, -1).shouldNotBeInRange(BigDecimal("1000")..BigDecimal("10000"))
+        }
+    }
+}

--- a/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/bigdecimal/BigDecimalShouldNotBeLessOrEqualToShould.kt
+++ b/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/bigdecimal/BigDecimalShouldNotBeLessOrEqualToShould.kt
@@ -1,0 +1,32 @@
+package org.amshove.kluent.tests.assertions.bigdecimal
+
+import org.amshove.kluent.shouldNotBeLessOrEqualTo
+import java.math.BigDecimal
+import kotlin.test.Test
+import kotlin.test.assertFails
+
+class BigDecimalShouldNotBeLessOrEqualToShould {
+    @Test
+    fun passWhenTestingAgainstASmallerValue() {
+        val a = BigDecimal("10000")
+        val b = BigDecimal.valueOf(10, 1)
+
+        a.shouldNotBeLessOrEqualTo(b)
+    }
+
+    @Test
+    fun failWhenTestingAgainstAGreaterValue() {
+        val a = BigDecimal("100")
+        val b = BigDecimal.valueOf(10, -2)
+
+        assertFails { a.shouldNotBeLessOrEqualTo(b) }
+    }
+
+    @Test
+    fun failWhenTestingAgainstAnEqualValue() {
+        val a = BigDecimal("100")
+        val b = BigDecimal.valueOf(10, -1)
+
+        assertFails { a.shouldNotBeLessOrEqualTo(b) }
+    }
+}

--- a/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/bigdecimal/BigDecimalShouldNotBeLessThanShould.kt
+++ b/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/bigdecimal/BigDecimalShouldNotBeLessThanShould.kt
@@ -1,0 +1,23 @@
+package org.amshove.kluent.tests.assertions.bigdecimal
+
+import org.amshove.kluent.shouldNotBeLessThan
+import org.junit.Test
+import java.math.BigDecimal
+import kotlin.test.assertFails
+
+class BigDecimalShouldNotBeLessThanShould {
+    @Test
+    fun passWhenTestingAgainstASmallerValue() {
+        BigDecimal("123124091250").shouldNotBeLessThan(BigDecimal("15251152"))
+    }
+
+    @Test
+    fun passWhenTestingAgainstAnEqualValue() {
+        BigDecimal("9815289512985").shouldNotBeLessThan(BigDecimal("9815289512985"))
+    }
+
+    @Test
+    fun failWhenTestingAgainstAGreaterValue() {
+        assertFails { BigDecimal("12345").shouldNotBeLessThan(BigDecimal("1582918952")) }
+    }
+}

--- a/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/bigdecimal/BigDecimalShouldNotEqualToShould.kt
+++ b/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/bigdecimal/BigDecimalShouldNotEqualToShould.kt
@@ -1,0 +1,23 @@
+package org.amshove.kluent.tests.assertions.bigdecimal
+
+import org.amshove.kluent.shouldNotEqualTo
+import org.junit.Test
+import java.math.BigDecimal
+import kotlin.test.assertFails
+
+class BigDecimalShouldNotEqualToShould {
+
+    @Test
+    fun passWhenComparingUnequalValues() {
+        val a = BigDecimal("590125871260891762126")
+        val b = BigDecimal("590125871260891762127")
+        a.shouldNotEqualTo(b)
+    }
+
+    @Test
+    fun failWhenComparingEqualValues() {
+        val a = BigDecimal("590125871260891762126")
+        val b = BigDecimal("590125871260891762126")
+        assertFails { a.shouldNotEqualTo(b) }
+    }
+}


### PR DESCRIPTION
Related issue: #114 

This PR brings all numerical assertions from the `common` module to the Java type `BigInteger`.

- [x] `shouldEqualTo`
- [x] `shouldNotEqualTo`
- [x] `shouldBeGreaterThan`
- [x] `shouldNotBeGreaterThan`
- [x] `shouldBeGreaterOrEqualTo`
- [x] `shouldNotBeGreaterOrEqualTo`
- [x] `shouldBeLessThan`
- [x] `shouldNotBeLessThan`
- [x] `shouldBeLessOrEqualTo`
- [x] `shouldNotBeLessOrEqualTo`
- [x] `shouldBePositive`
- [x] `shouldBeNegative`
- [x] `shouldBeInRange` (Unclear what overloads this should have)
- [x] `shouldNotBeInRange` (Unclear what overloads this should have)
