### PR TITLE
Gradle: Fix the syntax for SCM connection URLs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,8 +95,8 @@ subprojects {
                         url = 'https://github.com/MarkusAmshove/Kluent'
 
                         scm {
-                            connection = 'scm:git:git:github.com/MarkusAmshove/Kluent.git'
-                            developerConnection = 'scm:git:git:github.com/MarkusAmshove/Kluent.git'
+                            connection = 'scm:git:https://github.com/MarkusAmshove/Kluent.git'
+                            developerConnection = 'scm:git:git@github.com/MarkusAmshove/Kluent.git'
                             url = 'https://github.com/MarkusAmshove/Kluent'
                         }
 


### PR DESCRIPTION
Description

This fixes invalid SCM connection URL in published Maven POMs.

Checklist

- [ ] I've added my name to the `AUTHORS` file, if it wasn't already present.

