### PR TITLE
Update Mockint.kt to include implementation of itReturnsConsecutively

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -30,3 +30,4 @@
 1. Ivan Atanasov - [@IvanAtanasov89](https://github.com/IvanAtanasov89) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=IvanAtanasov89))
 1. Ruben Gees - [@rubengees](https://github.com/rubengees) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=rubengees))
 1. Juechen Wang - [@wangjuechen](https://github.com/wangjuechen) ([Contributions])(https://github.com/MarkusAmshove/Kluent/commits?author=wangjuechen))
+1. Joan Fuentes - [@nescafemix](https://github.com/Nescafemix) ([Contributions])(https://github.com/MarkusAmshove/Kluent/commits?author=Nescafemix))

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -29,5 +29,5 @@
 1. Jonathan Cornaz - [@jcornaz](https://github.com/jcornaz) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=jcornaz))
 1. Ivan Atanasov - [@IvanAtanasov89](https://github.com/IvanAtanasov89) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=IvanAtanasov89))
 1. Ruben Gees - [@rubengees](https://github.com/rubengees) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=rubengees))
-1. Juechen Wang - [@wangjuechen](https://github.com/wangjuechen) ([Contributions])(https://github.com/MarkusAmshove/Kluent/commits?author=wangjuechen))
-1. Joan Fuentes - [@nescafemix](https://github.com/Nescafemix) ([Contributions])(https://github.com/MarkusAmshove/Kluent/commits?author=Nescafemix))
+1. Juechen Wang - [@wangjuechen](https://github.com/wangjuechen) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=wangjuechen))
+1. Joan Fuentes - [@nescafemix](https://github.com/Nescafemix) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=Nescafemix))

--- a/jvm/src/main/kotlin/org/amshove/kluent/Mocking.kt
+++ b/jvm/src/main/kotlin/org/amshove/kluent/Mocking.kt
@@ -41,6 +41,10 @@ infix fun <T> WhenKeyword.calling(methodCall: T): OngoingStubbing<T> = `when`(me
 
 infix fun <T> OngoingStubbing<T>.itReturns(value: T): OngoingStubbing<T> = this.thenReturn(value)
 
+inline infix fun <reified T> OngoingStubbing<T>.itReturnsConsecutively(ts: List<T>): OngoingStubbing<T> {
+    return this.thenReturn(ts[0], *ts.drop(1).toTypedArray())
+}
+
 infix fun <T> OngoingStubbing<T>.itThrows(value: Throwable): OngoingStubbing<T> = this.thenThrow(value)
 
 infix fun <T> OngoingStubbing<T>.itAnswers(value: (InvocationOnMock) -> T): OngoingStubbing<T> = this.thenAnswer(value)


### PR DESCRIPTION
Description
the itReturns method doesn't let to return multiple values (something that Mockito resolve with an implementation of thenReturn(firstvalue, array_of_next_values))

Expected result:
we can return several values in case we need it

example: 
When calling mockView.isReady itReturnsConsecutively  listOf(true, false)

Checklist
<!--- We'd like to thank you for your help, appreciate them and give you credit for it. Please check the checkboxes below as you complete them -->

- [x] I've added my name to the `AUTHORS` file, if it wasn't already present.

