### PR TITLE
Bugfix gradle 5.1.1 compatibility

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -31,3 +31,4 @@
 1. Ruben Gees - [@rubengees](https://github.com/rubengees) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=rubengees))
 1. Juechen Wang - [@wangjuechen](https://github.com/wangjuechen) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=wangjuechen))
 1. Anton Sheihman [@sheix_](https://github.com/sheix_) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=rubengees))
+1. Vaios Tsitsonis [@St4B](https://github.com/St4B) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=st4b))

--- a/jvm/build.gradle
+++ b/jvm/build.gradle
@@ -9,7 +9,7 @@ if(isAndroid) {
 def artifactName = isAndroid ? 'kluent-android' : 'kluent'
 configurePublishing(artifactName)
 
-def mockito_kotlin_version = "2.0.0"
+def mockito_kotlin_version = "2.1.0"
 
 dependencies {
     expectedBy project(':kluent-common')


### PR DESCRIPTION
Description
After updating to Android Studio 3.4.1 and using  Gradle 5.1.1, the tests could not be build. 
The reason was that it could not find the Mockito library (caused Unresolved reference error).
By adding manual in my build file a later version of mockito the problem was solved

Checklist
<!--- We'd like to thank you for your help, appreciate them and give you credit for it. Please check the checkboxes below as you complete them -->

- [x] I've added my name to the `AUTHORS` file, if it wasn't already present.

