### PR TITLE
Support asserting suspend function

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -33,3 +33,4 @@
 1. Anton Sheihman [@sheix_](https://github.com/sheix_) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=rubengees))
 1. Vaios Tsitsonis [@St4B](https://github.com/St4B) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=st4b))
 1. Jógvan Olsen - [@jeggy](https://github.com/jeggy) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=jeggy))
+1. Yang C - [@ychescale9](https://github.com/ychescale9) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=ychescale9))

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.moowork.gradle:gradle-node-plugin:$gradle_node_version"
-        classpath "org.jetbrains.kotlin:kotlin-native-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.kotlin:kotlin-native-gradle-plugin:$kotlin_native_gradle_plugin_version"
         classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.+"
         classpath 'com.adarshr:gradle-test-logger-plugin:1.6.0'
     }
@@ -31,6 +31,7 @@ ext {
         kotlin_test_junit       : "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version",
         kotlin_test_js          : "org.jetbrains.kotlin:kotlin-test-js:$kotlin_version",
         kotlin_test_annotations : "org.jetbrains.kotlin:kotlin-test-annotations-common:$kotlin_version",
+        kotlinx_coroutines_test : "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlinx_coroutines_version",
 
         junit                   : "junit:junit:4.12",
     ]

--- a/docs/Exceptions.md
+++ b/docs/Exceptions.md
@@ -36,6 +36,6 @@ func shouldThrow CustomException(12345)
 // The above assertions also work with suspend functions:
 suspend fun myThrowingSuspendFunction() { throw RuntimeException("oops!") }
 
-invokingSuspend { myThrowingSuspendFunction() } shouldThrow RuntimeException::class withMessage "oops!"
-invokingSuspend { myThrowingSuspendFunction() } shouldNotThrow RuntimeException::class withMessage "oops!"
+coInvoking { myThrowingSuspendFunction() } shouldThrow RuntimeException::class withMessage "oops!"
+coInvoking { myThrowingSuspendFunction() } shouldNotThrow RuntimeException::class withMessage "oops!"
 ```

--- a/docs/Exceptions.md
+++ b/docs/Exceptions.md
@@ -32,4 +32,10 @@ func shouldThrow IllegalArgumentException::class withCause IOException::class wi
 data class CustomException(val code: Int) : Exception("code is $code")
 val func = { throw CustomException(12345) }
 func shouldThrow CustomException(12345)
+
+// The above assertions also work with suspend functions:
+suspend fun myThrowingSuspendFunction() { throw RuntimeException("oops!") }
+
+invokingSuspend { myThrowingSuspendFunction() } shouldThrow RuntimeException::class withMessage "oops!"
+invokingSuspend { myThrowingSuspendFunction() } shouldNotThrow RuntimeException::class withMessage "oops!"
 ```

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,6 @@
-kotlin_version = 1.3.10
+kotlin_version = 1.3.50
+kotlin_native_gradle_plugin_version = 1.3.41
+kotlinx_coroutines_version = 1.3.0
 
 gradle_node_version = 1.2.0
 node_version = 8.9.3

--- a/jvm/build.gradle
+++ b/jvm/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     testImplementation libs.junit
     testImplementation libs.kotlin_test_jvm
     testImplementation libs.kotlin_test_junit
+    testImplementation libs.kotlinx_coroutines_test
 
 
     // TODO: To be removed

--- a/jvm/src/main/kotlin/org/amshove/kluent/Exceptions.kt
+++ b/jvm/src/main/kotlin/org/amshove/kluent/Exceptions.kt
@@ -5,30 +5,63 @@ import kotlin.reflect.KClass
 
 fun invoking(function: () -> Any?): () -> Any? = function
 
+fun invokingSuspend(function: suspend () -> Any?): suspend () -> Any? = function
+
 infix fun <T : Throwable> (() -> Any?).shouldThrow(expectedException: KClass<T>): ExceptionResult<T> {
     try {
         this.invoke()
         fail("There was an Exception expected to be thrown, but nothing was thrown", "$expectedException", "None")
     } catch (e: Throwable) {
         @Suppress("UNCHECKED_CAST")
-        if (e.isA(ComparisonFailure::class)) throw e
-        else if (e.isA(expectedException)) return ExceptionResult(e as T)
-        else throw ComparisonFailure("Expected ${expectedException.javaObjectType} to be thrown", "${expectedException.javaObjectType}", "${e.javaClass}")
+        when {
+            e.isA(ComparisonFailure::class) -> throw e
+            e.isA(expectedException) -> return ExceptionResult(e as T)
+            else -> throw ComparisonFailure("Expected ${expectedException.javaObjectType} to be thrown", "${expectedException.javaObjectType}", "${e.javaClass}")
+        }
+    }
+}
+
+suspend infix fun <T : Throwable> (suspend () -> Any?).shouldThrow(expectedException: KClass<T>): ExceptionResult<T> {
+    try {
+        this.invoke()
+        fail("There was an Exception expected to be thrown, but nothing was thrown", "$expectedException", "None")
+    } catch (e: Throwable) {
+        @Suppress("UNCHECKED_CAST")
+        when {
+            e.isA(ComparisonFailure::class) -> throw e
+            e.isA(expectedException) -> return ExceptionResult(e as T)
+            else -> throw ComparisonFailure("Expected ${expectedException.javaObjectType} to be thrown", "${expectedException.javaObjectType}", "${e.javaClass}")
+        }
     }
 }
 
 infix fun <T : Throwable> (() -> Any?).shouldNotThrow(expectedException: KClass<T>): NotThrowExceptionResult {
-    try {
+    return try {
         this.invoke()
-        return NotThrowExceptionResult(noException)
+        NotThrowExceptionResult(noException)
     } catch (e: Throwable) {
         if (expectedException.isAnyException()) {
             fail("Expected no Exception to be thrown", "No Exception", "${e.javaClass}")
         }
         if (e.isA(expectedException)) {
-            fail("Expected no Exception of type ${e::class.qualifiedName} to be thrown", "No Exception", e.toInformativeString());
+            fail("Expected no Exception of type ${e::class.qualifiedName} to be thrown", "No Exception", e.toInformativeString())
         }
-        return NotThrowExceptionResult(e)
+        NotThrowExceptionResult(e)
+    }
+}
+
+suspend infix fun <T : Throwable> (suspend () -> Any?).shouldNotThrow(expectedException: KClass<T>): NotThrowExceptionResult {
+    return try {
+        this.invoke()
+        NotThrowExceptionResult(noException)
+    } catch (e: Throwable) {
+        if (expectedException.isAnyException()) {
+            fail("Expected no Exception to be thrown", "No Exception", "${e.javaClass}")
+        }
+        if (e.isA(expectedException)) {
+            fail("Expected no Exception of type ${e::class.qualifiedName} to be thrown", "No Exception", e.toInformativeString())
+        }
+        NotThrowExceptionResult(e)
     }
 }
 
@@ -37,8 +70,19 @@ infix fun <T : Throwable> (() -> Any?).shouldThrow(expectedException: T) {
         this.invoke()
         fail("There was an Exception expected to be thrown, but nothing was thrown", "$expectedException", "None")
     } catch (e: Throwable) {
-        if (!e.equals(expectedException)) {
-            throw ComparisonFailure("Expected ${expectedException} to be thrown", "${expectedException}", "${e.javaClass}")
+        if (e != expectedException) {
+            throw ComparisonFailure("Expected $expectedException to be thrown", "$expectedException", "${e.javaClass}")
+        }
+    }
+}
+
+suspend infix fun <T : Throwable> (suspend () -> Any?).shouldThrow(expectedException: T) {
+    try {
+        this.invoke()
+        fail("There was an Exception expected to be thrown, but nothing was thrown", "$expectedException", "None")
+    } catch (e: Throwable) {
+        if (e != expectedException) {
+            throw ComparisonFailure("Expected $expectedException to be thrown", "$expectedException", "${e.javaClass}")
         }
     }
 }
@@ -56,7 +100,7 @@ infix fun <T : Throwable> ExceptionResult<T>.withMessage(theMessage: String): Ex
 
 infix fun NotThrowExceptionResult.withMessage(theMessage: String): NotThrowExceptionResult {
     this.exceptionMessage shouldNotEqual theMessage
-    return this;
+    return this
 }
 
 infix fun <T : Throwable> ExceptionResult<T>.withCause(expectedCause: KClass<out Throwable>): ExceptionResult<T> {

--- a/jvm/src/main/kotlin/org/amshove/kluent/Exceptions.kt
+++ b/jvm/src/main/kotlin/org/amshove/kluent/Exceptions.kt
@@ -5,7 +5,7 @@ import kotlin.reflect.KClass
 
 fun invoking(function: () -> Any?): () -> Any? = function
 
-fun invokingSuspend(function: suspend () -> Any?): suspend () -> Any? = function
+fun coInvoking(function: suspend () -> Any?): suspend () -> Any? = function
 
 infix fun <T : Throwable> (() -> Any?).shouldThrow(expectedException: KClass<T>): ExceptionResult<T> {
     try {

--- a/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/exceptions/ShouldNotThrowShould.kt
+++ b/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/exceptions/ShouldNotThrowShould.kt
@@ -20,7 +20,7 @@ class ShouldNotThrowShould {
         suspend fun func() {
             coroutineScope { Unit }
         }
-        invokingSuspend { func() } shouldNotThrow AnyException
+        coInvoking { func() } shouldNotThrow AnyException
     }
 
     @Test
@@ -37,7 +37,7 @@ class ShouldNotThrowShould {
             suspendCancellableCoroutine<Any> { throw IllegalArgumentException() }
         }
         assertFails {
-            invokingSuspend { func() } shouldNotThrow AnyException
+            coInvoking { func() } shouldNotThrow AnyException
         }
     }
 
@@ -52,7 +52,7 @@ class ShouldNotThrowShould {
         suspend fun func() {
             suspendCancellableCoroutine<Any> { throw IllegalArgumentException() }
         }
-        invokingSuspend { func() } shouldNotThrow ArrayIndexOutOfBoundsException::class
+        coInvoking { func() } shouldNotThrow ArrayIndexOutOfBoundsException::class
     }
 
     @Test
@@ -66,7 +66,7 @@ class ShouldNotThrowShould {
         suspend fun func(): String? {
             return coroutineScope { null }
         }
-        invokingSuspend { func() } shouldNotThrow AnyException
+        coInvoking { func() } shouldNotThrow AnyException
     }
 
     @Test
@@ -81,7 +81,7 @@ class ShouldNotThrowShould {
         suspend fun func() {
             suspendCancellableCoroutine<Any> { throw IllegalArgumentException("Actual Message") }
         }
-        invokingSuspend { func() } shouldNotThrow
+        coInvoking { func() } shouldNotThrow
                 IllegalAccessException::class withMessage "Expected Message"
     }
 
@@ -100,7 +100,7 @@ class ShouldNotThrowShould {
             suspendCancellableCoroutine<Any> { throw IllegalArgumentException("Actual Message") }
         }
         assertFails {
-            invokingSuspend { func() } shouldNotThrow
+            coInvoking { func() } shouldNotThrow
                     IllegalAccessException::class withMessage "Actual Message"
         }
     }
@@ -120,7 +120,7 @@ class ShouldNotThrowShould {
             suspendCancellableCoroutine<Any> { throw Exception(RuntimeException()) }
         }
         assertFails {
-            invokingSuspend { func() } shouldNotThrow
+            coInvoking { func() } shouldNotThrow
                     Exception::class withCause RuntimeException::class
         }
     }
@@ -139,7 +139,7 @@ class ShouldNotThrowShould {
             suspendCancellableCoroutine<Any> { throw Exception() }
         }
         assertFails {
-            invokingSuspend { func() } shouldNotThrow Exception::class
+            coInvoking { func() } shouldNotThrow Exception::class
         }
     }
 }

--- a/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/exceptions/ShouldNotThrowShould.kt
+++ b/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/exceptions/ShouldNotThrowShould.kt
@@ -1,5 +1,9 @@
 package org.amshove.kluent.tests.assertions.exceptions
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.test.runBlockingTest
 import org.amshove.kluent.*
 import org.junit.Test
 import kotlin.test.assertFails
@@ -11,9 +15,29 @@ class ShouldNotThrowShould {
     }
 
     @Test
+    @ExperimentalCoroutinesApi
+    fun passWhenTestingASuspendFunctionThatDoesNotThrowAnException() = runBlockingTest {
+        suspend fun func() {
+            coroutineScope { Unit }
+        }
+        invokingSuspend { func() } shouldNotThrow AnyException
+    }
+
+    @Test
     fun failWhenTestingAFunctionThatDoesThrowAnException() {
         assertFails {
             invoking { throw IllegalArgumentException() } shouldNotThrow AnyException
+        }
+    }
+
+    @Test
+    @ExperimentalCoroutinesApi
+    fun failWhenTestingASuspendFunctionThatDoesThrowAnException() = runBlockingTest {
+        suspend fun func() {
+            suspendCancellableCoroutine<Any> { throw IllegalArgumentException() }
+        }
+        assertFails {
+            invokingSuspend { func() } shouldNotThrow AnyException
         }
     }
 
@@ -23,21 +47,61 @@ class ShouldNotThrowShould {
     }
 
     @Test
+    @ExperimentalCoroutinesApi
+    fun passWhenTestingASuspendFunctionThatDoesNotThrowTheExpectedException() = runBlockingTest {
+        suspend fun func() {
+            suspendCancellableCoroutine<Any> { throw IllegalArgumentException() }
+        }
+        invokingSuspend { func() } shouldNotThrow ArrayIndexOutOfBoundsException::class
+    }
+
+    @Test
     fun passWhenTestingAFunctionThatReturnsNull() {
         invoking { null } shouldNotThrow AnyException
     }
 
     @Test
+    @ExperimentalCoroutinesApi
+    fun passWhenTestingASuspendFunctionThatReturnsNull() = runBlockingTest {
+        suspend fun func(): String? {
+            return coroutineScope { null }
+        }
+        invokingSuspend { func() } shouldNotThrow AnyException
+    }
+
+    @Test
     fun passWhenTestingAFunctionThatThrowsAnExceptionWithADifferentMessage() {
         invoking { throw IllegalArgumentException("Actual Message") } shouldNotThrow
-            IllegalAccessException::class withMessage "Expected Message"
+                IllegalAccessException::class withMessage "Expected Message"
+    }
+
+    @Test
+    @ExperimentalCoroutinesApi
+    fun passWhenTestingASuspendFunctionThatThrowsAnExceptionWithADifferentMessage() = runBlockingTest {
+        suspend fun func() {
+            suspendCancellableCoroutine<Any> { throw IllegalArgumentException("Actual Message") }
+        }
+        invokingSuspend { func() } shouldNotThrow
+                IllegalAccessException::class withMessage "Expected Message"
     }
 
     @Test
     fun failWhenTestingAFunctionThatThrowsAnExceptionWithTheSameMessage() {
         assertFails {
             invoking { throw IllegalArgumentException("Actual Message") } shouldNotThrow
-                IllegalAccessException::class withMessage "Actual Message"
+                    IllegalAccessException::class withMessage "Actual Message"
+        }
+    }
+
+    @Test
+    @ExperimentalCoroutinesApi
+    fun failWhenTestingASuspendFunctionThatThrowsAnExceptionWithTheSameMessage() = runBlockingTest {
+        suspend fun func() {
+            suspendCancellableCoroutine<Any> { throw IllegalArgumentException("Actual Message") }
+        }
+        assertFails {
+            invokingSuspend { func() } shouldNotThrow
+                    IllegalAccessException::class withMessage "Actual Message"
         }
     }
 
@@ -45,14 +109,37 @@ class ShouldNotThrowShould {
     fun failWhenTestingAFunctionThatDoesThrowAnExceptionWithTheExpectedCause() {
         assertFails {
             invoking { throw Exception(RuntimeException()) } shouldNotThrow
-                Exception::class withCause RuntimeException::class
+                    Exception::class withCause RuntimeException::class
         }
     }
 
     @Test
-    fun failWhenExpectingAnExceptionThatWasThrown() {
+    @ExperimentalCoroutinesApi
+    fun failWhenTestingASuspendFunctionThatDoesThrowAnExceptionWithTheExpectedCause() = runBlockingTest {
+        suspend fun func() {
+            suspendCancellableCoroutine<Any> { throw Exception(RuntimeException()) }
+        }
+        assertFails {
+            invokingSuspend { func() } shouldNotThrow
+                    Exception::class withCause RuntimeException::class
+        }
+    }
+
+    @Test
+    fun failWhenTestingAFunctionThatThrowsAnExpectedException() {
         assertFails {
             invoking { throw Exception() } shouldNotThrow Exception::class
+        }
+    }
+
+    @Test
+    @ExperimentalCoroutinesApi
+    fun failWhenTestingASuspendFunctionThatThrowsAnExpectedException() = runBlockingTest {
+        suspend fun func() {
+            suspendCancellableCoroutine<Any> { throw Exception() }
+        }
+        assertFails {
+            invokingSuspend { func() } shouldNotThrow Exception::class
         }
     }
 }

--- a/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/exceptions/ShouldThrowShould.kt
+++ b/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/exceptions/ShouldThrowShould.kt
@@ -1,5 +1,9 @@
 package org.amshove.kluent.tests.assertions.exceptions
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.test.runBlockingTest
 import org.amshove.kluent.*
 import org.junit.Test
 import java.io.IOException
@@ -12,9 +16,29 @@ class ShouldThrowShould {
     }
 
     @Test
+    @ExperimentalCoroutinesApi
+    fun passWhenTestingASuspendFunctionThatThrowsTheExpectedException() = runBlockingTest {
+        suspend fun func() {
+            suspendCancellableCoroutine<Any> { throw IndexOutOfBoundsException() }
+        }
+        invokingSuspend { func() } shouldThrow IndexOutOfBoundsException::class
+    }
+
+    @Test
     fun failWhenTestingAFunctionThatDoesNotThrowTheExpectedException() {
         assertFails {
             invoking { throw IndexOutOfBoundsException() } shouldThrow IllegalArgumentException::class
+        }
+    }
+
+    @Test
+    @ExperimentalCoroutinesApi
+    fun failWhenTestingASuspendFunctionThatDoesNotThrowTheExpectedException() = runBlockingTest {
+        suspend fun func() {
+            suspendCancellableCoroutine<Any> { throw IndexOutOfBoundsException() }
+        }
+        assertFails {
+            invokingSuspend { func() } shouldThrow IllegalArgumentException::class
         }
     }
 
@@ -24,13 +48,40 @@ class ShouldThrowShould {
     }
 
     @Test
+    @ExperimentalCoroutinesApi
+    fun passWhenTestingASuspendFunctionThatTriesToGetAnOutOfIndexedItem() = runBlockingTest {
+        suspend fun func() {
+            suspendCancellableCoroutine<Int> { listOf(0)[-1] }
+        }
+        invokingSuspend { func() } shouldThrow IndexOutOfBoundsException::class
+    }
+
+    @Test
     fun passWhenTestingAFunctionWhichThrowsASubtypeOfTheExpectedException() {
         invoking { throw IllegalStateException() } shouldThrow RuntimeException::class
     }
 
     @Test
+    @ExperimentalCoroutinesApi
+    fun passWhenTestingASuspendFunctionWhichThrowsASubtypeOfTheExpectedException() = runBlockingTest {
+        suspend fun func() {
+            suspendCancellableCoroutine<Any> { throw IllegalStateException() }
+        }
+        invokingSuspend { func() } shouldThrow RuntimeException::class
+    }
+
+    @Test
     fun passWhenTestingAFunctionWhichThrowsAnExceptionWithTheExpectedMessage() {
         invoking { throw Exception("Hello World!") } shouldThrow Exception::class withMessage "Hello World!"
+    }
+
+    @Test
+    @ExperimentalCoroutinesApi
+    fun passWhenTestingASuspendFunctionWhichThrowsAnExceptionWithTheExpectedMessage() = runBlockingTest {
+        suspend fun func() {
+            suspendCancellableCoroutine<Any> { throw Exception("Hello World!") }
+        }
+        invokingSuspend { func() } shouldThrow Exception::class withMessage "Hello World!"
     }
 
     @Test
@@ -41,8 +92,28 @@ class ShouldThrowShould {
     }
 
     @Test
+    @ExperimentalCoroutinesApi
+    fun failWhenTestingASuspendFunctionWhichThrowsAnExceptionWithADifferentMessage() = runBlockingTest {
+        suspend fun func() {
+            suspendCancellableCoroutine<Any> { throw Exception("Hello World!") }
+        }
+        assertFails {
+            invokingSuspend { func() } shouldThrow Exception::class withMessage "Hello"
+        }
+    }
+
+    @Test
     fun passWhenTestingAFunctionWhichThrowsAnExceptionWithTheExpectedCause() {
         invoking { throw Exception(RuntimeException()) } shouldThrow Exception::class withCause RuntimeException::class
+    }
+
+    @Test
+    @ExperimentalCoroutinesApi
+    fun passWhenTestingASuspendFunctionWhichThrowsAnExceptionWithTheExpectedCause() = runBlockingTest {
+        suspend fun func() {
+            suspendCancellableCoroutine<Any> { throw Exception(RuntimeException()) }
+        }
+        invokingSuspend { func() } shouldThrow Exception::class withCause RuntimeException::class
     }
 
     @Test
@@ -53,8 +124,28 @@ class ShouldThrowShould {
     }
 
     @Test
+    @ExperimentalCoroutinesApi
+    fun failWhenTestingASuspendFunctionWhichThrowsAnExceptionWithAnUnexpectedCause() = runBlockingTest {
+        suspend fun func() {
+            suspendCancellableCoroutine<Any> { throw RuntimeException() }
+        }
+        assertFails {
+            invokingSuspend { func() } shouldThrow Exception::class withCause IOException::class
+        }
+    }
+
+    @Test
     fun passWhenTestingAFunctionWhichThrowsWhenAnyExceptionIsExpected() {
         invoking { throw Exception() } shouldThrow AnyException
+    }
+
+    @Test
+    @ExperimentalCoroutinesApi
+    fun passWhenTestingASuspendFunctionWhichThrowsWhenAnyExceptionIsExpected() = runBlockingTest {
+        suspend fun func() {
+            suspendCancellableCoroutine<Any> { throw Exception() }
+        }
+        invokingSuspend { func() } shouldThrow AnyException
     }
 
     @Test
@@ -63,16 +154,47 @@ class ShouldThrowShould {
     }
 
     @Test
+    @ExperimentalCoroutinesApi
+    fun failWhenTestingASuspendFunctionWhichDoesNotThrowButAnyExceptionIsExpected() = runBlockingTest {
+        suspend fun func() {
+            coroutineScope { Unit }
+        }
+        assertFails { invokingSuspend { func() } shouldThrow AnyException }
+    }
+
+    @Test
     fun passWhenTestingAFunctionWhichThrowsAnExceptionWithMessageAndCause() {
         invoking { throw IllegalArgumentException("hello", IOException()) } shouldThrow
-            IllegalArgumentException::class withCause IOException::class withMessage "hello"
+                IllegalArgumentException::class withCause IOException::class withMessage "hello"
+    }
+
+    @Test
+    @ExperimentalCoroutinesApi
+    fun passWhenTestingASuspendFunctionWhichThrowsAnExceptionWithMessageAndCause() = runBlockingTest {
+        suspend fun func() {
+            suspendCancellableCoroutine<Any> { throw IllegalArgumentException("hello", IOException()) }
+        }
+        invokingSuspend { func() } shouldThrow
+                IllegalArgumentException::class withCause IOException::class withMessage "hello"
     }
 
     @Test
     fun failWhenTestingAFunctionWhichThrowsAnExceptionWithMessageAndCauseExceptingADifferentMessage() {
         assertFails {
             invoking { throw IllegalArgumentException("not hello", IOException()) } shouldThrow
-                IllegalArgumentException::class withCause IOException::class withMessage "hello"
+                    IllegalArgumentException::class withCause IOException::class withMessage "hello"
+        }
+    }
+
+    @Test
+    @ExperimentalCoroutinesApi
+    fun failWhenTestingASuspendFunctionWhichThrowsAnExceptionWithMessageAndCauseExceptingADifferentMessage() = runBlockingTest {
+        suspend fun func() {
+            suspendCancellableCoroutine<Any> { throw IllegalArgumentException("not hello", IOException()) }
+        }
+        assertFails {
+            invokingSuspend { func() } shouldThrow
+                    IllegalArgumentException::class withCause IOException::class withMessage "hello"
         }
     }
 
@@ -84,15 +206,44 @@ class ShouldThrowShould {
     }
 
     @Test
+    @ExperimentalCoroutinesApi
+    fun returnTheExceptionWhenPassingWithASuspendFunction() = runBlockingTest {
+        suspend fun func() {
+            suspendCancellableCoroutine<Any> { throw CustomException(10) }
+        }
+
+        val exception = invokingSuspend { func() }.shouldThrow(CustomException::class).exception
+
+        exception.code.shouldEqual(10)
+    }
+
+    @Test
     fun passWhenTestingForAnExactThrownException() {
         invoking { throw CustomException(12345) } shouldThrow CustomException(12345)
     }
 
     @Test
-    fun failWhenTestisngForAnExactThrownExceptionWhenTheExceptionDiffers() {
+    @ExperimentalCoroutinesApi
+    fun passWhenTestingASuspendFunctionForAnExactThrownException() = runBlockingTest {
+        suspend fun func() {
+            suspendCancellableCoroutine<Any> { throw CustomException(12345) }
+        }
+        invokingSuspend { func() } shouldThrow CustomException(12345)
+    }
+
+    @Test
+    fun failWhenTestingForAnExactThrownExceptionWhenTheExceptionDiffers() {
         assertFails { invoking { throw CustomException(12345) } shouldThrow CustomException(54321) }
     }
 
+    @Test
+    @ExperimentalCoroutinesApi
+    fun failWhenTestingASuspendFunctionForAnExactThrownExceptionWhenTheExceptionDiffers() = runBlockingTest {
+        suspend fun func() {
+            suspendCancellableCoroutine<Any> { throw CustomException(12345) }
+        }
+        assertFails { invokingSuspend { func() } shouldThrow CustomException(54321) }
+    }
 }
 
 data class CustomException(val code: Int) : Exception("code is $code")

--- a/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/exceptions/ShouldThrowShould.kt
+++ b/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/exceptions/ShouldThrowShould.kt
@@ -21,7 +21,7 @@ class ShouldThrowShould {
         suspend fun func() {
             suspendCancellableCoroutine<Any> { throw IndexOutOfBoundsException() }
         }
-        invokingSuspend { func() } shouldThrow IndexOutOfBoundsException::class
+        coInvoking { func() } shouldThrow IndexOutOfBoundsException::class
     }
 
     @Test
@@ -38,7 +38,7 @@ class ShouldThrowShould {
             suspendCancellableCoroutine<Any> { throw IndexOutOfBoundsException() }
         }
         assertFails {
-            invokingSuspend { func() } shouldThrow IllegalArgumentException::class
+            coInvoking { func() } shouldThrow IllegalArgumentException::class
         }
     }
 
@@ -53,7 +53,7 @@ class ShouldThrowShould {
         suspend fun func() {
             suspendCancellableCoroutine<Int> { listOf(0)[-1] }
         }
-        invokingSuspend { func() } shouldThrow IndexOutOfBoundsException::class
+        coInvoking { func() } shouldThrow IndexOutOfBoundsException::class
     }
 
     @Test
@@ -67,7 +67,7 @@ class ShouldThrowShould {
         suspend fun func() {
             suspendCancellableCoroutine<Any> { throw IllegalStateException() }
         }
-        invokingSuspend { func() } shouldThrow RuntimeException::class
+        coInvoking { func() } shouldThrow RuntimeException::class
     }
 
     @Test
@@ -81,7 +81,7 @@ class ShouldThrowShould {
         suspend fun func() {
             suspendCancellableCoroutine<Any> { throw Exception("Hello World!") }
         }
-        invokingSuspend { func() } shouldThrow Exception::class withMessage "Hello World!"
+        coInvoking { func() } shouldThrow Exception::class withMessage "Hello World!"
     }
 
     @Test
@@ -98,7 +98,7 @@ class ShouldThrowShould {
             suspendCancellableCoroutine<Any> { throw Exception("Hello World!") }
         }
         assertFails {
-            invokingSuspend { func() } shouldThrow Exception::class withMessage "Hello"
+            coInvoking { func() } shouldThrow Exception::class withMessage "Hello"
         }
     }
 
@@ -113,7 +113,7 @@ class ShouldThrowShould {
         suspend fun func() {
             suspendCancellableCoroutine<Any> { throw Exception(RuntimeException()) }
         }
-        invokingSuspend { func() } shouldThrow Exception::class withCause RuntimeException::class
+        coInvoking { func() } shouldThrow Exception::class withCause RuntimeException::class
     }
 
     @Test
@@ -130,7 +130,7 @@ class ShouldThrowShould {
             suspendCancellableCoroutine<Any> { throw RuntimeException() }
         }
         assertFails {
-            invokingSuspend { func() } shouldThrow Exception::class withCause IOException::class
+            coInvoking { func() } shouldThrow Exception::class withCause IOException::class
         }
     }
 
@@ -145,7 +145,7 @@ class ShouldThrowShould {
         suspend fun func() {
             suspendCancellableCoroutine<Any> { throw Exception() }
         }
-        invokingSuspend { func() } shouldThrow AnyException
+        coInvoking { func() } shouldThrow AnyException
     }
 
     @Test
@@ -159,7 +159,7 @@ class ShouldThrowShould {
         suspend fun func() {
             coroutineScope { Unit }
         }
-        assertFails { invokingSuspend { func() } shouldThrow AnyException }
+        assertFails { coInvoking { func() } shouldThrow AnyException }
     }
 
     @Test
@@ -174,7 +174,7 @@ class ShouldThrowShould {
         suspend fun func() {
             suspendCancellableCoroutine<Any> { throw IllegalArgumentException("hello", IOException()) }
         }
-        invokingSuspend { func() } shouldThrow
+        coInvoking { func() } shouldThrow
                 IllegalArgumentException::class withCause IOException::class withMessage "hello"
     }
 
@@ -193,7 +193,7 @@ class ShouldThrowShould {
             suspendCancellableCoroutine<Any> { throw IllegalArgumentException("not hello", IOException()) }
         }
         assertFails {
-            invokingSuspend { func() } shouldThrow
+            coInvoking { func() } shouldThrow
                     IllegalArgumentException::class withCause IOException::class withMessage "hello"
         }
     }
@@ -212,7 +212,7 @@ class ShouldThrowShould {
             suspendCancellableCoroutine<Any> { throw CustomException(10) }
         }
 
-        val exception = invokingSuspend { func() }.shouldThrow(CustomException::class).exception
+        val exception = coInvoking { func() }.shouldThrow(CustomException::class).exception
 
         exception.code.shouldEqual(10)
     }
@@ -228,7 +228,7 @@ class ShouldThrowShould {
         suspend fun func() {
             suspendCancellableCoroutine<Any> { throw CustomException(12345) }
         }
-        invokingSuspend { func() } shouldThrow CustomException(12345)
+        coInvoking { func() } shouldThrow CustomException(12345)
     }
 
     @Test
@@ -242,7 +242,7 @@ class ShouldThrowShould {
         suspend fun func() {
             suspendCancellableCoroutine<Any> { throw CustomException(12345) }
         }
-        assertFails { invokingSuspend { func() } shouldThrow CustomException(54321) }
+        assertFails { coInvoking { func() } shouldThrow CustomException(54321) }
     }
 }
 


### PR DESCRIPTION
Resolves #151. 

This PR adds support for asserting suspend function invocation.

### Sample usage:

```kotlin
@Test
fun testASuspendFunctionThatThrowsTheExpectedException() = runBlockingTest {
    suspend fun func() {
        suspendCancellableCoroutine<Any> { throw IndexOutOfBoundsException() }
    }
    invokingSuspend {
        func()
    } shouldThrow IndexOutOfBoundsException::class
}
```

- `invokingSuspend` is the new API added that takes a suspend function as parameter.
- `runBlockingTest` is an experimental API from `kotlinx-coroutines-test` which provides a `CoroutineScope` as a lambda. In this case `runBlocking` also works.
- PR adds the `kotlinx-coroutines-test` dependency only for testing and no new runtime dependency is included in the library itself.

### Checklist

- [x] I've added my name to the `AUTHORS` file, if it wasn't already present.

