### PR TITLE
Remove JUnit 4 as a dependency

### DIFF
--- a/common/src/main/kotlin/org/amshove/kluent/AssertionErrors.kt
+++ b/common/src/main/kotlin/org/amshove/kluent/AssertionErrors.kt
@@ -1,19 +1,29 @@
 package org.amshove.kluent
 
-import kotlin.test.assertFails
+
+class ComparisonFailure(val customMessage: String?, val expected: String?, val actual: String?) : RuntimeException(
+    """${customMessage ?: ""}
+        |Expected: <$expected> but was: <$actual>
+    """.trimMargin().trim()
+) {
+    constructor(customMessage: String?, expected: Any?, actual: Any?)
+            : this(customMessage, expected?.toString(), actual?.toString())
+}
 
 /** An error that bundles multiple other [Throwable]s together */
 class MultiAssertionError(errors: List<Throwable>) : AssertionError(createMessage(errors)) {
     companion object {
         private fun createMessage(errors: List<Throwable>) = buildString {
-            append("\nThe following ")
+            append("\nExpected no assertion to fail, but ")
 
             if (errors.size == 1) {
-                append("assertion")
+                append("one assertion")
             } else {
                 append(errors.size).append(" assertions")
             }
             append(" failed:\n")
+
+            append("Expected: <>, but was: <")
 
             if (errors.size == 1) {
                 append(errors[0].message).append("\n")
@@ -28,6 +38,8 @@ class MultiAssertionError(errors: List<Throwable>) : AssertionError(createMessag
                     }
                 }
             }
+
+            append(">")
         }
     }
 }

--- a/common/src/main/kotlin/org/amshove/kluent/Basic.kt
+++ b/common/src/main/kotlin/org/amshove/kluent/Basic.kt
@@ -107,6 +107,19 @@ fun fail(message: String?) {
     }
 }
 
+/**
+ * Provides an assertSoftly-compatible way of reporting a failed assertion
+ * All assertions should rely on it for error reporting.
+ * Assertions that don't work with assertSoftly (for example shouldNotBeNull) can use hardFail
+ */
+fun fail(throwable: Throwable) {
+    if(errorCollector.getCollectionMode() == ErrorCollectionMode.Soft) {
+        errorCollector.pushError(throwable)
+    } else {
+        throw throwable
+    }
+}
+
 /** Use this function in places where a soft fail in assertSoftly would not make sense - for example shouldNotBeNull. */
 @PublishedApi
 internal fun hardFail(message: String?): Nothing = throw AssertionError(message)

--- a/common/src/main/kotlin/org/amshove/kluent/internal/Assertions.kt
+++ b/common/src/main/kotlin/org/amshove/kluent/internal/Assertions.kt
@@ -1,5 +1,6 @@
 package org.amshove.kluent.internal
 
+import org.amshove.kluent.ComparisonFailure
 import org.amshove.kluent.fail
 import kotlin.jvm.JvmName
 import kotlin.reflect.KClass
@@ -126,7 +127,9 @@ fun <T> assertEquals(expected: T, actual: T, message: String? = null) {
  * @param message the message to report if the assertion fails.
  */
 fun assertEquals(message: String?, expected: Any?, actual: Any?): Unit {
-    assertTrue(actual == expected) { messagePrefix(message) + "Expected <$expected>, actual <$actual>." }
+    if(actual != expected) {
+        fail(ComparisonFailure(message, expected, actual))
+    }
 }
 
 /** Asserts that the [actual] value is not equal to the illegal value, with an optional [message]. */

--- a/jvm/build.gradle
+++ b/jvm/build.gradle
@@ -15,7 +15,6 @@ dependencies {
     implementation libs.kotlin_stdlib_jvm
     implementation libs.kotlin_reflect
     implementation libs.kotlin_test_jvm
-    implementation libs.junit
 
     testImplementation libs.junit
     testImplementation libs.kotlin_test_jvm

--- a/jvm/src/main/kotlin/org/amshove/kluent/Exceptions.kt
+++ b/jvm/src/main/kotlin/org/amshove/kluent/Exceptions.kt
@@ -1,6 +1,6 @@
 package org.amshove.kluent
 
-import org.junit.ComparisonFailure
+import java.lang.RuntimeException
 import kotlin.reflect.KClass
 
 fun invoking(function: () -> Any?): () -> Any? = function

--- a/jvm/src/test/kotlin/org/amshove/kluent/tests/equivalency/ShouldBeEquivalentTo.kt
+++ b/jvm/src/test/kotlin/org/amshove/kluent/tests/equivalency/ShouldBeEquivalentTo.kt
@@ -2,7 +2,7 @@ package org.amshove.kluent.tests.equivalency
 
 import org.amshove.kluent.*
 import org.amshove.kluent.internal.assertFailsWith
-import org.junit.ComparisonFailure
+import org.amshove.kluent.ComparisonFailure
 import org.junit.Test
 import java.time.LocalDate
 


### PR DESCRIPTION
This PR aims to remove JUnit 4 as a hard dependency of Kluent.

To accomplish the same usability as it was with JUnit (e.g. the `click to see the difference`-button in IntelliJ) a new exception (currently called `ComparisonFailure` as in JUnit to keep the diff small) formats the failure message as IntelliJ expects it.

The testcases of `assertSoftly` are the only ones that fail at the moment, because the formatting needs to be changed.