### PR TITLE
Fix download button img src link in documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ It uses the [Infix-Notations](https://kotlinlang.org/docs/reference/functions.ht
 
 [Changelog](https://github.com/MarkusAmshove/Kluent/blob/master/CHANGELOG.md)
 
-[ ![Download](https://api.bintray.com/packages/markusamshove/maven/Kluent/images/download.svg) ](https://bintray.com/markusamshove/maven/Kluent/_latestVersion) 
+[ ![Download](https://api.bintray.com/packages/markusamshove/maven/kluent/images/download.svg) ](https://bintray.com/markusamshove/maven/Kluent/_latestVersion) 
 
 
 | Platform  | Status  |


### PR DESCRIPTION
Fixes a typo in the path for the download button image. The image is now loaded correctly.