### PR TITLE
ShouldEqual shouldn't care about creationOrder of maps

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -32,3 +32,4 @@
 1. Juechen Wang - [@wangjuechen](https://github.com/wangjuechen) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=wangjuechen))
 1. Anton Sheihman [@sheix_](https://github.com/sheix_) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=rubengees))
 1. Vaios Tsitsonis [@St4B](https://github.com/St4B) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=st4b))
+1. Jógvan Olsen - [@jeggy](https://github.com/jeggy) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=jeggy))

--- a/common/src/main/kotlin/org/amshove/kluent/Collections.kt
+++ b/common/src/main/kotlin/org/amshove/kluent/Collections.kt
@@ -448,6 +448,10 @@ infix fun <K, M : Map<K, *>> M.shouldEqual(expected: M): M = apply { assertMapEq
 
 infix fun <K, M : Map<K, *>> M.shouldNotEqual(expected: M): M = apply { assertMapNotEquals(this, expected) }
 
+infix fun <K, M : Map<K, *>> M.shouldEqualUnordered(expected: M): M = apply { assertMapEqualsUnordered(this, expected) }
+
+infix fun <K, M : Map<K, *>> M.shouldNotEqualUnordered(expected: M): M = apply { assertMapNotEqualsUnordered(this, expected) }
+
 infix fun <K, M : Map<K, *>> M.shouldHaveKey(theKey: K): M = apply { if (this.containsKey(theKey)) Unit else failExpectedActual("Map should contain key \"$theKey\"", "the Map to contain key \"$theKey\"", joinKeys(this)) }
 
 infix fun <K, M : Map<K, *>> M.shouldNotHaveKey(theKey: K): M = apply { if (!this.containsKey(theKey)) Unit else failExpectedActual("Map should not contain key \"$theKey\"", "the Map to not contain the key \"$theKey\"", joinKeys(this)) }

--- a/common/src/main/kotlin/org/amshove/kluent/internal/Assertions.kt
+++ b/common/src/main/kotlin/org/amshove/kluent/internal/Assertions.kt
@@ -41,10 +41,9 @@ internal fun <K, V, M : Map<K, V>> mapsEqual(m1: M?, m2: M?): Boolean {
     if (m1 == null || m2 == null) return false
     if (m1.size != m2.size) return false
 
-    val m1Iter = m1.toList()
-    val m2Iter = m2.toList()
-    for (index in m1Iter.indices) {
-        if (m1Iter[index] != m2Iter[index]) {
+    val iter = m1.toList()
+    for (i in iter) {
+        if (m2[i.first] != i.second) {
             return false
         }
     }

--- a/common/src/main/kotlin/org/amshove/kluent/internal/Assertions.kt
+++ b/common/src/main/kotlin/org/amshove/kluent/internal/Assertions.kt
@@ -37,13 +37,38 @@ internal fun <K, V, M : Map<K, V>> assertMapNotEquals(m1: M, m2: M) {
     }
 }
 
+internal fun <K, V, M : Map<K, V>> assertMapEqualsUnordered(m1: M, m2: M) {
+    if (!mapsEqualUnordered(m1, m2)) {
+        failFirstSecond("Expected Maps to contain same values, but were different", joinPairs(m1), joinPairs(m2))
+    }
+}
+
+internal fun <K, V, M : Map<K, V>> assertMapNotEqualsUnordered(m1: M, m2: M) {
+    if (mapsEqualUnordered(m1, m2)) {
+        failFirstSecond("Expected Maps to not contain same values, but did", joinPairs(m1), joinPairs(m2))
+    }
+}
+
 internal fun <K, V, M : Map<K, V>> mapsEqual(m1: M?, m2: M?): Boolean {
     if (m1 == null || m2 == null) return false
     if (m1.size != m2.size) return false
 
-    val iter = m1.toList()
-    for (i in iter) {
-        if (m2[i.first] != i.second) {
+    val m1Iter = m1.toList()
+    val m2Iter = m2.toList()
+    for (index in m1Iter.indices) {
+        if (m1Iter[index] != m2Iter[index]) {
+            return false
+        }
+    }
+    return true
+}
+
+internal fun <K, V, M : Map<K, V>> mapsEqualUnordered(m1: M?, m2: M?): Boolean {
+    if (m1 == null || m2 == null) return false
+    if (m1.size != m2.size) return false
+
+    for ((key, value) in m1) {
+        if (m2[key] != value) {
             return false
         }
     }

--- a/common/src/test/kotlin/org/amshove/kluent/collections/ShouldEqualShould.kt
+++ b/common/src/test/kotlin/org/amshove/kluent/collections/ShouldEqualShould.kt
@@ -44,14 +44,6 @@ class ShouldEqualShould {
     }
 
     @Test
-    fun passWhenMapCreationOrderNotTheSame() {
-        val firstMap = mapOf(2 to Person("C", "D"), 1 to Person("A", "B"))
-        val secondMap = mapOf(1 to Person("A", "B"), 2 to Person("C", "D"))
-
-        firstMap shouldEqual secondMap
-    }
-
-    @Test
     fun failWhenTestingDifferentMaps() {
         val firstMap = mapOf(1 to Person("A", "B"), 2 to Person("C", "D"))
         val secondMap = mapOf(1 to Person("A", "C"), 2 to Person("D", "C"))

--- a/common/src/test/kotlin/org/amshove/kluent/collections/ShouldEqualShould.kt
+++ b/common/src/test/kotlin/org/amshove/kluent/collections/ShouldEqualShould.kt
@@ -44,6 +44,14 @@ class ShouldEqualShould {
     }
 
     @Test
+    fun passWhenMapCreationOrderNotTheSame() {
+        val firstMap = mapOf(2 to Person("C", "D"), 1 to Person("A", "B"))
+        val secondMap = mapOf(1 to Person("A", "B"), 2 to Person("C", "D"))
+
+        firstMap shouldEqual secondMap
+    }
+
+    @Test
     fun failWhenTestingDifferentMaps() {
         val firstMap = mapOf(1 to Person("A", "B"), 2 to Person("C", "D"))
         val secondMap = mapOf(1 to Person("A", "C"), 2 to Person("D", "C"))

--- a/common/src/test/kotlin/org/amshove/kluent/collections/ShouldEqualUnorderedShould.kt
+++ b/common/src/test/kotlin/org/amshove/kluent/collections/ShouldEqualUnorderedShould.kt
@@ -1,0 +1,24 @@
+package org.amshove.kluent.collections
+
+import org.amshove.kluent.*
+import kotlin.test.Test
+import kotlin.test.assertFails
+
+class ShouldEqualUnorderedShould {
+    @Test
+    fun failWhenMapCreationOrderNotTheSame() {
+        val firstMap = mapOf(2 to Person("C", "D"), 1 to Person("A", "B"))
+        val secondMap = mapOf(1 to Person("A", "B"), 2 to Person("C", "D"))
+
+        assertFails { firstMap shouldEqual secondMap }
+    }
+
+    @Test
+    fun passWhenUnorderedMapsAreTheSame() {
+        val firstMap = mapOf(2 to Person("C", "D"), 1 to Person("A", "B"))
+        val secondMap = mapOf(1 to Person("A", "B"), 2 to Person("C", "D"))
+
+        firstMap shouldEqualUnordered secondMap
+    }
+
+}

--- a/common/src/test/kotlin/org/amshove/kluent/collections/ShouldNotEqualUnorderedShould.kt
+++ b/common/src/test/kotlin/org/amshove/kluent/collections/ShouldNotEqualUnorderedShould.kt
@@ -1,0 +1,26 @@
+package org.amshove.kluent.collections
+
+import org.amshove.kluent.Person
+import org.amshove.kluent.shouldNotEqualUnordered
+import kotlin.test.Test
+import kotlin.test.assertFails
+
+class ShouldNotEqualUnorderedShould {
+
+    @Test
+    fun failWhenUnorderedMapsAreTheSame() {
+        val firstMap = mapOf(2 to Person("C", "D"), 1 to Person("A", "B"))
+        val secondMap = mapOf(1 to Person("A", "B"), 2 to Person("C", "D"))
+
+        assertFails { firstMap shouldNotEqualUnordered secondMap }
+    }
+
+    @Test
+    fun passWhenMapsAreNotTheSame() {
+        val firstMap = mapOf(1 to Person("A", "A"), 2 to Person("C", "D"))
+        val secondMap = mapOf(1 to Person("A", "B"), 2 to Person("C", "D"))
+
+        firstMap shouldNotEqualUnordered secondMap
+    }
+
+}


### PR DESCRIPTION
Description:
I think when comparing maps that the order of how the 2 maps were created shouldn't matter. 
**_I might be wrong?_** 

Checklist
- [x] Created straighforward unit test showing the issue
- [x] I've added my name to the `AUTHORS` file, if it wasn't already present.

