### PR TITLE
Introduce shouldBeNear and shouldNotBeNear for BigDecimal

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -34,3 +34,4 @@
 1. Vaios Tsitsonis [@St4B](https://github.com/St4B) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=st4b))
 1. Jógvan Olsen - [@jeggy](https://github.com/jeggy) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=jeggy))
 1. Yang C - [@ychescale9](https://github.com/ychescale9) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=ychescale9))
+1. Christian Ivicevic - [@ChristianIvicevic](https://github.com/ChristianIvicevic) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=ChristianIvicevic))

--- a/jvm/src/main/kotlin/org/amshove/kluent/BigDecimal.kt
+++ b/jvm/src/main/kotlin/org/amshove/kluent/BigDecimal.kt
@@ -63,3 +63,9 @@ infix fun BigDecimal.shouldBeInRange(range: ClosedRange<BigDecimal>) = this.appl
 infix fun BigDecimal.shouldNotBeInRange(range: ClosedRange<BigDecimal>) = this.apply {
     this.shouldNotBeInRange(range.start, range.endInclusive)
 }
+
+fun BigDecimal.shouldBeNear(expected: BigDecimal, delta: BigDecimal) =
+    this.shouldBeInRange(expected - delta, expected + delta)
+
+fun BigDecimal.shouldNotBeNear(expected: BigDecimal, delta: BigDecimal) =
+    this.shouldNotBeInRange(expected - delta, expected + delta)

--- a/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/bigdecimal/BigDecimalShouldBeNearShould.kt
+++ b/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/bigdecimal/BigDecimalShouldBeNearShould.kt
@@ -1,0 +1,37 @@
+package org.amshove.kluent.tests.assertions.bigdecimal
+
+import org.amshove.kluent.shouldBeNear
+import java.math.BigDecimal
+import kotlin.test.Test
+import kotlin.test.assertFails
+
+class BigDecimalShouldBeNearShould {
+    @Test
+    fun passWhenTestingAValueWhichIsWithinTheDelta() {
+        BigDecimal("5.55").shouldBeNear(BigDecimal("5.5"), BigDecimal("0.1"))
+    }
+
+    @Test
+    fun passWhenTestingAValueWhichIsTheUpperBound() {
+        BigDecimal("5.6").shouldBeNear(BigDecimal("5.5"), BigDecimal("0.1"))
+    }
+
+    @Test
+    fun passWhenTestingAValueWhichIsTheLowerBound() {
+        BigDecimal("5.5").shouldBeNear(BigDecimal("5.5"), BigDecimal("0.1"))
+    }
+
+    @Test
+    fun failWhenTestingAValueWhichIsAboveTheBound() {
+        assertFails {
+            BigDecimal("5.7").shouldBeNear(BigDecimal("5.5"), BigDecimal("0.1"))
+        }
+    }
+
+    @Test
+    fun failWhenTestingAValueWhichIsBelowTheBound() {
+        assertFails {
+            BigDecimal("5.3").shouldBeNear(BigDecimal("5.5"), BigDecimal("0.1"))
+        }
+    }
+}

--- a/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/bigdecimal/BigDecimalShouldNotBeNearShould.kt
+++ b/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/bigdecimal/BigDecimalShouldNotBeNearShould.kt
@@ -1,0 +1,39 @@
+package org.amshove.kluent.tests.assertions.bigdecimal
+
+import org.amshove.kluent.shouldNotBeNear
+import java.math.BigDecimal
+import kotlin.test.Test
+import kotlin.test.assertFails
+
+class BigDecimalShouldNotBeNearShould {
+    @Test
+    fun passWhenTestingAValueWhichIsAboveTheBound() {
+        BigDecimal("5.7").shouldNotBeNear(BigDecimal("5.5"), BigDecimal("0.1"))
+    }
+
+    @Test
+    fun passWhenTestingAValueWhichIsBelowTheBound() {
+        BigDecimal("5.3").shouldNotBeNear(BigDecimal("5.5"), BigDecimal("0.1"))
+    }
+
+    @Test
+    fun failWhenTestingAValueWhichIsWithinTheDelta() {
+        assertFails {
+            BigDecimal("5.55").shouldNotBeNear(BigDecimal("5.5"), BigDecimal("0.1"))
+        }
+    }
+
+    @Test
+    fun failWhenTestingAValueWhichIsTheUpperBound() {
+        assertFails {
+            BigDecimal("5.6").shouldNotBeNear(BigDecimal("5.5"), BigDecimal("0.1"))
+        }
+    }
+
+    @Test
+    fun failWhenTestingAValueWhichIsTheLowerBound() {
+        assertFails {
+            BigDecimal("5.5").shouldNotBeNear(BigDecimal("5.5"), BigDecimal("0.1"))
+        }
+    }
+}


### PR DESCRIPTION
**Description**
<!--- Describe your changes in detail and which issue they might solve. -->
As suggested in #155 this PR contains two methods `BigDecimal.shouldBeNear` and `BigDecimal.shouldNotBeNear` that relay the calls to the respective `BigDecimal.shouldBeInRange` and `BigDecimal.shouldNotBeInRange` methods using the supplied `expected` value as the middle and a `delta` to test whether an actual value is either inside or outside the `[expected - delta, expected + delta]` interval.

Since Kluent already contains those methods for `Float` and `Double` I reused the same method names, even though I was initially going to use `should(Not)BeCloseTo`. I intentionally did not write those methods for the other number types.

In the already existing tests I didn't understand why you are initializing `BigDecimals` manually using strings instead of using the `toBigDecimal` extension method, but I sticked to your code style nonetheless to keep everything similar.

**Checklist**
<!--- We'd like to thank you for your help, appreciate them and give you credit for it. Please check the checkboxes below as you complete them -->

- [X] I've added my name to the `AUTHORS` file, if it wasn't already present.

