### PR TITLE
Add Instant asserts

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -39,3 +39,4 @@
 1. Jc Miñarro - [@JcMinarro](https://github.com/JcMinarro) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=JcMinarro))
 1. Kshitij Patil [@Kshitij09](https://github.com/Kshitij09) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=Kshitij09))
 1. Keivan Esbati - [@Tenkei](https://github.com/Tenkei) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=Tenkei))
+1. Sam Neirinck - [@samneirinck](https://github.com/samneirinck) ([Contributions](https://github.com/MarkusAmshove/Kluent/commits?author=samneirinck)) 

--- a/jvm/src/main/kotlin/org/amshove/kluent/DateTime.kt
+++ b/jvm/src/main/kotlin/org/amshove/kluent/DateTime.kt
@@ -116,3 +116,7 @@ internal enum class ComparatorType {
     AtLeast,
     Exactly
 }
+
+infix fun Instant.shouldBeAfter(expected: Instant) = assertTrue("Expected $this to be after $expected", this > expected)
+
+infix fun Instant.shouldBeBefore(expected: Instant) = assertTrue("Expected $this to be before $expected", this < expected)

--- a/jvm/src/main/kotlin/org/amshove/kluent/DateTimeBacktick.kt
+++ b/jvm/src/main/kotlin/org/amshove/kluent/DateTimeBacktick.kt
@@ -93,3 +93,7 @@ infix fun LocalDateTime.`should be`(timeComparator: TimeComparator) = this.shoul
 infix fun LocalDateTime.`should be at least`(timeComparator: TimeComparator) = this.shouldBeAtLeast(timeComparator)
 
 infix fun LocalDateTime.`should be at most`(timeComparator: TimeComparator) = this.shouldBeAtMost(timeComparator)
+
+infix fun Instant.`should be after`(expected: Instant) = this.shouldBeAfter(expected)
+
+infix fun Instant.`should be before`(expected: Instant) = this.shouldBeBefore(expected)

--- a/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/time/instant/ShouldBeAfterShould.kt
+++ b/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/time/instant/ShouldBeAfterShould.kt
@@ -1,0 +1,30 @@
+package org.amshove.kluent.tests.assertions.time.instant
+
+import org.amshove.kluent.shouldBeAfter
+import java.time.Instant
+import kotlin.test.Test
+import kotlin.test.assertFails
+
+class ShouldBeAfterShould {
+    @Test
+    fun passWhenTestingALaterDate() {
+        val instantToTest = Instant.ofEpochSecond(5000)
+        val instantBefore = instantToTest.minusSeconds(10)
+
+        instantToTest shouldBeAfter instantBefore
+    }
+
+    @Test
+    fun failWhenTestingAnEarlierInstant() {
+        val instantToTest = Instant.ofEpochSecond(5000)
+        val dateAfter = instantToTest.plusSeconds(10)
+
+        assertFails { instantToTest shouldBeAfter dateAfter }
+    }
+
+    @Test
+    fun failWhenPassingTheSameInstant() {
+        val instantToTest = Instant.ofEpochSecond(5000)
+        assertFails { instantToTest shouldBeAfter instantToTest }
+    }
+}

--- a/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/time/instant/ShouldBeBeforeShould.kt
+++ b/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/time/instant/ShouldBeBeforeShould.kt
@@ -1,0 +1,31 @@
+package org.amshove.kluent.tests.assertions.time.instant
+
+import org.amshove.kluent.shouldBeBefore
+import java.time.Instant
+import kotlin.test.Test
+import kotlin.test.assertFails
+
+class ShouldBeBeforeShould {
+    @Test
+    fun passWhenTestingAnEarlierInstant() {
+        val instantToTest = Instant.ofEpochSecond(5000)
+        val instantAfter = instantToTest.plusSeconds(10)
+
+        instantToTest shouldBeBefore instantAfter
+    }
+
+    @Test
+    fun failWhenTestingALaterInstant() {
+        val instantToTest = Instant.ofEpochSecond(5000)
+        val dateBefore = instantToTest.minusSeconds(10)
+
+        assertFails { instantToTest shouldBeBefore dateBefore }
+    }
+
+    @Test
+    fun failWhenTestingTheSameInstant() {
+        val instantToTest = Instant.ofEpochSecond(5000)
+
+        assertFails { instantToTest shouldBeBefore instantToTest }
+    }
+}


### PR DESCRIPTION
Description

Adds 2 asserts on the `Instant` class:
- `shouldBeAfter`
- `shouldBeBefore`

Didn't add any other asserts since `Instant` a single instantaneous point on the time-line, not related to time zones.

Fixes #175 

Checklist
<!--- We'd like to thank you for your help, appreciate them and give you credit for it. Please check the checkboxes below as you complete them -->

- [x] I've added my name to the `AUTHORS` file, if it wasn't already present.

