### PR TITLE
Fix for issue #170: bug in `shouldContainSame` for Map

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -35,3 +35,4 @@
 1. Jógvan Olsen - [@jeggy](https://github.com/jeggy) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=jeggy))
 1. Yang C - [@ychescale9](https://github.com/ychescale9) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=ychescale9))
 1. Christian Ivicevic - [@ChristianIvicevic](https://github.com/ChristianIvicevic) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=ChristianIvicevic))
+1. Ivan Mikhnovich - [@Murtaught](https://github.com/Murtaught) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=Murtaught))

--- a/common/src/main/kotlin/org/amshove/kluent/Collections.kt
+++ b/common/src/main/kotlin/org/amshove/kluent/Collections.kt
@@ -574,7 +574,7 @@ infix fun <K, V, M : Map<K, V>> M.shouldContain(expected: Pair<K, V>): M = apply
 
 infix fun <K, V, M : Map<K, V>> M.shouldContainAll(expected: M): M = apply { expected.forEach { shouldContain(it.toPair()) } }
 
-infix fun <K, V, M : Map<K, V>> M.shouldContainSame(expected: M): M = apply { expected.forEach { shouldContain(it.toPair()); this.forEach { shouldContain(it.toPair()) } } }
+infix fun <K, V, M : Map<K, V>> M.shouldContainSame(expected: M): M = apply { expected.forEach { shouldContain(it.toPair()) }; this.forEach { expected.shouldContain(it.toPair()) } }
 
 infix fun <K, V, M : Map<K, V>> M.shouldNotContain(expected: Pair<K, V>): M = apply { if (this[expected.first] != expected.second) Unit else failExpectedActual("Map should not contain Pair $expected", "the Map to not contain the Pair $expected", joinPairs(this)) }
 

--- a/common/src/test/kotlin/org/amshove/kluent/collections/ShouldContainSameShould.kt
+++ b/common/src/test/kotlin/org/amshove/kluent/collections/ShouldContainSameShould.kt
@@ -168,6 +168,12 @@ class ShouldContainSameShould {
     }
 
     @Test
+    fun failWhenTestingAMapWhichOnlyHasASubsetOfKeysOfThisMap() {
+        val map = mapOf('a' to 1, 'b' to 2)
+        assertFails { map shouldContainSame mapOf('a' to 1) }
+    }
+
+    @Test
     fun passWhenTestingAnIterableWhichContainsSameValuesOfAnArray() {
         val anIterable = listOf("Berlin", "Washington")
         val anArray = arrayOf("Washington", "Berlin")


### PR DESCRIPTION
Description
This PR fixes issue #170.
I added a new test with check that `shouldContainSame` throws an exception when the map compared to only has a subset of keys found in `this` map. In other words, compared maps definitely did not contain same elements, but this case wasn't caught by existing tests.

Then I fixed function `shouldContainSame` itself as I believe the problem was caused by simple literal error hidden by one-line formatting.

Checklist
<!--- We'd like to thank you for your help, appreciate them and give you credit for it. Please check the checkboxes below as you complete them -->

- [x] I've added my name to the `AUTHORS` file, if it wasn't already present.

