### PR TITLE
Update mockito-kotlin to 2.0.0

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -25,3 +25,5 @@
 1. Deconinck Alban - [@neyb](https://github.com/neyb) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=neyb))
 1. Fabrício Rissetto - [@fabriciorissetto](https://github.com/fabriciorissetto) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=fabriciorissetto))
 1. Vitus Ortner - [@vitusortner](https://github.com/vitusortner) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=vitusortner))
+1. Caleb Brinkman - [@floralvikings](https://github.com/floralvikings) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=floralvikings))
+

--- a/jvm/build.gradle
+++ b/jvm/build.gradle
@@ -9,6 +9,8 @@ if(isAndroid) {
 def artifactName = isAndroid ? 'kluent-android' : 'kluent'
 configurePublishing(artifactName)
 
+def mockito_kotlin_version = "2.0.0"
+
 dependencies {
     expectedBy project(':kluent-common')
     implementation libs.kotlin_stdlib_jvm
@@ -22,9 +24,9 @@ dependencies {
 
     // TODO: To be removed
     implementation libs.junit
-    implementation "com.nhaarman:mockito-kotlin-kt1.1:$mockito_version"
+    implementation "com.nhaarman.mockitokotlin2:mockito-kotlin:$mockito_kotlin_version"
     testImplementation "org.jetbrains.spek:spek:$spek_version"
-    testImplementation "com.nhaarman:mockito-kotlin-kt1.1:$mockito_version"
+    testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:$mockito_kotlin_version"
 }
 
 sourceSets {

--- a/jvm/src/main/kotlin/org/amshove/kluent/Mocking.kt
+++ b/jvm/src/main/kotlin/org/amshove/kluent/Mocking.kt
@@ -1,9 +1,9 @@
 package org.amshove.kluent
 
-import com.nhaarman.mockito_kotlin.never
-import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
-import com.nhaarman.mockito_kotlin.verifyZeroInteractions
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import org.mockito.AdditionalAnswers.*
 import org.mockito.Mockito.`when`
 import org.mockito.internal.util.MockUtil
@@ -15,7 +15,7 @@ import kotlin.reflect.KClass
 @Suppress("UNUSED_PARAMETER") // Backward compatibility
 inline fun <reified T : Any> mock(targetClass: KClass<out T>): T = mock()
 
-inline fun <reified T : Any> mock(): T = com.nhaarman.mockito_kotlin.mock()
+inline fun <reified T : Any> mock(): T = com.nhaarman.mockitokotlin2.mock()
 
 infix fun <T> VerifyKeyword.on(mock: T) = verify(mock)
 
@@ -35,7 +35,7 @@ infix fun <T> T.was(n: CalledKeyword) = n
 @Suppress("UNUSED_PARAMETER") // Backward compatibility
 inline fun <reified T : Any> any(kClass: KClass<T>): T = any()
 
-inline fun <reified T : Any> any(): T = com.nhaarman.mockito_kotlin.any()
+inline fun <reified T : Any> any(): T = com.nhaarman.mockitokotlin2.any()
 
 infix fun <T> WhenKeyword.calling(methodCall: T): OngoingStubbing<T> = `when`(methodCall)
 

--- a/jvm/src/test/kotlin/org/amshove/kluent/tests/backtickmockings/StubTests.kt
+++ b/jvm/src/test/kotlin/org/amshove/kluent/tests/backtickmockings/StubTests.kt
@@ -1,6 +1,6 @@
 package org.amshove.kluent.tests.backtickmockings
 
-import com.nhaarman.mockito_kotlin.reset
+import com.nhaarman.mockitokotlin2.reset
 import org.amshove.kluent.*
 import org.amshove.kluent.tests.helpclasses.Database
 import org.amshove.kluent.tests.helpclasses.Person

--- a/jvm/src/test/kotlin/org/amshove/kluent/tests/mocking/StubTests.kt
+++ b/jvm/src/test/kotlin/org/amshove/kluent/tests/mocking/StubTests.kt
@@ -1,7 +1,7 @@
 package org.amshove.kluent.tests.mocking
 
-import com.nhaarman.mockito_kotlin.anyVararg
-import com.nhaarman.mockito_kotlin.reset
+import com.nhaarman.mockitokotlin2.anyVararg
+import com.nhaarman.mockitokotlin2.reset
 import org.amshove.kluent.*
 import org.amshove.kluent.tests.helpclasses.Database
 import org.amshove.kluent.tests.helpclasses.Person


### PR DESCRIPTION
Description
Updates `mockito-kotlin` to version `2.0.0`.  The version currently in use
has a requirement on `kotlin-reflect`, which is causing issues with the
version of Kotlin I'm using. 

Checklist

- [x] I've added my name to the `AUTHORS` file, if it wasn't already present.

