### PR TITLE
Added `should throw` and `should not throw` assertions that operate on suspending functions

### DIFF
--- a/jvm/src/main/kotlin/org/amshove/kluent/ExceptionsBacktick.kt
+++ b/jvm/src/main/kotlin/org/amshove/kluent/ExceptionsBacktick.kt
@@ -5,8 +5,12 @@ import kotlin.reflect.KClass
 infix fun <T : Throwable> (() -> Any?).`should throw`(expectedException: KClass<T>) =
     this.shouldThrow(expectedException)
 
+suspend infix fun <T : Throwable> (suspend () -> Any?).`should throw`(expectedException: KClass<T>) = this.shouldThrow(expectedException)
+
 infix fun <T : Throwable> (() -> Any?).`should not throw`(expectedException: KClass<T>) =
     this.shouldNotThrow(expectedException)
+
+suspend infix fun <T : Throwable> (suspend () -> Any?).`should not throw`(expectedException: KClass<T>) = this.shouldNotThrow(expectedException)
 
 @Deprecated("Use `should throw` instead", ReplaceWith("this `should throw` expectedException"))
 infix fun <T : Throwable> (() -> Any).`should throw the Exception`(expectedException: KClass<T>) =
@@ -26,3 +30,5 @@ infix fun <T : Throwable> ExceptionResult<T>.`with cause`(expectedCause: KClass<
 infix fun NotThrowExceptionResult.`with cause`(expectedCause: KClass<out Throwable>) = this.withCause(expectedCause)
 
 infix fun <T : Throwable> (() -> Any?).`should throw`(expectedException: T) = this.shouldThrow(expectedException)
+
+suspend infix fun <T : Throwable> (suspend () -> Any?).`should throw`(expectedException: T) = this.shouldThrow(expectedException)

--- a/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/exceptions/ShouldNotThrowBackticksStyle.kt
+++ b/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/exceptions/ShouldNotThrowBackticksStyle.kt
@@ -1,0 +1,24 @@
+package org.amshove.kluent.tests.assertions.exceptions
+
+import org.amshove.kluent.AnyException
+import org.amshove.kluent.`should not throw`
+import org.amshove.kluent.invoking
+import org.junit.Test
+import kotlin.test.assertFails
+
+class ShouldNotThrowBackticksStyle {
+    @Test
+    fun shouldNotThrowSucceedsWhenNotThrown() {
+        invoking { } `should not throw` AnyException
+    }
+
+    @Test
+    fun shouldNotThrowFailsWhenThrown() {
+        assertFails { invoking { throw CustomException(12345) } `should not throw` AnyException }
+    }
+
+    @Test
+    fun shouldNotThrowSucceedsWhenDifferentExceptionClassThrown() {
+        invoking { throw IllegalArgumentException() } `should not throw` CustomException::class
+    }
+}

--- a/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/exceptions/ShouldNotThrowSuspendBackticksStyle.kt
+++ b/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/exceptions/ShouldNotThrowSuspendBackticksStyle.kt
@@ -1,0 +1,35 @@
+package org.amshove.kluent.tests.assertions.exceptions
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.test.runBlockingTest
+import org.amshove.kluent.AnyException
+import org.amshove.kluent.`should not throw`
+import org.amshove.kluent.coInvoking
+import org.amshove.kluent.internal.assertFails
+import org.junit.Test
+
+class ShouldNotThrowSuspendBackticksStyle {
+    @Test
+    @ExperimentalCoroutinesApi
+    fun shouldNotThrowSucceedsWhenNotThrown() = runBlockingTest {
+        suspend fun func() = coroutineScope {}
+        coInvoking { func() } `should not throw` AnyException
+    }
+
+    @Test
+    @ExperimentalCoroutinesApi
+    fun shouldNotThrowFailsWhenThrown() = runBlockingTest {
+        suspend fun func(): Nothing = coroutineScope { throw CustomException(12345) }
+
+        assertFails { coInvoking { func() } `should not throw` AnyException }
+    }
+
+    @Test
+    @ExperimentalCoroutinesApi
+    fun shouldNotThrowSucceedsWhenDifferentExceptionClassThrown() = runBlockingTest {
+        suspend fun func(): Nothing = coroutineScope { throw IllegalArgumentException() }
+
+        coInvoking { func() } `should not throw` CustomException::class
+    }
+}

--- a/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/exceptions/ShouldThrowBackticksStyle.kt
+++ b/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/exceptions/ShouldThrowBackticksStyle.kt
@@ -1,0 +1,34 @@
+package org.amshove.kluent.tests.assertions.exceptions
+
+
+import org.amshove.kluent.`should throw`
+import org.amshove.kluent.invoking
+import org.junit.Test
+import kotlin.test.assertFails
+
+class ShouldThrowBackticksStyle {
+    @Test
+    fun shouldThrowSucceedsWhenExpectedInstanceThrown() {
+        invoking { throw CustomException(12345) } `should throw` CustomException(12345)
+    }
+
+    @Test
+    fun shouldThrowSucceedsWhenExpectedClassThrown() {
+        invoking { throw CustomException(12345) } `should throw` CustomException::class
+    }
+
+    @Test
+    fun shouldThrowFailsWhenNoExceptionThrown() {
+        assertFails { invoking {  } `should throw` CustomException(12345) }
+    }
+
+    @Test
+    fun shouldThrowFailsWhenDifferentExceptionThrown() {
+        assertFails { invoking { throw CustomException(54321)  } `should throw` CustomException(12345) }
+    }
+
+    @Test
+    fun shouldThrowFailsWhenDifferentExceptionClassThrown() {
+        assertFails { invoking { throw IllegalArgumentException()  } `should throw` CustomException::class }
+    }
+}

--- a/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/exceptions/ShouldThrowSuspendBackticksStyle.kt
+++ b/jvm/src/test/kotlin/org/amshove/kluent/tests/assertions/exceptions/ShouldThrowSuspendBackticksStyle.kt
@@ -1,0 +1,51 @@
+package org.amshove.kluent.tests.assertions.exceptions
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.test.runBlockingTest
+import org.amshove.kluent.`should throw`
+import org.amshove.kluent.coInvoking
+import org.junit.Test
+import kotlin.test.assertFails
+
+class ShouldThrowSuspendBackticksStyle {
+    @Test
+    @ExperimentalCoroutinesApi
+    fun shouldThrowSucceedsWhenExpectedInstanceThrown() = runBlockingTest {
+        suspend fun func(): Nothing = coroutineScope { throw CustomException(12345) }
+
+        coInvoking { func() } `should throw` CustomException(12345)
+    }
+
+    @Test
+    @ExperimentalCoroutinesApi
+    fun shouldThrowSucceedsWhenExpectedClassThrown() = runBlockingTest {
+        suspend fun func(): Nothing = coroutineScope { throw CustomException(12345) }
+
+        coInvoking { func() } `should throw` CustomException::class
+    }
+
+    @Test
+    @ExperimentalCoroutinesApi
+    fun shouldThrowFailsWhenNoExceptionThrown() = runBlockingTest {
+        suspend fun func() = coroutineScope { }
+
+        assertFails { coInvoking { func() } `should throw` CustomException(12345) }
+    }
+
+    @Test
+    @ExperimentalCoroutinesApi
+    fun shouldThrowFailsWhenDifferentExceptionThrown() = runBlockingTest {
+        suspend fun func(): Nothing = coroutineScope { throw CustomException(54321) }
+
+        assertFails { coInvoking { func() } `should throw` CustomException(12345) }
+    }
+
+    @Test
+    @ExperimentalCoroutinesApi
+    fun shouldThrowFailsWhenDifferentExceptionClassThrown() = runBlockingTest {
+        suspend fun func(): Nothing = coroutineScope { throw java.lang.IllegalArgumentException() }
+
+        assertFails { coInvoking { func() } `should throw` CustomException::class }
+    }
+}


### PR DESCRIPTION
Description

I added support for suspend functions in `should throw` and `should not throw`, as requested in #215.
I also wrote tests for `should throw` and `should not throw` that check behavior on both suspending and regular functions.

Usage examples
```
coInvoking { foo() } `should throw` CustomException(12345)
coInvoking { bar() } `should not throw` CustomException::class
```

Checklist
<!--- We'd like to thank you for your help, appreciate them and give you credit for it. Please check the checkboxes below as you complete them -->

- [X] I've added my name to the `AUTHORS` file, if it wasn't already present.

