### PR TITLE
Implement VerificationMode times #49

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -38,3 +38,4 @@
 1. Ivan Mikhnovich - [@Murtaught](https://github.com/Murtaught) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=Murtaught))
 1. Jc Miñarro - [@JcMinarro](https://github.com/JcMinarro) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=JcMinarro))
 1. Kshitij Patil [@Kshitij09](https://github.com/Kshitij09) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=Kshitij09))
+1. Keivan Esbati - [@Tenkei](https://github.com/Tenkei) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=Tenkei))

--- a/jvm/src/main/kotlin/org/amshove/kluent/Mocking.kt
+++ b/jvm/src/main/kotlin/org/amshove/kluent/Mocking.kt
@@ -1,9 +1,6 @@
 package org.amshove.kluent
 
-import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
-import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import com.nhaarman.mockitokotlin2.*
 import org.mockito.AdditionalAnswers.*
 import org.mockito.Mockito.`when`
 import org.mockito.internal.util.MockUtil
@@ -12,10 +9,16 @@ import org.mockito.stubbing.Answer
 import org.mockito.stubbing.OngoingStubbing
 import kotlin.reflect.KClass
 
+
+
 @Suppress("UNUSED_PARAMETER") // Backward compatibility
 inline fun <reified T : Any> mock(targetClass: KClass<out T>): T = mock()
 
 inline fun <reified T : Any> mock(): T = com.nhaarman.mockitokotlin2.mock()
+
+infix fun VerifyKeyword.times(numInvocations: Int) = OngoingVerification(numInvocations)
+
+infix fun <T> OngoingVerification.on(mock: T) = verify(mock, times(numInvocations))
 
 infix fun <T> VerifyKeyword.on(mock: T) = verify(mock)
 
@@ -87,3 +90,5 @@ class CalledKeyword internal constructor()
 class WhenKeyword internal constructor()
 class VerifyNoInteractionsKeyword internal constructor()
 class VerifyNoFurtherInteractionsKeyword internal constructor()
+
+class OngoingVerification(val numInvocations: Int)

--- a/jvm/src/test/kotlin/org/amshove/kluent/tests/mocking/VerifyCalledOnceShould.kt
+++ b/jvm/src/test/kotlin/org/amshove/kluent/tests/mocking/VerifyCalledOnceShould.kt
@@ -1,0 +1,34 @@
+package org.amshove.kluent.tests.mocking
+
+import org.amshove.kluent.*
+import org.amshove.kluent.tests.helpclasses.Database
+import kotlin.test.Test
+import kotlin.test.assertFails
+
+class VerifyCalledOnceShould {
+
+    @Test
+    fun passWhenAMethodWasCalledOnlyOnce() {
+        val mock = mock(Database::class)
+        mock.getPerson(1)
+        mock.getPerson(1)
+        Verify times 2 on mock that mock.getPerson(1) was called
+        assertFails { Verify on mock that mock.getPerson(1) was called }
+    }
+
+    @Test
+    fun failWhenAMethodWasNotCalled() {
+        val mock = mock(Database::class)
+        mock.getPerson(1)
+        Verify on mock that mock.getPerson(1) was called
+        assertFails { Verify times 1 on mock that mock.getPerson(5) was called }
+    }
+
+    @Test
+    fun failWhenTimesThatAMethodWasCalledDoesNotMatch() {
+        val mock = mock(Database::class)
+        mock.getPerson(1)
+        Verify on mock that mock.getPerson(1) was called
+        assertFails { Verify times 2 on mock that mock.getPerson(1) was called }
+    }
+}

--- a/jvm/src/test/kotlin/org/amshove/kluent/tests/mocking/VerifyCalledOnceShould.kt
+++ b/jvm/src/test/kotlin/org/amshove/kluent/tests/mocking/VerifyCalledOnceShould.kt
@@ -5,15 +5,16 @@ import org.amshove.kluent.tests.helpclasses.Database
 import kotlin.test.Test
 import kotlin.test.assertFails
 
-class VerifyCalledOnceShould {
+class VerifyUsingTimesShould {
 
     @Test
-    fun passWhenAMethodWasCalledOnlyOnce() {
+    fun passWhenAMethodWasCalledSpecifiedTimes() {
         val mock = mock(Database::class)
         mock.getPerson(1)
-        mock.getPerson(1)
-        Verify times 2 on mock that mock.getPerson(1) was called
-        assertFails { Verify on mock that mock.getPerson(1) was called }
+        mock.getPerson(5)
+        Verify on mock that mock.getPerson(1) was called
+        Verify on mock that mock.getPerson(5) was called
+        Verify times 2 on mock that mock.getPerson(any()) was called
     }
 
     @Test
@@ -25,10 +26,20 @@ class VerifyCalledOnceShould {
     }
 
     @Test
-    fun failWhenTimesThatAMethodWasCalledDoesNotMatch() {
+    fun failWhenAMethodWasCalledLessThanSpecified() {
         val mock = mock(Database::class)
         mock.getPerson(1)
         Verify on mock that mock.getPerson(1) was called
-        assertFails { Verify times 2 on mock that mock.getPerson(1) was called }
+        assertFails { Verify times 2 on mock that mock.getPerson(any()) was called }
+    }
+
+    @Test
+    fun failWhenAMethodWasCalledMoreThanSpecified() {
+        val mock = mock(Database::class)
+        mock.getPerson(1)
+        mock.getPerson(5)
+        Verify on mock that mock.getPerson(1) was called
+        Verify on mock that mock.getPerson(5) was called
+        assertFails { Verify times 1 on mock that mock.getPerson(any()) was called }
     }
 }


### PR DESCRIPTION
**Description**
This PR adds the verification mode `times()` for mock verification described in this issue https://github.com/MarkusAmshove/Kluent/issues/49:
`Verify times 2 on mock that mock.getPerson(1) was called`

, we can also add a wide scope verification mode:
`Verify mode times(2) on mock that mock.getPerson(1) was called`

P.s: I know it doesn't have the best syntax but performance-wise it's the best approach, alternatively we can try to curry the `verify` method but it creates a lot of overhead.

**Checklist**
<!--- We'd like to thank you for your help, appreciate them and give you credit for it. Please check the checkboxes below as you complete them -->
- [x] I've added my name to the `AUTHORS` file, if it wasn't already present.

