### PR TITLE
Gradle fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ subprojects {
 
         task printArtifactName {
             doLast {
-                println "artifactName: $artifactName"
+                logger.info("artifactName: $artifactName")
             }
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,6 @@ subprojects {
         apply plugin: 'java'
 
         artifactName = artifactName ?: project.name
-        println "artifactName: $artifactName"
 
         task sourcesJar(type: Jar, dependsOn: classes) {
             classifier = 'sources'
@@ -94,5 +93,13 @@ subprojects {
                 }
             }
         }
+
+        task printArtifactName {
+            doLast {
+                println "artifactName: $artifactName"
+            }
+        }
+
+        bintrayUpload.dependsOn(printArtifactName)
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Description

1. Bump gradle version to latest
1. Print artifact name only when needed
1. Use `logger` instead of `println` statement for `printArtifactName`

## Checklist
- [x] I've added my name to the `AUTHORS` file, if it wasn't already present.

