### PR TITLE
Make the shouldBeLess/Greater family of assertion accept anything comparable

### DIFF
--- a/common/src/main/kotlin/org/amshove/kluent/Numerical.kt
+++ b/common/src/main/kotlin/org/amshove/kluent/Numerical.kt
@@ -74,101 +74,21 @@ infix fun Double.shouldNotEqualTo(expected: Double) = this.shouldNotBeEqualTo(ex
 
 infix fun Double.shouldNotBeEqualTo(expected: Double) = this.apply { assertNotEquals(expected, this) }
 
-infix fun Byte.shouldBeGreaterThan(expected: Byte) = this.apply { assertTrue("Expected $this to be greater than $expected", this > expected) }
+infix fun <T : Comparable<T>> T.shouldBeGreaterThan(expected: T) = this.apply { assertTrue("Expected $this to be greater than $expected", this > expected) }
 
-infix fun Short.shouldBeGreaterThan(expected: Short) = this.apply { assertTrue("Expected $this to be greater than $expected", this > expected) }
+infix fun <T : Comparable<T>> T.shouldNotBeGreaterThan(expected: T) = this.apply { assertTrue("Expected $this to not be greater than $expected", this <= expected) }
 
-infix fun Int.shouldBeGreaterThan(expected: Int) = this.apply { assertTrue("Expected $this to be greater than $expected", this > expected) }
+infix fun <T : Comparable<T>> T.shouldBeGreaterOrEqualTo(expected: T) = this.apply { assertTrue("Expected $this to be greater or equal to $expected", this >= expected) }
 
-infix fun Long.shouldBeGreaterThan(expected: Long) = this.apply { assertTrue("Expected $this to be greater than $expected", this > expected) }
+infix fun <T : Comparable<T>> T.shouldNotBeGreaterOrEqualTo(expected: T) = this.apply { assertTrue("Expected $this to be not be greater or equal to $expected", this < expected) }
 
-infix fun Float.shouldBeGreaterThan(expected: Float) = this.apply { assertTrue("Expected $this to be greater than $expected", this > expected) }
+infix fun <T : Comparable<T>> T.shouldBeLessThan(expected: T) = this.apply { assertTrue("Expected $this to be less than $expected", this < expected) }
 
-infix fun Double.shouldBeGreaterThan(expected: Double) = this.apply { assertTrue("Expected $this to be greater than $expected", this > expected) }
+infix fun <T : Comparable<T>> T.shouldNotBeLessThan(expected: T) = this.apply { assertTrue("Expected $this to not be less than $expected", this >= expected) }
 
-infix fun Byte.shouldNotBeGreaterThan(expected: Byte) = this.apply { assertTrue("Expected $this to not be greater than $expected", this <= expected) }
+infix fun <T : Comparable<T>> T.shouldBeLessOrEqualTo(expected: T) = this.apply { assertTrue("Expected $this to be less or equal to $expected", this <= expected) }
 
-infix fun Short.shouldNotBeGreaterThan(expected: Short) = this.apply { assertTrue("Expected $this to not be greater than $expected", this <= expected) }
-
-infix fun Int.shouldNotBeGreaterThan(expected: Int) = this.apply { assertTrue("Expected $this to not be greater than $expected", this <= expected) }
-
-infix fun Long.shouldNotBeGreaterThan(expected: Long) = this.apply { assertTrue("Expected $this to not be greater than $expected", this <= expected) }
-
-infix fun Float.shouldNotBeGreaterThan(expected: Float) = this.apply { assertTrue("Expected $this to not be greater than $expected", this <= expected) }
-
-infix fun Double.shouldNotBeGreaterThan(expected: Double) = this.apply { assertTrue("Expected $this to not be greater than $expected", this <= expected) }
-
-infix fun Byte.shouldBeGreaterOrEqualTo(expected: Byte) = this.apply { assertTrue("Expected $this to be greater or equal to $expected", this >= expected) }
-
-infix fun Short.shouldBeGreaterOrEqualTo(expected: Short) = this.apply { assertTrue("Expected $this to be greater or equal to $expected", this >= expected) }
-
-infix fun Int.shouldBeGreaterOrEqualTo(expected: Int) = this.apply { assertTrue("Expected $this to be greater or equal to $expected", this >= expected) }
-
-infix fun Long.shouldBeGreaterOrEqualTo(expected: Long) = this.apply { assertTrue("Expected $this to be greater or equal to $expected", this >= expected) }
-
-infix fun Float.shouldBeGreaterOrEqualTo(expected: Float) = this.apply { assertTrue("Expected $this to be greater or equal to $expected", this >= expected) }
-
-infix fun Double.shouldBeGreaterOrEqualTo(expected: Double) = this.apply { assertTrue("Expected $this to be greater or equal to $expected", this >= expected) }
-
-infix fun Byte.shouldNotBeGreaterOrEqualTo(expected: Byte) = this.apply { assertTrue("Expected $this to be not be greater or equal to $expected", this < expected) }
-
-infix fun Short.shouldNotBeGreaterOrEqualTo(expected: Short) = this.apply { assertTrue("Expected $this to not be greater or equal to $expected", this < expected) }
-
-infix fun Int.shouldNotBeGreaterOrEqualTo(expected: Int) = this.apply { assertTrue("Expected $this to not be greater or equal to $expected", this < expected) }
-
-infix fun Long.shouldNotBeGreaterOrEqualTo(expected: Long) = this.apply { assertTrue("Expected $this to not be greater or equal to $expected", this < expected) }
-
-infix fun Float.shouldNotBeGreaterOrEqualTo(expected: Float) = this.apply { assertTrue("Expected $this to not be greater or equal to $expected", this < expected) }
-
-infix fun Double.shouldNotBeGreaterOrEqualTo(expected: Double) = this.apply { assertTrue("Expected $this to not be greater or equal to $expected", this < expected) }
-
-infix fun Byte.shouldBeLessThan(expected: Byte) = this.apply { assertTrue("Expected $this to be less than $expected", this < expected) }
-
-infix fun Short.shouldBeLessThan(expected: Short) = this.apply { assertTrue("Expected $this to be less than $expected", this < expected) }
-
-infix fun Int.shouldBeLessThan(expected: Int) = this.apply { assertTrue("Expected $this to be less than $expected", this < expected) }
-
-infix fun Long.shouldBeLessThan(expected: Long) = this.apply { assertTrue("Expected $this to be less than $expected", this < expected) }
-
-infix fun Float.shouldBeLessThan(expected: Float) = this.apply { assertTrue("Expected $this to be less than $expected", this < expected) }
-
-infix fun Double.shouldBeLessThan(expected: Double) = this.apply { assertTrue("Expected $this to be less than $expected", this < expected) }
-
-infix fun Byte.shouldNotBeLessThan(expected: Byte) = this.apply { assertTrue("Expected $this to not be less than $expected", this >= expected) }
-
-infix fun Short.shouldNotBeLessThan(expected: Short) = this.apply { assertTrue("Expected $this to not be less than $expected", this >= expected) }
-
-infix fun Int.shouldNotBeLessThan(expected: Int) = this.apply { assertTrue("Expected $this to not be less than $expected", this >= expected) }
-
-infix fun Long.shouldNotBeLessThan(expected: Long) = this.apply { assertTrue("Expected $this to not be less than $expected", this >= expected) }
-
-infix fun Float.shouldNotBeLessThan(expected: Float) = this.apply { assertTrue("Expected $this to not be less than $expected", this >= expected) }
-
-infix fun Double.shouldNotBeLessThan(expected: Double) = this.apply { assertTrue("Expected $this to not be less than $expected", this >= expected) }
-
-infix fun Byte.shouldBeLessOrEqualTo(expected: Byte) = this.apply { assertTrue("Expected $this to be less or equal to $expected", this <= expected) }
-
-infix fun Short.shouldBeLessOrEqualTo(expected: Short) = this.apply { assertTrue("Expected $this to be less or equal to $expected", this <= expected) }
-
-infix fun Int.shouldBeLessOrEqualTo(expected: Int) = this.apply { assertTrue("Expected $this to be less or equal to $expected", this <= expected) }
-
-infix fun Long.shouldBeLessOrEqualTo(expected: Long) = this.apply { assertTrue("Expected $this to be less or equal to $expected", this <= expected) }
-
-infix fun Float.shouldBeLessOrEqualTo(expected: Float) = this.apply { assertTrue("Expected $this to be less or equal to $expected", this <= expected) }
-
-infix fun Double.shouldBeLessOrEqualTo(expected: Double) = this.apply { assertTrue("Expected $this to be less or equal to $expected", this <= expected) }
-
-infix fun Byte.shouldNotBeLessOrEqualTo(expected: Byte) = this.apply { assertTrue("Expected $this to not be less or equal to $expected", this > expected) }
-
-infix fun Short.shouldNotBeLessOrEqualTo(expected: Short) = this.apply { assertTrue("Expected $this to not be less or equal to $expected", this > expected) }
-
-infix fun Int.shouldNotBeLessOrEqualTo(expected: Int) = this.apply { assertTrue("Expected $this to not be less or equal to $expected", this > expected) }
-
-infix fun Long.shouldNotBeLessOrEqualTo(expected: Long) = this.apply { assertTrue("Expected $this to not be less or equal to $expected", this > expected) }
-
-infix fun Float.shouldNotBeLessOrEqualTo(expected: Float) = this.apply { assertTrue("Expected $this to not be less or equal to $expected", this > expected) }
-
-infix fun Double.shouldNotBeLessOrEqualTo(expected: Double) = this.apply { assertTrue("Expected $this to not be less or equal to $expected", this > expected) }
+infix fun <T : Comparable<T>> T.shouldNotBeLessOrEqualTo(expected: T) = this.apply { assertTrue("Expected $this to not be less or equal to $expected", this > expected) }
 
 fun Byte.shouldBePositive() = this.apply { assertTrue("Expected $this to be positive", this > 0) }
 
@@ -198,29 +118,9 @@ fun Float.shouldBeNear(expected: Float, delta: Float) = shouldBeInRange(expected
 
 fun Double.shouldBeNear(expected: Double, delta: Double) = shouldBeInRange(expected - delta, expected + delta)
 
-fun Byte.shouldBeInRange(lowerBound: Byte, upperBound: Byte) = this.apply { assertTrue("Expected $this to be between (and including) $lowerBound and $upperBound", this >= lowerBound && this <= upperBound) }
+fun <T : Comparable<T>> T.shouldBeInRange(lowerBound: T, upperBound: T) = this.apply { assertTrue("Expected $this to be between (and including) $lowerBound and $upperBound", this >= lowerBound && this <= upperBound) }
 
-fun Short.shouldBeInRange(lowerBound: Short, upperBound: Short) = this.apply { assertTrue("Expected $this to be between (and including) $lowerBound and $upperBound", this >= lowerBound && this <= upperBound) }
-
-fun Int.shouldBeInRange(lowerBound: Int, upperBound: Int) = this.apply { assertTrue("Expected $this to be between (and including) $lowerBound and $upperBound", this >= lowerBound && this <= upperBound) }
-
-fun Long.shouldBeInRange(lowerBound: Long, upperBound: Long) = this.apply { assertTrue("Expected $this to be between (and including) $lowerBound and $upperBound", this >= lowerBound && this <= upperBound) }
-
-fun Float.shouldBeInRange(lowerBound: Float, upperBound: Float) = this.apply { assertTrue("Expected $this to be between (and including) $lowerBound and $upperBound", this >= lowerBound && this <= upperBound) }
-
-fun Double.shouldBeInRange(lowerBound: Double, upperBound: Double) = this.apply { assertTrue("Expected $this to be between (and including) $lowerBound and $upperBound", this >= lowerBound && this <= upperBound) }
-
-fun Byte.shouldNotBeInRange(lowerBound: Byte, upperBound: Byte) = this.apply { assertTrue("Expected $this to not be between (and including) $lowerBound and $upperBound", this < lowerBound || this > upperBound) }
-
-fun Short.shouldNotBeInRange(lowerBound: Short, upperBound: Short) = this.apply { assertTrue("Expected $this to not be between (and including) $lowerBound and $upperBound", this < lowerBound || this > upperBound) }
-
-fun Int.shouldNotBeInRange(lowerBound: Int, upperBound: Int) = this.apply { assertTrue("Expected $this to not be between (and including) $lowerBound and $upperBound", this < lowerBound || this > upperBound) }
-
-fun Long.shouldNotBeInRange(lowerBound: Long, upperBound: Long) = this.apply { assertTrue("Expected $this to not be between (and including) $lowerBound and $upperBound", this < lowerBound || this > upperBound) }
-
-fun Float.shouldNotBeInRange(lowerBound: Float, upperBound: Float) = this.apply { assertTrue("Expected $this to not be between (and including) $lowerBound and $upperBound", this < lowerBound || this > upperBound) }
-
-fun Double.shouldNotBeInRange(lowerBound: Double, upperBound: Double) = this.apply { assertTrue("Expected $this to not be between (and including) $lowerBound and $upperBound", this < lowerBound || this > upperBound) }
+fun <T : Comparable<T>> T.shouldNotBeInRange(lowerBound: T, upperBound: T) = this.apply { assertTrue("Expected $this to not be between (and including) $lowerBound and $upperBound", this < lowerBound || this > upperBound) }
 
 infix fun Byte.shouldBeInRange(range: IntRange) = this.apply { (this.toInt()).shouldBeInRange(range) }
 
@@ -230,7 +130,7 @@ infix fun Int.shouldBeInRange(range: IntRange) = this.apply { this.shouldBeInRan
 
 infix fun Double.shouldBeInRange(range: ClosedFloatingPointRange<Double>) = this.assertIsInFloatingRange(range)
 
-infix fun Float.shouldBeInRange(range: ClosedRange<Float>) = this.assertIsInFloatingRange(range)
+infix fun <T : Comparable<T>> T.shouldBeInRange(range: ClosedRange<T>) = this.assertIsInFloatingRange(range)
 
 infix fun Long.shouldBeInRange(range: LongRange) = this.apply { this.shouldBeInRange(range.first, range.last) }
 
@@ -242,7 +142,7 @@ infix fun Int.shouldNotBeInRange(range: IntRange) = this.apply { this.shouldNotB
 
 infix fun Double.shouldNotBeInRange(range: ClosedFloatingPointRange<Double>) = this.assertIsNotInFloatingRange(range)
 
-infix fun Float.shouldNotBeInRange(range: ClosedRange<Float>) = this.assertIsNotInFloatingRange(range)
+infix fun <T : Comparable<T>> T.shouldNotBeInRange(range: ClosedRange<T>) = this.assertIsNotInFloatingRange(range)
 
 infix fun Long.shouldNotBeInRange(range: LongRange) = this.apply { this.shouldNotBeInRange(range.first, range.last) }
 


### PR DESCRIPTION
## Description

Make the comparision assertion familiy  (`shouldBeLessThan`, etc.) more generic, by taking anything comparable as arguments.

Resolves #169 

I see this as a simplification/refactoring of the existing code. Kind of the "refactor" step of a TDD cycle. This PR doesn't add any new funtion or even behavior. So I didn't add any new tests, I think that keeping the existing tests, should be enough. But feel free to tell me if you have a different view on it ;-)

## Checklist
- [x] I've added my name to the `AUTHORS` file, if it wasn't already present.

